### PR TITLE
build: optimize native linking and release packaging

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"
+
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,12 +116,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
+            clang \
             curl \
             file \
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libssl-dev \
             libwebkit2gtk-4.1-dev \
+            mold \
             patchelf \
             wget
 
@@ -129,6 +131,11 @@ jobs:
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: rustfmt, clippy
+
+      - name: Verify Linux fast linker
+        run: |
+          clang --version
+          mold --version
 
       - name: Rust fmt
         run: cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
@@ -209,8 +216,18 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
-      - name: Native cargo check
-        run: cargo check --manifest-path src-tauri/Cargo.toml
+      - name: Verify Windows LLD
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $rustLld = Join-Path (rustc --print sysroot) "lib/rustlib/x86_64-pc-windows-msvc/bin/rust-lld.exe"
+          if (-not (Test-Path -LiteralPath $rustLld)) {
+            throw "Rust toolchain LLD was not found at $rustLld"
+          }
+          Write-Output "Using Rust toolchain LLD at $rustLld"
+
+      - name: Native cargo build
+        run: cargo build --manifest-path src-tauri/Cargo.toml
 
   e2e:
     name: Playwright E2E

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,12 +162,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
+            clang \
             curl \
             file \
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libssl-dev \
             libwebkit2gtk-4.1-dev \
+            mold \
             patchelf \
             wget
 
@@ -180,6 +182,11 @@ jobs:
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: llvm-tools-preview
+
+      - name: Verify Linux fast linker
+        run: |
+          clang --version
+          mold --version
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --version 0.8.7 --locked

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -76,12 +76,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
+            clang \
             curl \
             file \
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libssl-dev \
             libwebkit2gtk-4.1-dev \
+            mold \
             patchelf \
             wget
 
@@ -95,6 +97,22 @@ jobs:
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: ${{ matrix.rust_target }}
+
+      - name: Verify Linux fast linker
+        if: matrix.platform == 'linux'
+        run: |
+          clang --version
+          mold --version
+
+      - name: Verify Windows LLD
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $rustLld = Join-Path (rustc --print sysroot) "lib/rustlib/x86_64-pc-windows-msvc/bin/rust-lld.exe"
+          if (-not (Test-Path -LiteralPath $rustLld)) {
+            throw "Rust toolchain LLD was not found at $rustLld"
+          }
+          Write-Output "Using Rust toolchain LLD at $rustLld"
 
       - name: Install npm dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ React components are expected to use the service interfaces in `src/services/` r
 - Node.js 22+ and npm.
 - Rust stable and Cargo.
 - Tauri system prerequisites for your platform.
-- Windows desktop builds: Microsoft C++ Build Tools with MSVC, Windows SDK, and WebView2 Runtime.
-- Linux desktop builds: WebKitGTK and related native packages used by the packaging workflow.
+- Windows x64 desktop builds: Microsoft C++ Build Tools with MSVC, Windows SDK, WebView2 Runtime, and the `rust-lld.exe` included in the selected Rust toolchain.
+- Linux x64 desktop builds: Clang, mold, WebKitGTK, and the related native packages used by the packaging workflow.
 - macOS desktop builds: Xcode command line tools.
+
+See `docs/build-performance.md` for linker verification, release-profile behavior, worktree cache guidance, and measured build evidence.
 
 ## Installation
 
@@ -117,6 +119,8 @@ Project configuration is stored in the repository:
 - `src-tauri/tauri.conf.json`: Tauri product name, app identifier, window settings, bundle settings, and version `0.1.0`.
 - `tailwind.config.ts` and `src/styles.css`: theme tokens and UI styling.
 - `.github/workflows/package.yml`: manual and tag-triggered desktop packaging workflow.
+- `.cargo/config.toml`: target-scoped Windows x64 LLD and Linux x64 mold configuration.
+- `docs/build-performance.md`: native build prerequisites, worktree behavior, release optimization, and measurement evidence.
 - `docs/release-signing.md`: release environment, signing, notarization, checksum, SBOM, and attestation guidance.
 
 Runtime state is created locally by the Tauri backend under `.vanehub/vanehub.sqlite` from the current working directory. No required environment variables were found in the repository.

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -1,0 +1,126 @@
+# Native build performance
+
+VaneHub uses target-scoped linker policies for the native targets exercised by the repository:
+
+| Target | Linker policy | Required tools |
+| --- | --- | --- |
+| `x86_64-pc-windows-msvc` | Rust LLD | Stable Rust MSVC toolchain and MSVC libraries |
+| `x86_64-unknown-linux-gnu` | Clang driving mold | `clang`, `mold`, and the documented Tauri Linux prerequisites |
+| Other targets | Platform default | Platform-specific Tauri prerequisites |
+
+The configuration intentionally does not fall back when a declared fast linker is missing. A missing tool fails the build instead of silently producing incomparable local and CI results.
+
+## Verify the linker
+
+On Windows PowerShell:
+
+```powershell
+$rustLld = Join-Path (rustc --print sysroot) "lib/rustlib/x86_64-pc-windows-msvc/bin/rust-lld.exe"
+Test-Path -LiteralPath $rustLld
+cargo build --manifest-path src-tauri/Cargo.toml --verbose
+```
+
+The final verbose `rustc` invocation identifies `rust-lld.exe` as its linker.
+
+On Linux:
+
+```bash
+clang --version
+mold --version
+cargo build --manifest-path src-tauri/Cargo.toml --verbose
+readelf -p .comment src-tauri/target/debug/vanehub-ai | grep mold
+```
+
+The `.comment` section provides artifact-level confirmation that mold linked the executable.
+
+## Release profile
+
+Distributable builds use:
+
+```toml
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+strip = "debuginfo"
+```
+
+ThinLTO and one codegen unit enable whole-program optimization but can increase release link time. Debuginfo is stripped from distributed binaries while more useful symbol behavior is retained than with full symbol stripping. These settings can change executable and package sizes; they do not guarantee a reduction on every target.
+
+The release profile does not compile out operational diagnostics. Unified logging continues to support redacted `error`, `warn`, `info`, and `debug` events. `#[cfg(debug_assertions)]` is reserved for behavior with no production contract; it must not guard unified-log levels, serialization, redaction, persistence, or required operational events.
+
+## Worktrees and comparable measurements
+
+`src-tauri/target/` is ignored and local to each Git worktree by default. The first Cargo command in a new worktree therefore compiles the dependency graph from scratch. That cold-build time measures dependency compilation and must not be presented as linker performance.
+
+For a comparable relink measurement:
+
+1. Use the same source state, host, target triple, Rust toolchain, and power conditions.
+2. Complete one cold build so third-party dependencies exist.
+3. Run `cargo clean --manifest-path src-tauri/Cargo.toml -p vanehub-ai`.
+4. Time `cargo build --manifest-path src-tauri/Cargo.toml`.
+5. Record linker identity separately from elapsed time.
+
+Release executable and package comparisons similarly use the same source state and target. Dependency installation time is excluded from package build timing. If a comparable baseline cannot be produced, record the absolute optimized sizes and the missing comparison without claiming a reduction.
+
+## Measurement record
+
+Environment captured on 2026-07-23/24:
+
+- Source base: commit `9ef6bd56c74cbbb42b9c2a7e92748b42ad53f575` plus the uncommitted `optimize-rust-build-and-release` implementation; both controlled linker arms used the identical working-tree state
+- Branch/worktree: `codex/package-distribution`
+- OS: Windows `10.0.26200.0`
+- Logical processors: 8
+- Baseline Rust: `rustc 1.97.0 (2d8144b78 2026-07-07)`
+- Optimized-run Rust: `rustc 1.97.1 (8bab26f4f 2026-07-14)`
+- Cargo: `cargo 1.97.1 (c980f4866 2026-06-30)` during the optimized run
+- Host target: `x86_64-pc-windows-msvc`
+- Node/npm: `v24.15.0` / `11.18.0`
+- Initial `src-tauri/target`: absent
+
+| Measurement | Default linker/profile baseline | Optimized linker/profile |
+| --- | ---: | ---: |
+| Cold dev build | 622.303 s | Not repeated; linker comparison uses cached dependencies |
+| VaneHub crate rebuild with cached dependencies | 216.875 s | 232.024 s with Rust LLD |
+| Windows x64 package | Failed after 1126.2 s during an external concurrent Rust toolchain update | Completed after the stable target metadata was repaired |
+| Release executable | Not produced by the interrupted baseline package | 30,486,016 bytes (29.074 MiB) |
+| MSI package | Not produced by the interrupted baseline package | 13,713,408 bytes (13.078 MiB) |
+| NSIS package | Not produced by the interrupted baseline package | 9,018,092 bytes (8.600 MiB) |
+
+Because no comparable pre-change release executable, MSI, or NSIS artifact was produced, the optimized sizes are absolute measurements only. They do not demonstrate that the release profile reduced distributable size.
+
+The optimized crate rebuild was 15.149 seconds (7.0%) slower than the baseline sample. The Rust patch version changed between samples, so this is directional evidence rather than a controlled benchmark. A separate Rust 1.97.1 linker-switch experiment took 300.550 seconds with `link.exe` and 520.270 seconds with Rust LLD, but changing the linker invalidated Cargo fingerprints and relinked the dependency graph; those values are not incremental-link measurements.
+
+### Controlled Windows linker A/B
+
+The controlled comparison used commit `9ef6bd56c74cbbb42b9c2a7e92748b42ad53f575`, Rust 1.97.1, the same host, and separate prewarmed target directories. Each measured run moved only the generated top-level `debug/vanehub-ai.exe` out of its target directory before invoking `cargo build`; cached dependencies and linker-specific Cargo fingerprints remained in place. The default arm explicitly overrode the repository configuration with `link.exe`; verbose output confirmed `rust-lld.exe` for the optimized arm.
+
+| Idle matched run | `link.exe` | `rust-lld.exe` | LLD delta |
+| --- | ---: | ---: | ---: |
+| Prewarmed VaneHub package relink | 2.858 s | 3.177 s | +0.319 s (+11.2%) |
+
+No other Rust processes appeared during either timed command. Two earlier matched runs were retained only as diagnostics: one was contaminated by unequal external Rust activity, while another measured 6.841 seconds for `link.exe` and 9.700 seconds for Rust LLD with background Rust processes present. The clean idle pair is the reportable result: Rust LLD did not improve steady-state relink time on this host. The target-scoped configuration remains useful for deterministic linker selection, but it is not claimed as a measured Windows speedup.
+
+The optimized release build completed in 1414.416 seconds. Its final `rustc` invocation contained `-C linker=rust-lld.exe`, `-C opt-level=3`, `-C lto=thin`, `-C codegen-units=1`, and `-C strip=debuginfo`.
+
+The baseline package failure coincided with other `rustup` processes replacing the active stable toolchain; subsequent `rustc` and `cargo` proxy calls reported that their binaries were temporarily not applicable. An intermediate attempt reached the bundle stage only by running:
+
+```powershell
+npx tauri bundle --target x86_64-pc-windows-msvc --ci --no-sign
+```
+
+After the shared toolchain became idle, stable was repaired/reinstalled and `rustup target list --installed` again reported `x86_64-pc-windows-msvc`. The supported command then passed Tauri's target preflight and completed the Cargo release build plus both WiX and NSIS bundling stages:
+
+```powershell
+npm run package:windows:x64
+```
+
+The command outlived the 20-minute orchestration capture window, so its wall time is intentionally not reported as a controlled package benchmark. The child process chain was monitored through natural completion. The regenerated artifacts are identified by:
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `vanehub-ai.exe` | `441CFA2F6D3EDB30BCB4436FC51E4E778BDA1909F01F0D6C5F6FB1F199B7FFA7` |
+| MSI package | `446944305839D58057B5CBFFFA16F644E4FEBC6F6839A849AB5B227FA4D46C6A` |
+| NSIS package | `18E3B13B13A8C16C8FA50074A9CA7331308335435AED73541E88E02238BB5B69` |
+
+The earlier rustup failures are environmental failures, not repository build results. The sizes and hashes above come from the final successful full package run.

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -13,6 +13,16 @@ The `Package Desktop Apps` workflow uses an unprivileged `build-preview` environ
 
 The publish job cannot run until all Windows, macOS, and Linux jobs finish successfully. It uses short-lived GitHub OIDC identity for attestations and does not require a stored GitHub token.
 
+## Native build profile
+
+Desktop packages use the shared Cargo release profile declared in `src-tauri/Cargo.toml`: optimization level 3, ThinLTO, one codegen unit, and debuginfo stripping. ThinLTO and a single codegen unit can extend release link time while enabling whole-program optimization and changing distributable size; they do not guarantee a smaller package on every target.
+
+Windows x64 builds use the Rust-toolchain-provided LLD linker. Linux x64 builds require Clang and mold; the package workflow verifies both before compilation. Other targets retain their platform-default linker unless a target-specific policy is added and validated.
+
+Debuginfo stripping does not remove VaneHub's operational `debug` log level. Release builds continue to persist redacted `error`, `warn`, `info`, and `debug` events through unified logging. Build prerequisites, verification commands, worktree cache behavior, and measurement evidence are documented in `docs/build-performance.md`.
+
+The current measurement record contains optimized Windows executable, MSI, and NSIS sizes but no comparable pre-change package artifacts because the baseline package was interrupted by an external Rust toolchain update. Those absolute sizes do not establish a measured size reduction.
+
 ## GitHub environment secrets
 
 Store credentials only as secrets on the `release` environment. Never place their values in repository variables, workflow files, issues, logs, or artifacts.

--- a/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/design.md
+++ b/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/design.md
@@ -1,0 +1,142 @@
+## Context
+
+The native application is a single Tauri 2 Rust crate with a large dependency graph spanning SQLite, async runtimes, networking, telemetry, terminal handling, and platform integrations. No repository Cargo linker configuration or custom release profile currently exists. Native commands run from the repository root, so a root `.cargo/config.toml` can consistently affect direct Cargo commands and Tauri builds.
+
+The supported release matrix currently builds Windows x86_64 MSVC, macOS ARM64, and Linux x86_64 GNU packages. CI also checks Windows and macOS natively. A newly created Git worktree has its own ignored `src-tauri/target` directory, so its first build is a cold dependency compilation; a linker change affects final and incremental linking but does not eliminate that cold-build cost.
+
+The unified logging contract requires production support for `error`, `warn`, `info`, and `debug`. Existing debug-level events describe operational behavior such as ignored IM events and successful opener discovery, so debug log severity must not be treated as synonymous with development-only code.
+
+This change affects repository build configuration and the Rust/native build path only. It does not alter React services, the Tauri frontend adapter, the Web/mock adapter, Tauri commands, or SQLite/runtime behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Select and reproducibly exercise target-scoped Windows and Linux linkers, then report controlled relink results without presuming they improve on every host.
+- Optimize release binaries with an explicit, reviewable Cargo release profile and measure artifact size without presuming it decreases.
+- Keep CI and packaging environments reproducible by provisioning every non-toolchain linker dependency.
+- Measure incremental build time before and after the linker change, measure release artifact size where a valid baseline is available, and label unavailable comparisons explicitly.
+- Preserve production diagnostic behavior and document when `#[cfg(debug_assertions)]` is appropriate.
+- Make cold-worktree and incremental-build behavior explicit in maintainer documentation.
+
+**Non-Goals:**
+
+- Changing application features, frontend/runtime service boundaries, database behavior, or package formats.
+- Introducing a shared Cargo target directory, `sccache`, or a remote build cache.
+- Requiring mold for unsupported Linux cross-compilation targets.
+- Replacing the native Apple linker or changing macOS signing/notarization.
+- Compiling production debug-severity operational logs out of the application.
+- Guaranteeing any build-time or binary-size improvement across different machines.
+- Claiming distributable-size reduction when no comparable pre-change artifact exists.
+
+## Decisions
+
+### 1. Use target-scoped repository linker configuration
+
+Add root Cargo target configuration for the targets that the repository actually validates:
+
+```toml
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"
+
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+```
+
+Windows uses the `rust-lld.exe` shipped with the installed Rust MSVC toolchain, avoiding a separate LLVM installation. Linux uses Clang as the linker driver and mold as the ELF linker. The Linux configuration is limited to x86_64 GNU so it cannot silently impose host-linker assumptions on ARM64 or musl cross-builds.
+
+The controlled Windows measurement recorded for this change found Rust LLD 11.2% slower than `link.exe` for the clean prewarmed relink pair on the measured host. The configuration is therefore retained as a reproducible, validated linker policy rather than claimed as a demonstrated Windows speedup. Broader evidence can justify revisiting the Windows selection in a follow-up change.
+
+The project will not silently fall back to the default linker on these declared targets. A silent fallback would make local and CI performance inconsistent and could hide missing build prerequisites. CI workflows and documentation will provision or declare the required tooling.
+
+Alternatives considered:
+
+- User-global Cargo configuration was rejected because CI, packaging, and contributors would not share a reproducible policy.
+- A wrapper script that probes and falls back was rejected because `npm run tauri:dev`, direct Cargo commands, and IDE integrations could bypass it.
+- Applying mold or LLD through global `RUSTFLAGS` was rejected because it can contaminate unsupported targets and makes the active linker harder to audit.
+
+### 2. Prefer a balanced release profile over maximum size reduction
+
+Define the following explicit release policy in `src-tauri/Cargo.toml`:
+
+```toml
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+strip = "debuginfo"
+```
+
+ThinLTO is selected instead of fat LTO because it retains cross-crate optimization with a lower linking-time penalty. One codegen unit gives LLVM the best opportunity to optimize the application crate in the infrequent packaging path. `strip = "debuginfo"` removes debug information from shipped binaries while retaining more useful symbol/backtrace behavior than `strip = true`/`"symbols"`. These choices can change distributable size, but the change does not claim a size reduction without comparable pre-change artifacts.
+
+`opt-level = 3` is already Cargo's release default, but it is stated explicitly so the complete distribution policy is reviewable in one place.
+
+Alternatives considered:
+
+- Fat LTO was rejected for the first iteration because release build latency would increase substantially without measured evidence that its additional size or runtime benefit is material.
+- `opt-level = "s"` or `"z"` was deferred because this desktop runtime performs parsing, networking, telemetry, and local orchestration; a benchmark should precede a global speed-for-size trade.
+- `strip = "symbols"` was rejected initially because it can make production backtraces and crash investigation substantially less useful.
+- `panic = "abort"` was deferred because it changes failure behavior rather than being a purely build-time optimization.
+
+### 3. Preserve operational debug logs in release builds
+
+`#[cfg(debug_assertions)]` may guard only behavior that has no production contract, such as developer-only UI, local probes, or expensive assertions. It must not guard unified logging severity variants, serialization mappings, redaction paths, or operational debug events.
+
+The implementation will audit current conditional compilation and debug-severity call sites. If no genuinely development-only feature exists, it will not add a gratuitous conditional block merely to demonstrate the mechanism. Existing `cfg(test)` isolation and the release-only Windows subsystem attribute remain valid.
+
+Alternatives considered:
+
+- Compiling out all debug-severity records was rejected because `unified-log-management` explicitly requires the level and several production flows use it.
+- A new user-facing log-level setting was rejected because the current logging specification explicitly excludes that control.
+
+### 4. Measure cold, incremental, and release outcomes separately
+
+Verification will record:
+
+- environment and toolchain identity;
+- cold build context for the fresh worktree;
+- a representative incremental Rust rebuild/relink time before and after linker selection;
+- release executable size and packaged artifact sizes before and after the release profile when comparable pre-change artifacts are available;
+- active linker evidence on Windows and Linux where the host supports it.
+
+Measurements are evidence attached to implementation verification, not hard cross-machine performance requirements. The same source state and comparable target/cache state must be used for each before/after pair. A neutral or negative result must be reported as such. If an environmental failure prevents a valid baseline, verification must identify the missing comparison and must not infer an improvement from the optimized artifact alone.
+
+Alternatives considered:
+
+- A fixed percentage gate was rejected because GitHub-hosted runner load, filesystem cache state, and dependency cache state make such a gate flaky.
+- Measuring only a cold build was rejected because dependency compilation would obscure the linker-specific effect.
+
+### 5. Provision linkers in every affected workflow
+
+Linux CI and package jobs will install Clang and mold before invoking Cargo/Tauri. Windows native validation will verify the toolchain-provided LLD by producing at least one linked native artifact rather than relying only on `cargo check`. Packaging continues to use the release profile through the existing Tauri build command.
+
+macOS keeps its current native linker and validation path. Unsupported targets retain their platform defaults because the Cargo configuration is exact-target scoped.
+
+## Risks / Trade-offs
+
+- [ThinLTO and one codegen unit increase release build time] → Limit them to the release profile and record packaging duration alongside size results.
+- [A missing mold or Clang installation breaks Linux builds] → Install both in CI/package workflows and document them as local prerequisites with a direct verification command.
+- [LLD differs subtly from Microsoft's linker for native libraries] → Run a linked Windows validation artifact and the Windows package build before accepting the change.
+- [Changing linker flags invalidates Cargo caches] → Treat the first optimized build as a one-time cold build and compare representative subsequent relinks.
+- [A declared candidate linker is slower on a measured host] → Retain the measured direction in documentation, make no speedup claim, and revisit linker selection only through a follow-up spec change with broader controlled evidence.
+- [Stripping reduces post-mortem visibility] → Strip debuginfo rather than all symbols and preserve unified production diagnostics.
+- [A pre-change release artifact cannot be produced] → Record optimized artifact sizes as absolute values, label the baseline unavailable, and make no size-reduction claim.
+- [Fresh worktrees appear unaffected because dependency compilation dominates] → Document separate cold and incremental measurements and avoid claiming linker gains from cold-build totals alone.
+- [Repository Cargo configuration affects all contributors] → Scope configuration to the two validated target triples and document unsupported-target behavior.
+
+## Migration Plan
+
+1. Capture baseline toolchain details, incremental build timing, release executable size, and package size where the current host permits; explicitly record unavailable baselines.
+2. Add the target-scoped Cargo linker configuration and provision matching CI/package prerequisites.
+3. Add the explicit release profile and audit conditional compilation against unified logging requirements.
+4. Run native checks/tests, linked Windows/Linux validation as available, local packaging on the current host, and strict OpenSpec validation.
+5. Record before/after results and update build/release documentation.
+6. Roll back by removing the target linker tables and release profile; no data or runtime migration is required.
+
+## Open Questions
+
+- Whether later evidence justifies `strip = "symbols"`, `opt-level = "s"`, or fat LTO for a dedicated size-minimized release profile.
+- Whether controlled measurements on additional Windows hosts justify retaining Rust LLD as the default MSVC linker or returning to `link.exe`.
+- Whether cross-worktree compilation should later gain a separate `sccache` or shared-target proposal after linker gains are measured.
+- Whether Linux ARM64 packaging should adopt mold after a native or controlled cross-build environment is added to the supported matrix.

--- a/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/proposal.md
+++ b/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Rust development builds in fresh worktrees currently use platform-default linkers and isolated target directories, while release packages use Cargo's default release profile without whole-program optimization or symbol stripping. The project needs an explicit, measurable build policy that evaluates target-scoped linker choices and optimizes distributable builds without weakening production diagnostics, pre-committing to a performance gain before measurement, or making supported builds dependent on undeclared tooling.
+
+## What Changes
+
+- Define supported target-scoped linker behavior for Windows MSVC and Linux native development and validation builds, including required tool provisioning and documented fallback or unsupported-target behavior.
+- Define an optimized Cargo release profile using ThinLTO, release optimization, a single codegen unit, and debuginfo stripping.
+- Require controlled before/after measurements for representative incremental native builds and packaged artifact sizes where a valid baseline is available, and prohibit improvement claims when evidence is unavailable, neutral, or negative.
+- Update native packaging and CI workflows to provision and exercise the declared linker configuration on their supported runners.
+- Preserve production `error`, `warn`, `info`, and `debug` unified-log semantics; restrict `#[cfg(debug_assertions)]` to genuinely development-only behavior rather than operational diagnostics.
+- Document worktree cache behavior and supported local prerequisites so a fresh worktree's cold build is not mistaken for linker performance.
+
+## Capabilities
+
+### New Capabilities
+
+- `native-build-optimization`: Defines target-scoped linker selection, optimized release profile behavior, measurement expectations, worktree cache guidance, and the boundary between development-only code and production diagnostics.
+
+### Modified Capabilities
+
+- `native-app-packaging`: Require packaged native artifacts to use the declared optimized release profile and document its platform tooling and diagnostic tradeoffs.
+- `continuous-integration`: Require native validation runners to provision and verify the linker prerequisites selected for supported Windows and Linux builds.
+
+## Impact
+
+- Desktop/native runtime and its build, CI, and release tooling are affected; the Web runtime and frontend service adapter boundary are unchanged.
+- Expected implementation areas include `src-tauri/Cargo.toml`, project Cargo configuration, `.github/workflows/ci.yml`, `.github/workflows/package.yml`, packaging/build documentation, and focused verification scripts or commands.
+- Linux builds gain a declared `clang`/mold prerequisite; Windows MSVC builds use the Rust-toolchain-provided LLD linker where validated.
+- Release linking can take longer than the current default because of ThinLTO and a single codegen unit. The profile enables whole-program optimization and removes debuginfo, but distributable-size reduction is not claimed without a comparable baseline.
+- Unified logging APIs and release diagnostics remain available; this change must not compile away operational debug-level events required by `unified-log-management`.

--- a/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/specs/continuous-integration/spec.md
+++ b/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/specs/continuous-integration/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Native linker prerequisite validation
+Continuous integration SHALL provision and exercise the declared linker prerequisites for every supported target that has a repository target-scoped linker policy.
+
+#### Scenario: Validate Linux x86_64 native code
+- **WHEN** CI validates `x86_64-unknown-linux-gnu`
+- **THEN** the runner SHALL install or verify Clang and mold before invoking native compilation
+- **AND** at least one validation step SHALL link a native artifact using the declared linker
+
+#### Scenario: Validate Windows x86_64 MSVC native code
+- **WHEN** CI validates `x86_64-pc-windows-msvc`
+- **THEN** the runner SHALL verify that the selected Rust toolchain provides the declared LLD linker
+- **AND** at least one validation step SHALL link a native artifact using that linker
+
+#### Scenario: Linker prerequisite is unavailable
+- **WHEN** a required linker or linker driver cannot be provisioned on a declared CI target
+- **THEN** native validation SHALL fail before reporting the target as successfully validated

--- a/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/specs/native-app-packaging/spec.md
+++ b/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/specs/native-app-packaging/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Optimized distributable native artifacts
+Native package commands and release workflows SHALL build distributable binaries with the declared optimized Cargo release profile.
+
+#### Scenario: Run local native packaging
+- **WHEN** a maintainer runs a supported local Tauri package command
+- **THEN** the packaged native binary SHALL use the declared release optimization and debuginfo-stripping policy
+
+#### Scenario: Run tagged release packaging
+- **WHEN** the release workflow builds a supported native target
+- **THEN** the packaged native binary SHALL use the same declared release profile as local release packaging
+- **AND** the workflow SHALL fail rather than publish an artifact built without required linker prerequisites
+
+### Requirement: Packaging optimization documentation
+Packaging documentation SHALL identify the release profile, platform linker prerequisites, expected release-build tradeoffs, and retained production diagnostic behavior.
+
+#### Scenario: Review release build guidance
+- **WHEN** a maintainer prepares a local or CI package build
+- **THEN** the documentation SHALL identify required linker tools for the target platform
+- **AND** it SHALL explain that ThinLTO and a single codegen unit can increase release build time and can affect optimization or distributable size without guaranteeing a size reduction
+- **AND** it SHALL distinguish measured artifact sizes from a demonstrated before/after size improvement
+- **AND** it SHALL state that operational debug-level unified logs remain available in release packages

--- a/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/specs/native-build-optimization/spec.md
+++ b/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/specs/native-build-optimization/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Target-scoped native linkers
+The project SHALL select a declared linker only for native target triples whose linker configuration and prerequisites are validated by the repository.
+
+#### Scenario: Build Windows x86_64 MSVC target
+- **WHEN** a native build targets `x86_64-pc-windows-msvc`
+- **THEN** Cargo SHALL use the Rust-toolchain-provided LLD linker
+- **AND** the build SHALL remain compatible with the required MSVC libraries and Windows packaging toolchain
+
+#### Scenario: Build Linux x86_64 GNU target
+- **WHEN** a native build targets `x86_64-unknown-linux-gnu`
+- **THEN** Cargo SHALL use Clang as the linker driver and mold as the ELF linker
+- **AND** the build environment SHALL provide both declared tools before compilation starts
+
+#### Scenario: Build an undeclared target
+- **WHEN** a native build targets a platform or architecture without a validated target-scoped linker policy
+- **THEN** the project SHALL NOT apply incompatible linker flags from a different target
+
+### Requirement: Optimized native release profile
+The native application SHALL use an explicit release profile that enables optimization level 3, ThinLTO, one code generation unit, and debuginfo stripping for distributable builds.
+
+#### Scenario: Build a release binary
+- **WHEN** Cargo builds the native application with the release profile
+- **THEN** the build SHALL use `opt-level = 3`, `lto = "thin"`, `codegen-units = 1`, and `strip = "debuginfo"`
+
+#### Scenario: Build a development binary
+- **WHEN** Cargo builds the native application with the development profile
+- **THEN** the release-only LTO, codegen-unit, and stripping policy SHALL NOT disable incremental development behavior
+
+### Requirement: Production diagnostic preservation
+Native build optimization MUST preserve every production unified-log severity and MUST restrict `debug_assertions` conditional compilation to behavior without a production diagnostic contract.
+
+#### Scenario: Compile a release build
+- **WHEN** the native application is compiled without debug assertions
+- **THEN** the release binary SHALL retain `error`, `warn`, `info`, and `debug` unified-log level semantics
+- **AND** operational debug-level events, redaction, persistence, and serialization paths SHALL remain available
+
+#### Scenario: Gate development-only behavior
+- **WHEN** implementation code uses `#[cfg(debug_assertions)]`
+- **THEN** the gated behavior SHALL be development-only
+- **AND** removing it from a release build SHALL NOT remove required diagnostics or change a service/runtime contract
+
+### Requirement: Comparable build optimization evidence
+The implementation SHALL record comparable evidence for linker performance and release artifact size before claiming an optimization result, and SHALL report unavailable, neutral, or negative results without inferring an improvement.
+
+#### Scenario: Compare incremental native builds
+- **WHEN** linker performance is evaluated
+- **THEN** baseline and optimized measurements SHALL use the same source state and comparable cache state
+- **AND** the result SHALL distinguish cold dependency compilation from representative incremental relinking
+- **AND** the result SHALL state whether the measured linker improved, regressed, or remained neutral
+
+#### Scenario: Compare release artifact size
+- **WHEN** release profile optimization is evaluated
+- **THEN** every available baseline and optimized executable or package size SHALL identify the host, target, toolchain, profile, and artifact measured
+- **AND** if a comparable baseline artifact is unavailable, the evidence SHALL identify the missing comparison and SHALL NOT claim a size reduction
+
+### Requirement: Worktree build behavior documentation
+Maintainer documentation SHALL explain that ignored Cargo target output is worktree-local by default and SHALL distinguish cold-build cost from incremental linker cost.
+
+#### Scenario: Build from a fresh worktree
+- **WHEN** a maintainer prepares to build the native application from a new Git worktree
+- **THEN** the documentation SHALL identify that the first build may compile the complete dependency graph
+- **AND** it SHALL describe how to verify the active platform linker before interpreting performance results

--- a/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/tasks.md
+++ b/openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/tasks.md
@@ -1,0 +1,34 @@
+## 1. Baseline and Tooling Audit
+
+- [x] 1.1 Record the current host, Rust/Cargo versions, target triple, linker availability, worktree cache state, and the exact commands used for comparable measurements.
+- [x] 1.2 Capture baseline cold-build context, representative incremental native rebuild/relink time, and locally available pre-change release/package artifact sizes; explicitly record any baseline artifact that cannot be produced.
+- [x] 1.3 Define how Windows LLD and Linux mold usage will be verified from build output or produced artifacts without relying on timing alone.
+
+## 2. Cargo Build Configuration
+
+- [x] 2.1 Add root target-scoped Cargo configuration for `rust-lld.exe` on `x86_64-pc-windows-msvc` and `clang` plus mold on `x86_64-unknown-linux-gnu`, leaving undeclared targets on their platform defaults and treating measured performance as evidence rather than an assumed gain.
+- [x] 2.2 Add the explicit native release profile with `opt-level = 3`, ThinLTO, one codegen unit, and debuginfo stripping.
+- [x] 2.3 Audit existing `cfg(debug_assertions)` and production debug-level logging paths, retaining every unified-log severity, mapping, redaction path, and required operational diagnostic in release builds.
+- [x] 2.4 Add or update focused native tests or architecture checks that verify release-compatible unified-log level serialization and prevent development-only gating from removing the production logging contract.
+
+## 3. CI and Packaging Integration
+
+- [x] 3.1 Update Linux native CI provisioning to install or verify Clang and mold before compilation and link at least one native validation artifact.
+- [x] 3.2 Update Windows native CI validation to confirm the Rust-toolchain-provided LLD is selected and link at least one MSVC native artifact.
+- [x] 3.3 Update Linux desktop packaging provisioning to install or verify Clang and mold before the Tauri release build.
+- [x] 3.4 Verify that Windows, Linux, and macOS package commands continue using the shared Cargo release profile while unsupported target triples do not inherit incompatible linker flags.
+
+## 4. Documentation and Evidence
+
+- [x] 4.1 Document Windows and Linux linker prerequisites, verification commands, supported target scope, and failure behavior for missing tools.
+- [x] 4.2 Document release profile choices, ThinLTO/link-time tradeoffs, debuginfo stripping, and preservation of operational debug-level unified logs.
+- [x] 4.3 Document fresh-worktree cold builds, worktree-local ignored target output, and the distinction between dependency compilation and incremental linker performance.
+- [x] 4.4 Capture optimized incremental relink, release executable, and package measurements using the baseline method, then record a reviewable comparison with environment metadata, the measured direction, and any unavailable baseline without claiming unsupported improvement.
+
+## 5. Verification
+
+- [x] 5.1 Run `npm run lint`, `npm run test`, and `npm run build`.
+- [x] 5.2 Run `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`, `cargo check --manifest-path src-tauri/Cargo.toml`, `cargo clippy --manifest-path src-tauri/Cargo.toml`, and `cargo test --manifest-path src-tauri/Cargo.toml`.
+- [x] 5.3 Run a linked native development build and `cargo build --release --manifest-path src-tauri/Cargo.toml`, confirming the expected linker and release profile on the current host.
+- [x] 5.4 Run the supported current-host Tauri package command and verify that expected bundle artifacts are produced and measured.
+- [x] 5.5 Run `openspec validate optimize-rust-build-and-release --strict` and `openspec validate --specs --strict`.

--- a/openspec/changes/archive/README.md
+++ b/openspec/changes/archive/README.md
@@ -72,5 +72,6 @@ Online archive location: `openspec/changes/archive/`
 | 2026-07-23 | add-multi-agent-coordination | agent-execution-observability, multi-agent-coordination | `openspec/changes/archive/2026-07-23-add-multi-agent-coordination/` |
 | 2026-07-23 | agent-execution-observability | agent-execution-observability, app-settings, contract-and-task-foundation, mcp-client-management, session-runtime-management, unified-log-management | `openspec/changes/archive/2026-07-23-agent-execution-observability/` |
 | 2026-07-23 | optimize-frontend-rendering-and-loading | frontend-runtime-architecture, main-layout-ui, session-log-viewer, session-workspace-tabs, settings-center-ui, settings-prompt-hooks-ui | `openspec/changes/archive/2026-07-23-optimize-frontend-rendering-and-loading/` |
+| 2026-07-24 | optimize-rust-build-and-release | continuous-integration, native-app-packaging, native-build-optimization | `openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/` |
 
 Cold-archive destinations are recorded in `openspec/archive-cold-migrations.md`.

--- a/openspec/changes/archive/archive-index.json
+++ b/openspec/changes/archive/archive-index.json
@@ -1003,6 +1003,21 @@
                                               "settings-center-ui",
                                               "settings-prompt-hooks-ui"
                                           ]
+                     },
+                     {
+                         "archivedOn":  "2026-07-24",
+                         "changeName":  "optimize-rust-build-and-release",
+                         "path":  "openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/",
+                         "artifacts":  [
+                                           "proposal",
+                                           "design",
+                                           "tasks"
+                                       ],
+                         "capabilities":  [
+                                              "continuous-integration",
+                                              "native-app-packaging",
+                                              "native-build-optimization"
+                                          ]
                      }
                  ]
 }

--- a/openspec/specs/continuous-integration/spec.md
+++ b/openspec/specs/continuous-integration/spec.md
@@ -38,3 +38,20 @@ CI SHALL retain the Playwright HTML report as a GitHub Actions artifact when Pla
 #### Scenario: Successful E2E run
 - **WHEN** Playwright E2E execution succeeds
 - **THEN** the workflow SHALL not upload a failure-only report artifact
+
+### Requirement: Native linker prerequisite validation
+Continuous integration SHALL provision and exercise the declared linker prerequisites for every supported target that has a repository target-scoped linker policy.
+
+#### Scenario: Validate Linux x86_64 native code
+- **WHEN** CI validates `x86_64-unknown-linux-gnu`
+- **THEN** the runner SHALL install or verify Clang and mold before invoking native compilation
+- **AND** at least one validation step SHALL link a native artifact using the declared linker
+
+#### Scenario: Validate Windows x86_64 MSVC native code
+- **WHEN** CI validates `x86_64-pc-windows-msvc`
+- **THEN** the runner SHALL verify that the selected Rust toolchain provides the declared LLD linker
+- **AND** at least one validation step SHALL link a native artifact using that linker
+
+#### Scenario: Linker prerequisite is unavailable
+- **WHEN** a required linker or linker driver cannot be provisioned on a declared CI target
+- **THEN** native validation SHALL fail before reporting the target as successfully validated

--- a/openspec/specs/native-app-packaging/spec.md
+++ b/openspec/specs/native-app-packaging/spec.md
@@ -1,9 +1,7 @@
 ## Purpose
 
 Defines how VaneHub AI produces native desktop package artifacts locally and through GitHub Actions for supported operating systems and architectures.
-
 ## Requirements
-
 ### Requirement: Local one-command packaging
 The system SHALL provide a documented local command that builds the frontend and produces Tauri desktop package artifacts for the current host platform.
 
@@ -81,3 +79,25 @@ The system SHALL document local prerequisites, local packaging commands, GitHub 
 #### Scenario: Maintainer reviews CI documentation
 - **WHEN** a maintainer reviews the CI packaging documentation
 - **THEN** they can identify workflow triggers, artifact naming, and unsupported or credential-dependent release steps
+
+### Requirement: Optimized distributable native artifacts
+Native package commands and release workflows SHALL build distributable binaries with the declared optimized Cargo release profile.
+
+#### Scenario: Run local native packaging
+- **WHEN** a maintainer runs a supported local Tauri package command
+- **THEN** the packaged native binary SHALL use the declared release optimization and debuginfo-stripping policy
+
+#### Scenario: Run tagged release packaging
+- **WHEN** the release workflow builds a supported native target
+- **THEN** the packaged native binary SHALL use the same declared release profile as local release packaging
+- **AND** the workflow SHALL fail rather than publish an artifact built without required linker prerequisites
+
+### Requirement: Packaging optimization documentation
+Packaging documentation SHALL identify the release profile, platform linker prerequisites, expected release-build tradeoffs, and retained production diagnostic behavior.
+
+#### Scenario: Review release build guidance
+- **WHEN** a maintainer prepares a local or CI package build
+- **THEN** the documentation SHALL identify required linker tools for the target platform
+- **AND** it SHALL explain that ThinLTO and a single codegen unit can increase release build time and can affect optimization or distributable size without guaranteeing a size reduction
+- **AND** it SHALL distinguish measured artifact sizes from a demonstrated before/after size improvement
+- **AND** it SHALL state that operational debug-level unified logs remain available in release packages

--- a/openspec/specs/native-build-optimization/spec.md
+++ b/openspec/specs/native-build-optimization/spec.md
@@ -1,0 +1,67 @@
+# native-build-optimization Specification
+
+## Purpose
+TBD - created by archiving change optimize-rust-build-and-release. Update Purpose after archive.
+## Requirements
+### Requirement: Target-scoped native linkers
+The project SHALL select a declared linker only for native target triples whose linker configuration and prerequisites are validated by the repository.
+
+#### Scenario: Build Windows x86_64 MSVC target
+- **WHEN** a native build targets `x86_64-pc-windows-msvc`
+- **THEN** Cargo SHALL use the Rust-toolchain-provided LLD linker
+- **AND** the build SHALL remain compatible with the required MSVC libraries and Windows packaging toolchain
+
+#### Scenario: Build Linux x86_64 GNU target
+- **WHEN** a native build targets `x86_64-unknown-linux-gnu`
+- **THEN** Cargo SHALL use Clang as the linker driver and mold as the ELF linker
+- **AND** the build environment SHALL provide both declared tools before compilation starts
+
+#### Scenario: Build an undeclared target
+- **WHEN** a native build targets a platform or architecture without a validated target-scoped linker policy
+- **THEN** the project SHALL NOT apply incompatible linker flags from a different target
+
+### Requirement: Optimized native release profile
+The native application SHALL use an explicit release profile that enables optimization level 3, ThinLTO, one code generation unit, and debuginfo stripping for distributable builds.
+
+#### Scenario: Build a release binary
+- **WHEN** Cargo builds the native application with the release profile
+- **THEN** the build SHALL use `opt-level = 3`, `lto = "thin"`, `codegen-units = 1`, and `strip = "debuginfo"`
+
+#### Scenario: Build a development binary
+- **WHEN** Cargo builds the native application with the development profile
+- **THEN** the release-only LTO, codegen-unit, and stripping policy SHALL NOT disable incremental development behavior
+
+### Requirement: Production diagnostic preservation
+Native build optimization MUST preserve every production unified-log severity and MUST restrict `debug_assertions` conditional compilation to behavior without a production diagnostic contract.
+
+#### Scenario: Compile a release build
+- **WHEN** the native application is compiled without debug assertions
+- **THEN** the release binary SHALL retain `error`, `warn`, `info`, and `debug` unified-log level semantics
+- **AND** operational debug-level events, redaction, persistence, and serialization paths SHALL remain available
+
+#### Scenario: Gate development-only behavior
+- **WHEN** implementation code uses `#[cfg(debug_assertions)]`
+- **THEN** the gated behavior SHALL be development-only
+- **AND** removing it from a release build SHALL NOT remove required diagnostics or change a service/runtime contract
+
+### Requirement: Comparable build optimization evidence
+The implementation SHALL record comparable evidence for linker performance and release artifact size before claiming an optimization result, and SHALL report unavailable, neutral, or negative results without inferring an improvement.
+
+#### Scenario: Compare incremental native builds
+- **WHEN** linker performance is evaluated
+- **THEN** baseline and optimized measurements SHALL use the same source state and comparable cache state
+- **AND** the result SHALL distinguish cold dependency compilation from representative incremental relinking
+- **AND** the result SHALL state whether the measured linker improved, regressed, or remained neutral
+
+#### Scenario: Compare release artifact size
+- **WHEN** release profile optimization is evaluated
+- **THEN** every available baseline and optimized executable or package size SHALL identify the host, target, toolchain, profile, and artifact measured
+- **AND** if a comparable baseline artifact is unavailable, the evidence SHALL identify the missing comparison and SHALL NOT claim a size reduction
+
+### Requirement: Worktree build behavior documentation
+Maintainer documentation SHALL explain that ignored Cargo target output is worktree-local by default and SHALL distinguish cold-build cost from incremental linker cost.
+
+#### Scenario: Build from a fresh worktree
+- **WHEN** a maintainer prepares to build the native application from a new Git worktree
+- **THEN** the documentation SHALL identify that the first build may compile the complete dependency graph
+- **AND** it SHALL describe how to verify the active platform linker before interpreting performance results

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,3 +55,9 @@ tracing-subscriber = { version = "=0.3.22", default-features = false, features =
 opentelemetry_sdk = { version = "=0.32.1", default-features = false, features = ["trace", "metrics", "logs", "testing"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 syn = { version = "3", features = ["full", "visit"] }
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+strip = "debuginfo"

--- a/src-tauri/src/platform/logging.rs
+++ b/src-tauri/src/platform/logging.rs
@@ -632,6 +632,21 @@ mod tests {
     }
 
     #[test]
+    fn serializes_every_production_log_level() {
+        for (level, expected) in [
+            (LogLevel::Error, "\"error\""),
+            (LogLevel::Warn, "\"warn\""),
+            (LogLevel::Info, "\"info\""),
+            (LogLevel::Debug, "\"debug\""),
+        ] {
+            assert_eq!(
+                serde_json::to_string(&level).expect("serialize production log level"),
+                expected
+            );
+        }
+    }
+
+    #[test]
     fn writes_redacted_client_log_event() {
         let dir = temp_dir("client");
         let mut details = BTreeMap::new();

--- a/src-tauri/tests/architecture.rs
+++ b/src-tauri/tests/architecture.rs
@@ -743,3 +743,31 @@ mod tests {
     assert_eq!(uses.len(), 3);
     assert!(uses.iter().all(|usage| usage.line <= 4));
 }
+
+#[test]
+fn production_logging_contract_is_not_debug_assertion_gated() {
+    let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let logging_contract_files = [
+        "platform/logging.rs",
+        "contexts/operations/infrastructure/unified_logging.rs",
+        "contexts/communications/infrastructure/runtime_manager.rs",
+        "contexts/desktop/infrastructure/folder_openers.rs",
+    ];
+
+    for relative in logging_contract_files {
+        let source = fs::read_to_string(source_root.join(relative)).expect("read logging source");
+        assert!(
+            !source.contains("cfg(debug_assertions)"),
+            "production logging contract cannot be debug-assertion gated: {relative}"
+        );
+    }
+
+    let logging =
+        fs::read_to_string(source_root.join("platform/logging.rs")).expect("read log levels");
+    for variant in ["Error", "Warn", "Info", "Debug"] {
+        assert!(
+            logging.contains(&format!("    {variant},")),
+            "production log level is missing: {variant}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add exact-target Cargo linker policies for Windows x64 (`rust-lld`) and Linux x64 (Clang + mold), with CI/package prerequisite verification.
- Define the shared release profile with optimization level 3, ThinLTO, one codegen unit, and debuginfo stripping while preserving production unified-log semantics.
- Document controlled linker/package evidence and archive the completed `optimize-rust-build-and-release` OpenSpec change into the main specifications.

## Related work

- Issue: N/A
- OpenSpec change: `openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/`

## Risk and compatibility

The linker configuration is scoped only to `x86_64-pc-windows-msvc` and `x86_64-unknown-linux-gnu`; macOS and undeclared targets retain platform defaults. Linux builds now require Clang and mold. The controlled Windows relink sample found Rust LLD 11.2% slower than `link.exe`, so the documentation makes no Windows speedup claim. No runtime data migration or frontend service-boundary change is involved. Rollback consists of removing the target linker tables and release profile.

## Validation

- [x] `npm run lint`
- [x] `npm run test` (86 files, 290 tests)
- [x] `npm run contracts:check`
- [x] `npm run build`
- [ ] `npx playwright test` (not applicable: no UI behavior change)
- [x] Rust fmt, check, Clippy, and tests (691 passed, 3 ignored; 9 architecture tests passed)
- [x] Strict OpenSpec validation (63 main specs)

## Screenshots or diagnostics

No UI screenshots required. `docs/build-performance.md` records the controlled linker A/B method, complete Windows package artifacts, sizes, and SHA-256 values. No size reduction is claimed because a comparable pre-change package baseline was unavailable.

## Checklist

- [x] The change follows `AGENTS.md` and `openspec/project.md`.
- [x] New behavior is covered by focused logging and architecture tests.
- [x] Documentation is updated; service adapters are not affected.
- [x] No secrets, signing material, local databases, or sensitive logs are committed.