### PR TITLE
docs(openspec): propose pooling native SQLite connections

### DIFF
--- a/openspec/changes/pool-native-sqlite-connections/.openspec.yaml
+++ b/openspec/changes/pool-native-sqlite-connections/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/pool-native-sqlite-connections/design.md
+++ b/openspec/changes/pool-native-sqlite-connections/design.md
@@ -1,0 +1,54 @@
+## Context
+
+`NativeDatabase` holds a `db_path` plus a one-time-init flag; `connection()` opens a fresh `rusqlite::Connection` per call. There are ~173 call sites, each a synchronous operation running on a Tauri command worker thread (not the async executor). With WAL enabled, readers no longer block the single writer, but every operation still pays a file open + pragma round-trip + cold page cache.
+
+## Goals / Non-Goals
+
+Goals:
+- Eliminate per-operation connection open/configure overhead by reusing connections.
+- Bound the number of live SQLite handles and provide back-pressure under load.
+- Keep the change surface at the ~173 call sites near-zero.
+
+Non-Goals:
+- No change to SQL, schema, or migration content.
+- No move to an async SQLite driver.
+- No change to the service/command boundary, Tauri commands, or DTOs.
+
+## Decisions
+
+### Pool implementation
+
+- **Option A — `r2d2` + `r2d2_sqlite`**: battle-tested. Provides a `CustomizeConnection` hook for per-connection pragmas and a manager that opens connections lazily. `PooledConnection<SqliteConnectionManager>` dereferences to `rusqlite::Connection`, so `connection()` returning it keeps call sites unchanged. Layers two crates over the already-approved `rusqlite`.
+- **Option B — hand-rolled pool**: `Arc<Mutex<Vec<Connection>>>` with a checkout guard whose `Drop` returns the connection. Zero new dependency, but re-implements customizer/health/timeout/exhaustion logic and is easy to get subtly wrong (mutex poisoning, guard return on panic, fairness).
+
+Recommendation: **Option A**. It satisfies the "SQLite via rusqlite" stack constraint (additive layer, not a replacement) and avoids bespoke concurrency code. If a new dependency is unacceptable, fall back to a minimal Option B with an explicit bounded size and checkout timeout.
+
+### Connection configuration
+
+Move `busy_timeout(5s)`, `PRAGMA foreign_keys=ON`, and `journal_mode=WAL` into a pool connection customizer that runs once per physical connection (instead of on every `connection()` call). Run `migrate()` + `seed_registry()` exactly once at pool build (or on first checkout), guarded so racing checkouts cannot double-apply migrations — the current `Mutex<bool>` gate already provides this and can be reused.
+
+### Pool sizing
+
+Default max size ≈ the Tauri worker-thread count (e.g. 8–16). WAL supports many concurrent readers with a single writer, so a small pool suffices and bounds handles. Expose the size and checkout timeout as constants for later tuning.
+
+### Call-site compatibility
+
+Change `connection()`'s return type from `Connection` to the pooled guard. Because the guard implements `Deref`/`DerefMut` to `Connection`, `conn.prepare(...)`, `conn.execute(...)`, and `conn.transaction()` keep compiling. The few sites that consume a `Connection` by value (rare — most bind `let connection = ...; connection.prepare(...)`) need a local adjustment.
+
+## Risks / Trade-offs
+
+- **New dependency** (`r2d2_sqlite`) — mitigated: it wraps the already-approved `rusqlite`; called out in `proposal.md` Impact.
+- **`transaction()` needs `&mut Connection`** — pooled guards provide `DerefMut`, so `let mut connection = db.connection()?` works; sites using transactions must keep the `mut` binding.
+- **Pool exhaustion under a burst** — bounded by a checkout timeout; pick a sane max + timeout and surface a structured `DatabaseError` rather than blocking indefinitely.
+
+## Migration Plan
+
+1. Add the pool to `NativeDatabase`, keeping the `connection()` name and `DatabaseError` return type.
+2. Move pragmas into the customizer; run migrate/seed once at build behind the existing gate.
+3. Compile; fix any by-value `Connection` uses among the ~173 call sites.
+4. Add concurrency + exhaustion tests; run full `cargo test` + `cargo clippy` and confirm no regression.
+
+## Open Questions
+
+- Preferred maximum pool size and checkout timeout values.
+- Accept the `r2d2_sqlite` dependency, or require the zero-dependency hand-rolled pool (Option B)?

--- a/openspec/changes/pool-native-sqlite-connections/proposal.md
+++ b/openspec/changes/pool-native-sqlite-connections/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The native runtime opens a brand-new SQLite connection on every operation — `NativeDatabase::connection()` is called at ~173 sites, each performing `Connection::open` plus per-connection pragma setup. A prior change (`fix(runtime)` PR) removed the redundant per-connection migration/seed work and added `busy_timeout` + WAL, but the connect-per-operation model still pays a fresh file open, pragma configuration, and cold page cache for every read and write, and offers no back-pressure on the number of live database handles under concurrent load. Reusing pooled, pre-configured connections removes this fixed per-operation overhead and bounds concurrent handles.
+
+## What Changes
+
+- Introduce a bounded SQLite connection pool inside `NativeDatabase`, replacing per-operation `Connection::open` with checkout/return of reused connections.
+- Configure each pooled connection once on creation (`busy_timeout`, `foreign_keys`, WAL) via a connection customizer, and run schema migration + registry seeding exactly once at pool initialization.
+- Preserve the `NativeDatabase::connection()` call contract so the ~173 existing call sites keep using a value that dereferences to `rusqlite::Connection` with minimal or no edits.
+- Add concurrency and pool-lifecycle regression tests (parallel readers/writers, pool-exhaustion back-pressure, migrate-once-under-races).
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `native-runtime-architecture`: Require the native runtime to serve database operations from a bounded pool of reused, pre-configured SQLite connections rather than opening a new connection per operation, initializing schema exactly once.
+
+## Impact
+
+- Affects `src-tauri/src/platform/database/mod.rs` (connection lifecycle and pragma customizer). Call sites that bind `let connection = self.database.connection()?` continue to compile if the returned guard dereferences to `rusqlite::Connection`.
+- Adds a connection-pool dependency (`r2d2` + `r2d2_sqlite`, which layer over the existing `rusqlite`) or a hand-rolled equivalent — see `design.md`. No change to the SQLite storage format, migrations, DTOs, or the service/command boundaries.
+- WAL (already enabled) permits concurrent readers against the pool; writers remain serialized by SQLite with `busy_timeout` back-pressure. The `unified-log-management` and other persistence-backed capabilities are unaffected functionally; only the connection-acquisition mechanism changes.

--- a/openspec/changes/pool-native-sqlite-connections/specs/native-runtime-architecture/spec.md
+++ b/openspec/changes/pool-native-sqlite-connections/specs/native-runtime-architecture/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Pooled SQLite connection reuse
+The native runtime SHALL serve database operations from a bounded pool of reused, pre-configured SQLite connections instead of opening a new connection per operation, and SHALL initialize schema migration and registry seeding exactly once for the database.
+
+#### Scenario: Reuse connections across operations
+- **WHEN** the native runtime performs successive database operations
+- **THEN** it SHALL check out an already-open connection from the pool rather than opening a new SQLite connection for each operation
+- **AND** each pooled connection SHALL already have busy-timeout, foreign-key enforcement, and write-ahead logging configured
+
+#### Scenario: One-time schema preparation
+- **WHEN** the native runtime prepares the database during pool initialization
+- **THEN** it SHALL apply versioned migrations and registry seeding exactly once
+- **AND** concurrent first-use checkouts SHALL NOT apply migrations or seeding more than once
+
+#### Scenario: Bounded connections under concurrent load
+- **WHEN** more concurrent database operations are requested than the pool's maximum size
+- **THEN** the runtime SHALL bound the number of live SQLite connections to the configured maximum
+- **AND** excess requests SHALL wait for an available connection or fail with a structured timeout error rather than opening unbounded connections

--- a/openspec/changes/pool-native-sqlite-connections/tasks.md
+++ b/openspec/changes/pool-native-sqlite-connections/tasks.md
@@ -1,0 +1,16 @@
+## 1. Connection Pool Foundation
+
+- [ ] 1.1 Add the connection-pool dependency (`r2d2` + `r2d2_sqlite`) or a hand-rolled pool module, plus a connection customizer that sets `busy_timeout`, `foreign_keys`, and WAL per physical connection.
+- [ ] 1.2 Build the pool in `NativeDatabase` with a bounded max size and checkout timeout; run `migrate()` + `seed_registry()` exactly once, reusing the existing race-safe init gate.
+- [ ] 1.3 Change `NativeDatabase::connection()` to return a pooled guard that dereferences to `rusqlite::Connection`, keeping the existing `DatabaseError` return type.
+
+## 2. Call-Site Migration
+
+- [ ] 2.1 Compile the crate and resolve any call sites that consume `Connection` by value or rely on `Connection`-specific ownership.
+- [ ] 2.2 Confirm `transaction()` / `&mut` usages bind `let mut connection = ...`.
+
+## 3. Verification
+
+- [ ] 3.1 Add tests: parallel readers + writer under WAL, pool-exhaustion back-pressure/timeout, migrate-once-under-races.
+- [ ] 3.2 Run `cargo test`, `cargo clippy --manifest-path src-tauri/Cargo.toml`, and `cargo check`; confirm no regression across the existing 550+ tests.
+- [ ] 3.3 Confirm the hot path no longer performs `Connection::open` + pragma configuration per operation (open/configure happens only on pool growth).


### PR DESCRIPTION
## 背景

审查中发现 `NativeDatabase::connection()` 在 ~173 个调用点每次都 `Connection::open` 新建连接。已合入的 PR #2 去掉了每连接重跑的迁移/seed 并加了 `busy_timeout`+WAL,但「每操作新建连接」这一架构级问题需要单独 proposal 决策后再改。

## 本 proposal 内容(纯 planning artifact,无代码改动)

`openspec/changes/pool-native-sqlite-connections/`:
- **proposal.md** — Why / What / Capabilities(修改 `native-runtime-architecture`)/ Impact
- **design.md** — 选型对比:`r2d2`+`r2d2_sqlite`(推荐,`PooledConnection` deref 到 `rusqlite::Connection`,调用点近零改动)vs 手写池(零新依赖但需自己实现 customizer/超时/回收);连接 customizer 统一配 pragma;池大小/超时;调用点兼容性
- **tasks.md** — 池基建 → 调用点迁移 → 验证(并发读写、池耗尽回压、迁移一次性)
- **specs/native-runtime-architecture/spec.md** — ADDED「Pooled SQLite connection reuse」需求 + 3 个 scenario

## 待你拍板的 Open Questions

1. 池最大连接数 / checkout 超时取值
2. 接受 `r2d2_sqlite` 新依赖,还是要零依赖手写池?

## 校验

`openspec validate pool-native-sqlite-connections --strict` → valid。