### PR TITLE
fix: render embedded terminals on an opaque dark canvas for TUI readability

### DIFF
--- a/openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/design.md
+++ b/openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/design.md
@@ -1,0 +1,46 @@
+## Context
+
+工作区 agent 终端(`src/session-workspace/agent-terminal-tab.tsx`)与 Shell 终端(`src/session-workspace/shell-tab.tsx`)都用 xterm.js 渲染 PTY 原始输出,共用 `src/session-workspace/terminal-theme.ts` 的 `createTerminalTheme()` 和 `src/styles.css` 中 `.ucd-agent-terminal` / `.ucd-shell-terminal` 一组样式。
+
+现状:`createTerminalTheme()` 返回的主题 `background: rgba(0,0,0,0)` 透明,16 色 ANSI 只映射了 `black`/`brightBlack` 两色;`styles.css` 用 `.xterm-viewport{background:transparent}` + `.xterm-bg-0`/`.xterm-bg-257` → `panel-muted`、`.xterm-fg-257` → `foreground` 把终端"漂白"成浅色。Codex 等全屏 TUI 用 256 色 / truecolor 背景绘制输入框、状态栏,这些既非索引 0 也非默认背景,不被上述覆盖命中;truecolor 更是走 xterm DOM 渲染器的行内样式,CSS 类选择器无法拦截。结果这些区域按原始深色渲染成黑块,其上为深色终端配的浅色/中间色文字失去对比度 → 黑底看不清。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 内嵌终端在一块自洽、不透明的深色画布上渲染,提供**完整 16 色 ANSI 调色板**,让任意 ANSI/256/truecolor 前景与背景都能原生、可读地呈现。
+- 终端配色来自 `styles.css` 的**语义化终端 token**,不在组件里硬编码调色板;两个注册视觉样式(`futuristic`/`minimal`)复用同一套终端画布。
+- agent 终端与 Shell 终端共用同一渲染路径,一处修复两处受益,并覆盖后续接入的其他全屏 TUI。
+
+**Non-Goals:**
+
+- 不强制 agent CLI 切换到浅色主题,不改写其色彩输出;终端忠实渲染,只是给它一块深色底。
+- 不修改 PTY 环境变量 / 色深(不设 `TERM`/`COLORTERM`)。
+- 不改动前端 service 边界、Tauri 命令、适配器契约或 SQLite。
+- 不改动终端下方 VaneHub 自带的命令输入框(`.ucd-agent-terminal-input`),它仍随应用主题。
+
+## Decisions
+
+1. **新增语义化终端 token(`src/styles.css`)**
+   - 定义一组终端专用 token:`--terminal-background`、`--terminal-foreground`、`--terminal-cursor`、`--terminal-selection`、`--terminal-selection-foreground`,以及完整 16 色 `--terminal-ansi-{black,red,green,yellow,blue,magenta,cyan,white}` 与 `--terminal-ansi-bright-{...}`。
+   - 终端是自成一体的深色面,采用一套固定的深色 ANSI 调色板,放在基础 `:root` 层,`futuristic`/`minimal` 默认共享(样式如需可覆盖同名 token,组件不感知)。
+   - 这些 token 以**完整颜色值**(hex)定义,而非项目其它 token 的 HSL 三元组——16 色 ANSI 调色板用 hex 是终端领域通用写法,更可读可维护;此偏差仅限终端调色板,并在此记录理由。
+
+2. **`createTerminalTheme()` 返回完整不透明主题(`terminal-theme.ts`)**
+   - 改为读取上述终端 token 的**原始计算值**(新增 `terminalColor(name, fallback)`,直接返回 computed value,不再包 `hsl()`),各 token 带一个安全 fallback 深色默认值。
+   - 返回完整 xterm `ITheme`:不透明 `background`、`foreground`、`cursor`、`cursorAccent`、`selectionBackground`、`selectionForeground`,以及 `black/red/green/yellow/blue/magenta/cyan/white` + 8 个 `bright*`。
+
+3. **两个终端组件设为不透明画布**
+   - `agent-terminal-tab.tsx` 与 `shell-tab.tsx` 的 `new XtermTerminal({...})` 将 `allowTransparency` 由 `true` 改为 `false`(不透明背景由主题填充)。
+   - 终端宿主 `<div className="ucd-agent-terminal ...">` / `ucd-shell-terminal` 去掉内联 `bg-[hsl(var(--panel-muted))]`,背景改由 `styles.css` 中 `.ucd-agent-terminal, .ucd-shell-terminal { background: var(--terminal-background); }` 提供,使 padding 边框与终端底色一致。
+   - 保留现有 `themeObserver`(监听 `data-theme` 变化后重建主题)。
+
+4. **移除只兜半截的 CSS 覆盖(`styles.css`)**
+   - 删除 `.xterm-viewport{background:transparent}`、`.xterm-bg-0`→`panel-muted`、`.xterm-bg-257`→`panel-muted`、`.xterm-fg-257`→`foreground` 这四组 agent/shell 终端覆盖(它们只对索引 0/默认色生效,是问题的来源)。终端背景/前景改由 xterm 主题统一提供。
+
+## Risks / Trade-offs
+
+- **浅色应用模式下终端是"深色孤岛"**:这是刻意取舍。agent CLI 普遍是深色 TUI,深色画布是让其忠实且可读的唯一稳妥解法(等价于绝大多数 IDE 的内嵌终端做法),优先保证可读性。
+- **既有测试/截图**:需检查 `src/session-workspace/session-workspace-components.test.tsx` 与 `tests/` 下工作区/文档截图用例是否断言了终端浅色外观,必要时同步更新期望。
+- **token 偏差**:终端调色板用 hex 而非 HSL 三元组,与项目其它 token 约定不同——已在 Decisions 记录理由,范围仅限终端。
+- **视觉一致性**:改动后需在 `futuristic`/`minimal` × 浅/深 下目视确认终端可读、无残留浅色缝隙、无低对比文字(对照 project.md「Frontend Visual Design」的 Visual QA 要求)。

--- a/openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/proposal.md
+++ b/openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+内嵌终端(工作区 agent 终端与 Shell 终端)在运行 Codex CLI 等全屏 TUI 时出现黑底色块且其上文字低对比、无法阅读。根因是终端被强行做成"透明背景 + 只中和两类 ANSI 背景色"的浅色外观:xterm.js 以 `allowTransparency` 透明渲染,CSS 只把 `xterm-bg-0`(ANSI 黑)与 `xterm-bg-257`(默认背景)改成浅色,而 Codex 用 256 色 / 24 位 truecolor 背景绘制的输入框、选中行、状态栏未被覆盖(truecolor 走行内样式,CSS 类根本无法拦截),于是按原始深色渲染成黑块,其上为深色终端准备的文字失去对比度。
+
+## What Changes
+
+- 内嵌终端(agent 终端 + Shell 终端)改为渲染在一块**自洽、不透明的深色终端画布**上,ANSI 前景/背景色按标准终端方式原生渲染,不再依赖"透明 + 逐色 CSS 兜底"。
+- 在 `src/styles.css` 新增一组**语义化终端调色板 token**(完整 16 色 ANSI 前景/亮色、不透明终端背景、光标、选区前景/背景),供两个注册视觉样式复用,避免在组件里硬编码调色板。
+- `createTerminalTheme()` 由这些 token 生成**完整**的 xterm 主题(不透明背景 + 16 色全集),取代当前只映射 `black`/`brightBlack` 两色、背景透明的残缺主题。
+- 移除只兜半截的 CSS 覆盖(`.xterm-bg-0`、`.xterm-bg-257`、`.xterm-fg-257` 改色与 `.xterm-viewport` 透明),终端容器背景由浅色面板改为终端画布背景 token,消除深色 TUI 块与浅色面板之间的割裂。
+- 该改动同时惠及后续接入的其他全屏 TUI(Claude Code、Gemini CLI 等),不需要为每个 CLI 再逐色追加兜底。
+
+## Capabilities
+
+### New Capabilities
+
+（无）
+
+### Modified Capabilities
+
+- `session-workspace-tabs`: 在"主题感知的会话标签"能力下补充要求——内嵌终端(工作区 agent 终端与 Shell 终端)必须在自洽的不透明终端画布上以完整 ANSI 调色板渲染 agent/TUI 输出,使全屏 TUI 绘制的背景色块及其文字在两个注册视觉样式下都保持可读,不得残留未中和的深色块或低对比文字。
+
+## Impact
+
+- 影响运行时:桌面端与 Web 端均受影响(改动集中在前端渲染层)。
+- 受影响代码:
+  - `src/session-workspace/terminal-theme.ts`(`createTerminalTheme` 生成完整不透明主题)
+  - `src/styles.css`(新增终端调色板 token;移除/替换 `.xterm-bg-0`/`.xterm-bg-257`/`.xterm-fg-257`/`.xterm-viewport` 覆盖;终端容器背景)
+  - `src/session-workspace/agent-terminal-tab.tsx` 与 `src/session-workspace/shell-tab.tsx`(终端宿主容器背景类、`allowTransparency` 取值)
+- 不改动:前端 service 边界、Tauri 命令、适配器契约、SQLite;不涉及前后端隔离或 runtime adapter 边界变化。
+- 无破坏性变更;不新增依赖。

--- a/openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/specs/session-workspace-tabs/spec.md
+++ b/openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/specs/session-workspace-tabs/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Readable embedded terminal rendering for agent and shell TUIs
+
+The embedded terminals (the workspace agent terminal and the Shell terminal) SHALL render agent and full-screen TUI output on a self-consistent, opaque terminal canvas using a complete ANSI color palette, so that regions a TUI paints with background fills and the text on those regions remain readable in every registered visual style. The terminal SHALL NOT rely on per-color CSS neutralization of individual ANSI background classes to stay legible, and SHALL NOT leave background-filled TUI regions rendered as unreadable dark blocks or low-contrast text.
+
+#### Scenario: Full-screen TUI paints background-filled regions
+
+- **WHEN** an agent CLI that is a full-screen TUI (for example Codex CLI) paints its input composer, selected rows, or status bar using ANSI background colors
+- **THEN** those regions SHALL render on the opaque terminal canvas with foreground text that keeps readable contrast against the region background, with no unreadable dark blocks and no low-contrast text
+
+#### Scenario: Truecolor and 256-color backgrounds
+
+- **WHEN** TUI output uses 256-color or 24-bit truecolor background sequences that no per-class CSS override can target
+- **THEN** the terminal SHALL still present that output legibly by rendering it natively against the self-consistent opaque terminal background, without depending on CSS overrides of specific ANSI background classes
+
+#### Scenario: Token-driven terminal palette across registered styles
+
+- **WHEN** the `futuristic` or `minimal` visual style is active
+- **THEN** the terminal canvas background, foreground, cursor, selection, and the full 16-color ANSI palette SHALL be provided by semantic terminal tokens rather than a component-hard-coded palette, and SHALL keep agent and TUI output readable in that style
+
+#### Scenario: Consistent rendering for agent terminal and shell terminal
+
+- **WHEN** the same rendering path is used by both the workspace agent terminal and the Shell terminal
+- **THEN** both SHALL use the shared opaque terminal canvas and complete ANSI palette so that TUI output stays readable in either tab

--- a/openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/tasks.md
+++ b/openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/tasks.md
@@ -1,0 +1,29 @@
+## 1. 终端调色板 token
+
+- [x] 1.1 在 `src/styles.css` 新增语义化终端 token:`--terminal-background`、`--terminal-foreground`、`--terminal-cursor`、`--terminal-selection`、`--terminal-selection-foreground`,以及完整 16 色 `--terminal-ansi-{black,red,green,yellow,blue,magenta,cyan,white}` 与 `--terminal-ansi-bright-{black,red,green,yellow,blue,magenta,cyan,white}`,以固定深色 hex 值定义在基础 `:root` 层,供 `futuristic`/`minimal` 共享
+- [x] 1.2 确认 token 命名与放置不与既有语义 token 冲突,且两个视觉样式均能继承(基础 `:root` 定义,`futuristic`/`minimal` 未覆盖即继承)
+
+## 2. 完整不透明 xterm 主题
+
+- [x] 2.1 在 `src/session-workspace/terminal-theme.ts` 新增 `terminalColor(name, fallback)`,读取终端 token 的原始计算值(不包 `hsl()`),每个 token 带安全深色 fallback
+- [x] 2.2 重写 `createTerminalTheme()` 返回完整 xterm `ITheme`:不透明 `background`、`foreground`、`cursor`、`cursorAccent`、`selectionBackground`、`selectionForeground`,以及 `black/red/green/yellow/blue/magenta/cyan/white` + 8 个 `bright*`,全部取自终端 token
+
+## 3. 终端组件改为不透明画布
+
+- [x] 3.1 `src/session-workspace/agent-terminal-tab.tsx`:`new XtermTerminal({...})` 的 `allowTransparency` 改为 `false`;终端宿主 `div.ucd-agent-terminal` 去掉内联 `bg-[hsl(var(--panel-muted))]`
+- [x] 3.2 `src/session-workspace/shell-tab.tsx`:同样将 `allowTransparency` 改为 `false`;终端宿主 `div.ucd-shell-terminal` 去掉内联 `bg-[hsl(var(--panel-muted))]`
+- [x] 3.3 保留两个组件现有的 `themeObserver`(`data-theme` 变化后重建主题)行为不变
+
+## 4. 收敛 CSS 覆盖
+
+- [x] 4.1 在 `src/styles.css` 为 `.ucd-agent-terminal, .ucd-shell-terminal` 设置 `background: var(--terminal-background)`,使 padding 边框与终端底色一致
+- [x] 4.2 删除针对 agent/shell 终端的半截覆盖:`.xterm-viewport{background:transparent}`、`.xterm-bg-0`→`panel-muted`、`.xterm-bg-257`→`panel-muted`、`.xterm-fg-257`→`foreground`(改由 xterm 主题统一提供背景/前景)
+
+## 5. 测试与验证
+
+- [x] 5.1 更新 `src/session-workspace/session-workspace-components.test.tsx` 的两条"终端可读性"用例,由断言旧的透明+逐色覆盖契约改为断言不透明画布 + 完整调色板 token
+- [x] 5.2 `npm run lint` 通过(0 error;既有 warning 均在 `.claude/worktrees/` 副本,非本次文件)
+- [x] 5.3 真实测试套件通过:排除 `.claude/worktrees/` 后 `vitest run` 92 文件 / 301 测试全绿。注:裸 `npm run test` 因未跟踪的 `.claude/worktrees/main-dev/`(嵌套 worktree 的 node_modules 第三方测试 + e2e specs 被误扫)exit 1,属既有环境噪音,与本改动无关
+- [x] 5.4 `npm run build` 通过
+- [x] 5.5 目视 QA:operator 在桌面端实机运行 Codex 确认已修复(终端为深色画布、文字可读、无黑底盖字)
+- [x] 5.6 `openspec validate "fix-embedded-terminal-tui-contrast" --strict` 通过

--- a/openspec/changes/archive/README.md
+++ b/openspec/changes/archive/README.md
@@ -76,5 +76,6 @@ Online archive location: `openspec/changes/archive/`
 | 2026-07-24 | enhance-prompt-library-advanced-features | chat-experience, frontend-runtime-architecture, native-runtime-architecture, prompt-hook-management, settings-prompt-hooks-ui | `openspec/changes/archive/2026-07-24-enhance-prompt-library-advanced-features/` |
 | 2026-07-24 | establish-multilingual-documentation | multilingual-readme, native-developer-documentation, user-guide-documentation | `openspec/changes/archive/2026-07-24-establish-multilingual-documentation/` |
 | 2026-07-24 | optimize-rust-build-and-release | continuous-integration, native-app-packaging, native-build-optimization | `openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/` |
+| 2026-07-26 | fix-embedded-terminal-tui-contrast | session-workspace-tabs | `openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/` |
 
 Cold-archive destinations are recorded in `openspec/archive-cold-migrations.md`.

--- a/openspec/changes/archive/archive-index.json
+++ b/openspec/changes/archive/archive-index.json
@@ -1069,6 +1069,19 @@
                                               "native-app-packaging",
                                               "native-build-optimization"
                                           ]
+                     },
+                     {
+                         "archivedOn":  "2026-07-26",
+                         "changeName":  "fix-embedded-terminal-tui-contrast",
+                         "path":  "openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/",
+                         "artifacts":  [
+                                           "proposal",
+                                           "design",
+                                           "tasks"
+                                       ],
+                         "capabilities":  [
+                                              "session-workspace-tabs"
+                                          ]
                      }
                  ]
 }

--- a/openspec/specs/session-workspace-tabs/spec.md
+++ b/openspec/specs/session-workspace-tabs/spec.md
@@ -220,3 +220,27 @@ The session workspace SHALL dynamically load non-default tab modules on first ac
 - **THEN** only that tab panel SHALL show a localized retry action
 - **AND** other mounted tabs SHALL remain operable
 
+### Requirement: Readable embedded terminal rendering for agent and shell TUIs
+
+The embedded terminals (the workspace agent terminal and the Shell terminal) SHALL render agent and full-screen TUI output on a self-consistent, opaque terminal canvas using a complete ANSI color palette, so that regions a TUI paints with background fills and the text on those regions remain readable in every registered visual style. The terminal SHALL NOT rely on per-color CSS neutralization of individual ANSI background classes to stay legible, and SHALL NOT leave background-filled TUI regions rendered as unreadable dark blocks or low-contrast text.
+
+#### Scenario: Full-screen TUI paints background-filled regions
+
+- **WHEN** an agent CLI that is a full-screen TUI (for example Codex CLI) paints its input composer, selected rows, or status bar using ANSI background colors
+- **THEN** those regions SHALL render on the opaque terminal canvas with foreground text that keeps readable contrast against the region background, with no unreadable dark blocks and no low-contrast text
+
+#### Scenario: Truecolor and 256-color backgrounds
+
+- **WHEN** TUI output uses 256-color or 24-bit truecolor background sequences that no per-class CSS override can target
+- **THEN** the terminal SHALL still present that output legibly by rendering it natively against the self-consistent opaque terminal background, without depending on CSS overrides of specific ANSI background classes
+
+#### Scenario: Token-driven terminal palette across registered styles
+
+- **WHEN** the `futuristic` or `minimal` visual style is active
+- **THEN** the terminal canvas background, foreground, cursor, selection, and the full 16-color ANSI palette SHALL be provided by semantic terminal tokens rather than a component-hard-coded palette, and SHALL keep agent and TUI output readable in that style
+
+#### Scenario: Consistent rendering for agent terminal and shell terminal
+
+- **WHEN** the same rendering path is used by both the workspace agent terminal and the Shell terminal
+- **THEN** both SHALL use the shared opaque terminal canvas and complete ANSI palette so that TUI output stays readable in either tab
+

--- a/src/session-workspace/agent-terminal-tab.tsx
+++ b/src/session-workspace/agent-terminal-tab.tsx
@@ -59,7 +59,7 @@ export function AgentTerminalTab({ active, session, sessionActivationKey }: { ac
     let disposed = false;
     let unsubscribe: (() => void) | null = null;
     const terminal = new XtermTerminal({
-      allowTransparency: true,
+      allowTransparency: false,
       convertEol: true,
       cursorBlink: true,
       fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
@@ -214,7 +214,7 @@ export function AgentTerminalTab({ active, session, sessionActivationKey }: { ac
         </div>
       </div>
       {error ? <div className="p-2"><WorkspaceState kind="error" message={t(error)} /></div> : null}
-      <div aria-label={t("sessionTabs.agentTerminal.terminal")} className="ucd-agent-terminal min-h-0 flex-1 bg-[hsl(var(--panel-muted))] p-2" ref={hostRef} />
+      <div aria-label={t("sessionTabs.agentTerminal.terminal")} className="ucd-agent-terminal min-h-0 flex-1 p-2" ref={hostRef} />
       <form className="shrink-0 border-t border-border bg-background/80 p-2" onSubmit={(event) => { event.preventDefault(); submitCommand(); }}>
         <div className="rounded-lg border border-border bg-[hsl(var(--panel-muted))] p-2 shadow-sm focus-within:border-primary">
           <textarea

--- a/src/session-workspace/session-workspace-components.test.tsx
+++ b/src/session-workspace/session-workspace-components.test.tsx
@@ -61,27 +61,32 @@ describe("session workspace components", () => {
     expect(managedCliAgentIds).toEqual(["claude-code", "codex-cli", "gemini-cli", "opencode"]);
     expect(sessionTabsSource).toContain('<AgentTerminalTab active={activeTab === "chat"}');
     expect(source).not.toContain("bg-zinc-950");
-    expect(source).toContain("allowTransparency: true");
+    // Full-screen TUIs paint 256-color/truecolor backgrounds that no per-class CSS
+    // override can catch, so the terminal renders on an opaque dark canvas with a
+    // complete ANSI palette instead of a transparent surface patched per ANSI class.
+    expect(source).toContain("allowTransparency: false");
     expect(themeSource).toContain("selectionForeground");
-    expect(themeSource).toContain('background: "rgba(0, 0, 0, 0)"');
-    expect(themeSource).toContain("black: foreground");
-    expect(styles).toContain(".ucd-agent-terminal .xterm-viewport");
-    expect(styles).toContain(".ucd-agent-terminal .xterm-bg-0");
-    expect(styles).toContain(".ucd-agent-terminal .xterm-bg-257");
-    expect(styles).toContain(".ucd-agent-terminal .xterm-fg-257");
+    expect(themeSource).toContain("--terminal-background");
+    expect(themeSource).toContain("brightWhite");
+    expect(themeSource).not.toContain("rgba(0, 0, 0, 0)");
+    expect(styles).toContain("--terminal-background");
+    expect(styles).toContain("--terminal-ansi-blue");
+    expect(styles).toContain("background: var(--terminal-background)");
+    expect(styles).not.toContain(".xterm-bg-0");
+    expect(styles).not.toContain(".xterm-fg-257");
   });
 
   it("keeps the ordinary shell readable for ANSI inverse output", () => {
     const source = readFileSync(new URL("./shell-tab.tsx", import.meta.url), "utf8");
     const styles = readFileSync(new URL("../styles.css", import.meta.url), "utf8");
 
-    expect(source).toContain("allowTransparency: true");
+    expect(source).toContain("allowTransparency: false");
     expect(source).toContain("createTerminalTheme()");
     expect(source).toContain("ucd-shell-terminal");
-    expect(styles).toContain(".ucd-shell-terminal .xterm-viewport");
-    expect(styles).toContain(".ucd-shell-terminal .xterm-bg-0");
-    expect(styles).toContain(".ucd-shell-terminal .xterm-bg-257");
-    expect(styles).toContain(".ucd-shell-terminal .xterm-fg-257");
+    // Inverse video swaps theme fg/bg; both come from the opaque terminal palette.
+    expect(styles).toContain("background: var(--terminal-background)");
+    expect(styles).not.toContain(".xterm-viewport");
+    expect(styles).not.toContain(".xterm-bg-257");
   });
 
   it("reconnects stopped agent terminals only after an explicit session activation", () => {

--- a/src/session-workspace/shell-tab.tsx
+++ b/src/session-workspace/shell-tab.tsx
@@ -28,7 +28,7 @@ export function ShellTab({ active, sessionId }: { active: boolean; sessionId: st
     let disposed = false;
     let unsubscribe: (() => void) | null = null;
     const terminal = new XtermTerminal({
-      allowTransparency: true,
+      allowTransparency: false,
       convertEol: true,
       cursorBlink: true,
       fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
@@ -103,7 +103,7 @@ export function ShellTab({ active, sessionId }: { active: boolean; sessionId: st
         </div>
       </div>
       {error ? <div className="p-2"><WorkspaceState kind="error" message={t(error)} /></div> : null}
-      <div aria-label={t("sessionTabs.shell.terminal")} className="ucd-shell-terminal min-h-0 flex-1 bg-[hsl(var(--panel-muted))] p-2" ref={hostRef} />
+      <div aria-label={t("sessionTabs.shell.terminal")} className="ucd-shell-terminal min-h-0 flex-1 p-2" ref={hostRef} />
     </div>
   );
 }

--- a/src/session-workspace/terminal-theme.ts
+++ b/src/session-workspace/terminal-theme.ts
@@ -1,19 +1,37 @@
-function semanticColor(name: string, fallback: string) {
+// Terminal palette tokens are full color values (hex), so read the raw computed
+// value rather than wrapping it in hsl() like the app's semantic tokens.
+function terminalColor(name: string, fallback: string) {
   const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-  return value ? `hsl(${value})` : fallback;
+  return value || fallback;
 }
 
+// Agent CLIs are dark-themed full-screen TUIs that paint background-filled
+// regions with 256-color/truecolor codes, so the embedded terminal renders on
+// an opaque dark canvas with the complete 16-color ANSI palette instead of a
+// transparent surface patched per ANSI class.
 export function createTerminalTheme() {
-  const foreground = semanticColor("--foreground", "#111827");
-  const primary = semanticColor("--primary", "#0284c7");
-
   return {
-    background: "rgba(0, 0, 0, 0)",
-    foreground,
-    cursor: primary,
-    selectionBackground: primary,
-    selectionForeground: semanticColor("--primary-foreground", "#ffffff"),
-    black: foreground,
-    brightBlack: semanticColor("--muted-foreground", "#64748b"),
+    background: terminalColor("--terminal-background", "#0d1117"),
+    foreground: terminalColor("--terminal-foreground", "#c9d1d9"),
+    cursor: terminalColor("--terminal-cursor", "#58a6ff"),
+    cursorAccent: terminalColor("--terminal-background", "#0d1117"),
+    selectionBackground: terminalColor("--terminal-selection", "#26456a"),
+    selectionForeground: terminalColor("--terminal-selection-foreground", "#f0f6fc"),
+    black: terminalColor("--terminal-ansi-black", "#484f58"),
+    red: terminalColor("--terminal-ansi-red", "#ff7b72"),
+    green: terminalColor("--terminal-ansi-green", "#3fb950"),
+    yellow: terminalColor("--terminal-ansi-yellow", "#d29922"),
+    blue: terminalColor("--terminal-ansi-blue", "#58a6ff"),
+    magenta: terminalColor("--terminal-ansi-magenta", "#bc8cff"),
+    cyan: terminalColor("--terminal-ansi-cyan", "#39c5cf"),
+    white: terminalColor("--terminal-ansi-white", "#b1bac4"),
+    brightBlack: terminalColor("--terminal-ansi-bright-black", "#6e7681"),
+    brightRed: terminalColor("--terminal-ansi-bright-red", "#ffa198"),
+    brightGreen: terminalColor("--terminal-ansi-bright-green", "#56d364"),
+    brightYellow: terminalColor("--terminal-ansi-bright-yellow", "#e3b341"),
+    brightBlue: terminalColor("--terminal-ansi-bright-blue", "#79c0ff"),
+    brightMagenta: terminalColor("--terminal-ansi-bright-magenta", "#d2a8ff"),
+    brightCyan: terminalColor("--terminal-ansi-bright-cyan", "#56d4dd"),
+    brightWhite: terminalColor("--terminal-ansi-bright-white", "#f0f6fc"),
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -38,6 +38,33 @@
   --agent-claude: 35 92% 52%;
   --agent-opencode: 154 64% 40%;
   --agent-gemini: 262 83% 62%;
+
+  /* Embedded terminals render agent/TUI ANSI output as their own opaque dark
+     surface (full-screen TUIs are dark-themed and paint 256/truecolor
+     backgrounds), so the palette is a fixed dark set shared by every visual
+     style. Terminal colors use hex — the terminal-domain convention — rather
+     than the HSL triplets used elsewhere. */
+  --terminal-background: #0d1117;
+  --terminal-foreground: #c9d1d9;
+  --terminal-cursor: #58a6ff;
+  --terminal-selection: #26456a;
+  --terminal-selection-foreground: #f0f6fc;
+  --terminal-ansi-black: #484f58;
+  --terminal-ansi-red: #ff7b72;
+  --terminal-ansi-green: #3fb950;
+  --terminal-ansi-yellow: #d29922;
+  --terminal-ansi-blue: #58a6ff;
+  --terminal-ansi-magenta: #bc8cff;
+  --terminal-ansi-cyan: #39c5cf;
+  --terminal-ansi-white: #b1bac4;
+  --terminal-ansi-bright-black: #6e7681;
+  --terminal-ansi-bright-red: #ffa198;
+  --terminal-ansi-bright-green: #56d364;
+  --terminal-ansi-bright-yellow: #e3b341;
+  --terminal-ansi-bright-blue: #79c0ff;
+  --terminal-ansi-bright-magenta: #d2a8ff;
+  --terminal-ansi-bright-cyan: #56d4dd;
+  --terminal-ansi-bright-white: #f0f6fc;
 }
 
 :root[data-theme="futuristic"] {
@@ -307,24 +334,13 @@ body.floating-assistant-surface {
   -webkit-text-fill-color: hsl(var(--foreground));
 }
 
-.ucd-agent-terminal .xterm-viewport,
-.ucd-shell-terminal .xterm-viewport {
-  background-color: transparent !important;
-}
-
-.ucd-agent-terminal .xterm-bg-0,
-.ucd-shell-terminal .xterm-bg-0 {
-  background-color: hsl(var(--panel-muted)) !important;
-}
-
-.ucd-agent-terminal .xterm-bg-257,
-.ucd-shell-terminal .xterm-bg-257 {
-  background-color: hsl(var(--panel-muted)) !important;
-}
-
-.ucd-agent-terminal .xterm-fg-257,
-.ucd-shell-terminal .xterm-fg-257 {
-  color: hsl(var(--foreground)) !important;
+/* Agent/TUI output owns an opaque terminal canvas; xterm paints ANSI colors
+   natively from the terminal palette instead of relying on per-class overrides
+   (which cannot reach 256-color/truecolor backgrounds emitted by full-screen
+   TUIs like Codex). */
+.ucd-agent-terminal,
+.ucd-shell-terminal {
+  background: var(--terminal-background);
 }
 
 .ucd-status-success {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,9 @@ export default defineConfig({
       "src-tauri/**",
       "tests/docs/**",
       "tests/e2e/**",
+      // Nested git worktrees under .claude ship their own node_modules and e2e
+      // specs; keep the test runner from descending into those copies.
+      "**/.claude/**",
     ],
     setupFiles: ["./src/test/setup.ts"],
     coverage: {


### PR DESCRIPTION
## 问题

工作区 agent 终端与 Shell 终端在运行 Codex CLI 等全屏 TUI 时出现黑底色块且其上文字低对比、无法阅读。

## 根因

内嵌终端被做成「透明背景 + 只中和两类 ANSI 背景色」的浅色外观:xterm.js 以 `allowTransparency` 透明渲染,CSS 只把 `xterm-bg-0`(ANSI 黑)与 `xterm-bg-257`(默认背景)改浅。Codex 用 256 色 / 24 位 truecolor 背景绘制的输入框、选中行、状态栏既非索引 0 也非默认背景,不被覆盖命中;truecolor 更走 xterm DOM 渲染器的行内样式,CSS 类根本拦不住。于是这些区域按原始深色渲染成黑块,其上为深色终端配的文字失去对比度。

## 改动

- 内嵌终端(agent + shell)改为渲染在一块**自洽、不透明的深色终端画布**上,ANSI 前景/背景色原生渲染,不再依赖逐色 CSS 兜底。
- `src/styles.css` 新增一组语义化终端 token(完整 16 色 ANSI + 深色背景 + 选区,GitHub Dark 系),供 `futuristic`/`minimal` 共享;终端宿主设 `background: var(--terminal-background)`;删除 `.xterm-viewport/bg-0/bg-257/fg-257` 半截覆盖。
- `createTerminalTheme()` 重写为**完整、不透明**的 xterm 主题,读终端 token 原始值。
- `agent-terminal-tab.tsx` / `shell-tab.tsx`:`allowTransparency: false`,宿主去掉浅色内联背景。
- `vite.config.ts`:`test.exclude` 加 `**/.claude/**`,阻止 vitest 扫进嵌套 worktree 副本(修掉裸 `npm run test` 被污染 exit 1 的问题)。

规范落在 `session-workspace-tabs`(新增「内嵌终端可读渲染」需求),OpenSpec change 已随本 PR 归档。

## 验证

- `npm run lint` → 0 error
- `npm run test` → 92 文件 / 301 测试全绿(exit 0)
- `npm run build` → 通过
- `openspec validate --strict` → 通过
- 实机目视:桌面端运行 Codex 确认终端为深色画布、文字可读、无黑底盖字(`futuristic`/`minimal` 均正常)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
