### PR TITLE
fix: persist and resume exact CLI terminal sessions

### DIFF
--- a/openspec/changes/fix-cli-terminal-session-resume-capture/.openspec.yaml
+++ b/openspec/changes/fix-cli-terminal-session-resume-capture/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/fix-cli-terminal-session-resume-capture/design.md
+++ b/openspec/changes/fix-cli-terminal-session-resume-capture/design.md
@@ -1,0 +1,83 @@
+## Context
+
+VaneHub already stores the selected stable Agent id and has a nullable `sessions.runtime_session_id` column. The native Agent Terminal also knows how to build provider-specific resume arguments. The missing link is initial interactive TUI startup: the current runtime looks for structured session-id events in PTY output, while normal Claude Code, Codex CLI, Gemini CLI, and OpenCode TUIs emit ANSI-rendered screens rather than JSON lines.
+
+Provider capabilities differ:
+
+- Claude Code and Gemini CLI accept a caller-supplied UUID for a fresh session and resume that UUID later.
+- Codex CLI allocates its own thread id and writes it in the first `session_meta` record of a new rollout under the Codex session store.
+- OpenCode allocates its own `ses_...` id and writes a session row containing the working directory and creation time in its data-store SQLite database.
+
+The React service interface, Tauri adapter, and Web/mock adapter already expose sufficient session metadata. This change is native-only except for preserving existing Web/mock parity.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist the exact provider session id belonging to each newly opened CLI-backed VaneHub session.
+- Resume that exact provider session after the terminal or desktop process restarts.
+- Avoid associating a VaneHub session with another concurrently created provider session.
+- Keep provider argument and provider-store knowledge in the native Agent runtime infrastructure.
+- Preserve unified redacted diagnostics and the existing frontend service boundary.
+
+**Non-Goals:**
+
+- Persisting or reconstructing the terminal transcript as VaneHub chat messages.
+- Importing provider conversation contents into VaneHub-owned storage.
+- Recovering historical VaneHub sessions that already have a NULL runtime session id by guessing a "most recent" provider conversation.
+- Changing the CLI selection UI, session schema, Tauri command DTOs, or Web/mock service interface.
+
+## Decisions
+
+### 1. Use provider-aware acquisition, preferring caller-assigned ids
+
+For a fresh Claude Code or Gemini CLI process, `build_interactive_invocation` generates a UUID and returns it with the invocation specification. It adds the provider's fresh-session argument and the Agent Terminal returns that id only after the PTY child has spawned successfully. The application service then persists it through the existing session gateway before reporting the session as running.
+
+For resume, the builder never generates a replacement id. It emits only the provider-specific resume arguments for the stored id.
+
+Alternative considered: parse all TUI output. Rejected because ANSI screen updates are not a stable provider API and do not consistently expose a session id.
+
+### 2. Discover provider-allocated ids from a launch baseline
+
+For a fresh Codex CLI or OpenCode terminal, native infrastructure captures a provider-store baseline before spawning the process:
+
+- Codex baseline: known rollout paths/ids in the provider session directory. New rollout candidates are validated by parsing only their first `session_meta` JSON line and comparing the recorded `cwd` with the terminal working directory.
+- OpenCode baseline: known ids from the provider's SQLite session table. New candidates are filtered by creation time and normalized working directory.
+
+During PTY monitoring, discovery is retried at a bounded cadence after terminal activity. A single new matching id is persisted and published through the existing runtime-session-id event path. No provider conversation content is copied.
+
+Alternative considered: invoke `resume --last` or `--continue`. Rejected because "latest" is global/provider-directory state and can restore a different VaneHub session.
+
+Alternative considered: query the provider CLI through a second long-running process. Rejected because it adds startup latency and shell/shim complexity. Read-only access to provider-owned metadata is smaller and deterministic.
+
+### 3. Fail closed on ambiguity or unavailable metadata
+
+Discovery persists an id only when exactly one new candidate is absent from the launch baseline and its provider metadata matches the terminal working directory. Zero candidates remain pending. Multiple candidates, malformed metadata, or an unavailable provider store produce redacted diagnostics and do not update `runtime_session_id`.
+
+The runtime keeps the structured PTY session-id parser as a valid additional source. Whichever exact source persists first ends discovery; later empty or unrelated values do not replace the association.
+
+Alternative considered: choose the newest candidate. Rejected because timestamps do not prove ownership when multiple CLI sessions start together.
+
+### 4. Keep persistence and runtime boundaries unchanged
+
+The Agent Terminal infrastructure discovers or assigns the id, while the Agent runtime application persists it through `AgentSessionGateway`. SQLite ownership stays in the sessions context. React components continue to call `openAgentTerminal` through `agent-service.ts`; Tauri `invoke()` remains in `tauri-agent-client.ts`. The Web/mock adapter retains its deterministic `web-runtime-<session-id>` behavior and performs no provider-store access.
+
+No new logging file is introduced. Capture success, ambiguity, and read failures use the existing unified Agent terminal logging port with session and stable Agent correlation.
+
+## Risks / Trade-offs
+
+- [Provider storage formats or locations change] → Isolate readers behind provider-specific capture code, validate metadata before use, cover supported shapes with fixtures/tests, and fail closed with redacted diagnostics.
+- [Provider creates its durable session only after first user input] → Keep discovery active during terminal output rather than requiring the id to exist immediately at process spawn.
+- [Two external sessions start concurrently in the same working directory] → Require a unique candidate relative to the captured baseline; never select merely by newest timestamp.
+- [Assigned id is persisted but the provider later fails during initialization] → Persist only after successful child spawn; later provider failure remains visible through existing lifecycle and diagnostic handling.
+- [Provider session record is deleted before reopen] → Preserve the exact stored id and surface the provider's resume failure instead of silently starting unrelated history.
+
+## Migration Plan
+
+No schema migration is required. New sessions begin capturing ids after deployment. Existing rows with a valid `runtime_session_id` resume unchanged; existing NULL rows start fresh and acquire an id only when a new provider session can be correlated exactly.
+
+Rollback is code-only. Persisted ids remain compatible with the pre-change resume path.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-cli-terminal-session-resume-capture/proposal.md
+++ b/openspec/changes/fix-cli-terminal-session-resume-capture/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Interactive CLI-backed sessions persist the selected Agent id, but their provider `runtime_session_id` is usually never recorded because the embedded TUI does not emit the structured JSON events consumed by the current parser. After the process or desktop app restarts, reopening the VaneHub session therefore starts a new provider conversation instead of restoring that session's history.
+
+## What Changes
+
+- Capture an exact provider session id for every newly opened Claude Code, Codex CLI, Gemini CLI, and OpenCode terminal without relying only on structured PTY output.
+- Assign and persist a caller-supplied id at successful launch for providers that support it.
+- For providers that allocate their own id, correlate the newly created provider record with the launch baseline and working directory, persisting only a unique match.
+- Reopen a stopped CLI-backed VaneHub session with its persisted provider session id; never substitute a global "most recent session" when the exact id is missing.
+- Fail closed on ambiguous discovery and record a redacted diagnostic through unified logging instead of associating the wrong provider history.
+- Preserve the existing frontend Agent service boundary and Web/mock runtime-session-id behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-terminal-runtime`: Make creation-time runtime session id capture provider-aware and exact, and require reopen to use only the owning VaneHub session's persisted provider id.
+
+## Impact
+
+- Desktop runtime: provider invocation construction, Agent Terminal process startup/monitoring, provider session-store discovery, and existing session metadata persistence.
+- Web runtime: no contract change; deterministic mock runtime session ids remain supported.
+- Data: no SQLite migration; the existing `sessions.runtime_session_id` column remains authoritative.
+- Frontend/backend isolation: unchanged. React continues through `src/services/agent-service.ts`; provider-specific behavior remains native-owned behind the Agent runtime adapter.
+- Dependencies: no new frontend package or alternative package manager; native implementation reuses existing Rust dependencies and standard filesystem access.

--- a/openspec/changes/fix-cli-terminal-session-resume-capture/specs/agent-terminal-runtime/spec.md
+++ b/openspec/changes/fix-cli-terminal-session-resume-capture/specs/agent-terminal-runtime/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: Creation-time resume id capture
+The Agent Terminal runtime SHALL persist the exact provider resume id owned by a newly created CLI-backed VaneHub session as soon as the id can be assigned or correlated, without depending solely on structured PTY output.
+
+#### Scenario: Caller-assigned id is persisted after launch
+- **WHEN** a fresh Agent Terminal starts for a stable Agent whose CLI accepts a caller-supplied session id
+- **THEN** the desktop runtime SHALL generate a provider-valid id and pass it in the fresh-session invocation
+- **AND** it SHALL persist that id on the owning VaneHub session after the provider process spawns successfully
+
+#### Scenario: Provider-allocated id is correlated exactly
+- **WHEN** a fresh Agent Terminal starts for a stable Agent whose CLI allocates its own session id
+- **THEN** the desktop runtime SHALL capture a provider-store baseline before launch
+- **AND** it SHALL persist a newly created provider id only when it is absent from the baseline and its provider metadata uniquely matches the terminal working directory
+
+#### Scenario: Ambiguous provider records are not associated
+- **WHEN** provider session discovery finds more than one new candidate that could belong to the same VaneHub session
+- **THEN** the desktop runtime SHALL NOT persist any candidate as the session runtime session id
+- **AND** it SHALL record a redacted warning through unified logging
+
+#### Scenario: Start result includes resume id
+- **WHEN** an Agent Terminal start for a newly created session returns a runtime session id
+- **THEN** the desktop runtime SHALL persist that value on the owning session as the session runtime session id
+- **AND** subsequent session list and session detail reads SHALL expose the same value
+
+#### Scenario: Runtime event includes resume id
+- **WHEN** an Agent Terminal process emits an exact runtime session id event after startup
+- **THEN** the desktop runtime SHALL persist the latest non-empty value on the owning session
+- **AND** the frontend SHALL refresh service-backed session state without writing persistence directly
+
+#### Scenario: Web mock creation resume id
+- **WHEN** the Web/mock runtime creates and opens a CLI-backed mock session
+- **THEN** it SHALL assign or preserve deterministic mock runtime session id metadata through the Agent service contract
+
+### Requirement: Resume id based terminal restore
+The Agent Terminal runtime SHALL use the owning VaneHub session's persisted runtime session id as the provider resume id when opening a CLI terminal without a retained live process, and SHALL NOT substitute a provider-global or working-directory "most recent" session.
+
+#### Scenario: Reopen uses persisted resume id
+- **WHEN** a user selects a CLI-backed session whose prior process is closed and whose session record has a runtime session id
+- **THEN** the desktop runtime SHALL pass that exact id to the provider-specific resume invocation for the session's stable Agent id
+- **AND** the restored CLI process SHALL be associated with the same VaneHub session id
+
+#### Scenario: Retained process takes precedence
+- **WHEN** a session has both a retained live terminal process and a persisted runtime session id
+- **THEN** the desktop runtime SHALL attach to the retained process
+- **AND** it SHALL NOT spawn a provider resume invocation for the same session
+
+#### Scenario: Missing resume id starts fresh
+- **WHEN** a CLI-backed session has no retained live process and no persisted runtime session id
+- **THEN** the desktop runtime SHALL start a fresh provider CLI process for the session's stable Agent id
+- **AND** it SHALL NOT invoke a provider-global or working-directory "resume most recent" operation

--- a/openspec/changes/fix-cli-terminal-session-resume-capture/tasks.md
+++ b/openspec/changes/fix-cli-terminal-session-resume-capture/tasks.md
@@ -1,0 +1,24 @@
+## 1. Provider invocation identity
+
+- [x] 1.1 Extend interactive invocation specs to assign provider-valid ids for fresh Claude Code and Gemini CLI launches while preserving exact-id resume arguments for all stable Agents.
+- [x] 1.2 Add provider invocation tests covering fresh assignment, exact resume, empty-id handling, and stable Agent coverage.
+
+## 2. Provider-allocated session capture
+
+- [x] 2.1 Add a Codex rollout baseline/discovery reader that validates a unique new `session_meta` id against the terminal working directory.
+- [x] 2.2 Add an OpenCode SQLite baseline/discovery reader that validates a unique new session id against creation metadata and the normalized terminal working directory.
+- [x] 2.3 Add deterministic reader tests for unique, missing, malformed, wrong-directory, and ambiguous candidates.
+
+## 3. Agent Terminal integration
+
+- [x] 3.1 Integrate pre-launch capture preparation and post-spawn assigned-id persistence into the native Agent Terminal process path.
+- [x] 3.2 Retry provider-allocated discovery at a bounded cadence during terminal activity, publish the existing runtime-session-id event on success, and stop after an id is recorded.
+- [x] 3.3 Record capture ambiguity and provider-store failures through the unified redacted Agent terminal logging port without adding feature-local logs.
+- [x] 3.4 Add terminal/application tests proving assigned and discovered ids are persisted, retained, returned, and used by exact-id reopen.
+
+## 4. Compatibility and verification
+
+- [x] 4.1 Confirm the frontend Agent service, Tauri adapter, and Web/mock adapter require no contract changes and keep deterministic Web runtime ids covered by tests.
+- [x] 4.2 Run `npm run lint`, `npm run test`, and `npm run build`.
+- [x] 4.3 Run `cargo test`, `cargo check`, and `cargo clippy` for `src-tauri/Cargo.toml`.
+- [x] 4.4 Run `openspec validate fix-cli-terminal-session-resume-capture --strict` and `openspec validate --specs --strict`.

--- a/src-tauri/src/contexts/agent_runtime/application/terminal_service_tests.rs
+++ b/src-tauri/src/contexts/agent_runtime/application/terminal_service_tests.rs
@@ -494,6 +494,7 @@ fn open_terminal_starts_session_and_uses_interactive_profile() {
         .expect("open terminal");
 
     assert_eq!(opened.terminal_id, "terminal-1");
+    assert_eq!(opened.runtime_session_id.as_deref(), Some("runtime-1"));
     assert_eq!(
         *world.lifecycle.lock().expect("lifecycle"),
         vec![AgentLifecycle::Starting, AgentLifecycle::Running]

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/invocation.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/invocation.rs
@@ -20,6 +20,7 @@ pub(crate) struct ProviderInvocationSpec {
 pub(crate) struct ProviderInteractiveInvocationSpec {
     pub(crate) executable: String,
     pub(crate) args: Vec<String>,
+    pub(crate) assigned_runtime_session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -120,29 +121,49 @@ pub(crate) fn build_interactive_invocation(
     managed_args: &[String],
 ) -> Result<ProviderInteractiveInvocationSpec, ProviderInvocationError> {
     let mut args = Vec::new();
+    let existing_session_id = non_empty_session_id(runtime_session_id);
+    let mut assigned_runtime_session_id = None;
     match agent_id {
         "claude-code" => {
             args.extend_from_slice(managed_args);
-            push_resume_args(&mut args, runtime_session_id, "--resume");
+            if let Some(session_id) = existing_session_id {
+                push_session_arg(&mut args, "--resume", session_id);
+            } else {
+                let session_id = uuid::Uuid::new_v4().to_string();
+                push_session_arg(&mut args, "--session-id", &session_id);
+                assigned_runtime_session_id = Some(session_id);
+            }
         }
         "codex-cli" => {
             args.extend_from_slice(managed_args);
-            if let Some(session_id) = non_empty_session_id(runtime_session_id) {
+            if let Some(session_id) = existing_session_id {
                 args.extend(["resume".to_string(), session_id.to_string()]);
             }
         }
         "gemini-cli" => {
             args.extend_from_slice(managed_args);
-            push_resume_args(&mut args, runtime_session_id, "--resume");
+            if let Some(session_id) = existing_session_id {
+                push_session_arg(&mut args, "--resume", session_id);
+            } else {
+                let session_id = uuid::Uuid::new_v4().to_string();
+                push_session_arg(&mut args, "--session-id", &session_id);
+                assigned_runtime_session_id = Some(session_id);
+            }
         }
         "opencode" => {
             args.extend_from_slice(managed_args);
-            push_resume_args(&mut args, runtime_session_id, "--session");
+            if let Some(session_id) = existing_session_id {
+                push_session_arg(&mut args, "--session", session_id);
+            }
         }
         other => return Err(ProviderInvocationError::UnsupportedAgent(other.to_string())),
     };
 
-    Ok(ProviderInteractiveInvocationSpec { executable, args })
+    Ok(ProviderInteractiveInvocationSpec {
+        executable,
+        args,
+        assigned_runtime_session_id,
+    })
 }
 
 pub(crate) fn add_codex_output_capture_args(args: &mut Vec<String>, output_path: &str) {
@@ -277,6 +298,10 @@ fn non_empty_session_id(runtime_session_id: Option<&str>) -> Option<&str> {
 
 fn push_resume_args(args: &mut Vec<String>, runtime_session_id: Option<&str>, flag: &str) {
     if let Some(session_id) = non_empty_session_id(runtime_session_id) {
-        args.extend([flag.to_string(), session_id.to_string()]);
+        push_session_arg(args, flag, session_id);
     }
+}
+
+fn push_session_arg(args: &mut Vec<String>, flag: &str, session_id: &str) {
+    args.extend([flag.to_string(), session_id.to_string()]);
 }

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/mod.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/mod.rs
@@ -1,5 +1,6 @@
 mod invocation;
 mod output;
+mod session_capture;
 
 pub(crate) use invocation::{
     add_codex_output_capture_args, apply_configuration_overrides, build_interactive_invocation,
@@ -8,6 +9,11 @@ pub(crate) use invocation::{
 pub(crate) use output::{
     output_parser_for, ProviderOutputEvent, ProviderToolEvent, ProviderToolPhase,
 };
+pub(crate) use session_capture::{
+    prepare_provider_session_capture, ProviderSessionCapture, ProviderSessionDiscovery,
+};
 
+#[cfg(test)]
+mod session_capture_tests;
 #[cfg(test)]
 mod tests;

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/session_capture.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/session_capture.rs
@@ -1,0 +1,329 @@
+use rusqlite::{Connection, OpenFlags};
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::env;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProviderSessionDiscovery {
+    Pending,
+    Found(String),
+    Ambiguous(usize),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ProviderSessionCapture {
+    Codex(CodexSessionBaseline),
+    OpenCode(OpenCodeSessionBaseline),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ProviderSessionCaptureError {
+    message: String,
+}
+
+impl std::fmt::Display for ProviderSessionCaptureError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ProviderSessionCaptureError {}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CodexSessionBaseline {
+    session_root: PathBuf,
+    known_rollouts: HashSet<PathBuf>,
+    working_directory: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OpenCodeSessionBaseline {
+    database_path: PathBuf,
+    known_ids: HashSet<String>,
+    working_directory: PathBuf,
+    pub(super) started_at_ms: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexSessionEnvelope {
+    #[serde(rename = "type")]
+    event_type: String,
+    payload: CodexSessionMeta,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexSessionMeta {
+    id: Option<String>,
+    session_id: Option<String>,
+    cwd: Option<String>,
+}
+
+pub(crate) fn prepare_provider_session_capture(
+    agent_id: &str,
+    working_directory: PathBuf,
+) -> Result<Option<ProviderSessionCapture>, ProviderSessionCaptureError> {
+    match agent_id {
+        "codex-cli" => codex_session_root()
+            .map(|root| {
+                capture_codex_baseline(root, working_directory).map(ProviderSessionCapture::Codex)
+            })
+            .transpose(),
+        "opencode" => opencode_database_path()
+            .map(|path| {
+                capture_opencode_baseline(path, working_directory)
+                    .map(ProviderSessionCapture::OpenCode)
+            })
+            .transpose(),
+        _ => Ok(None),
+    }
+}
+
+impl ProviderSessionCapture {
+    pub(crate) fn discover(&self) -> Result<ProviderSessionDiscovery, ProviderSessionCaptureError> {
+        match self {
+            Self::Codex(baseline) => discover_codex_session(baseline),
+            Self::OpenCode(baseline) => discover_opencode_session(baseline),
+        }
+    }
+}
+
+pub(super) fn capture_codex_baseline(
+    session_root: PathBuf,
+    working_directory: PathBuf,
+) -> Result<CodexSessionBaseline, ProviderSessionCaptureError> {
+    Ok(CodexSessionBaseline {
+        known_rollouts: collect_rollout_paths(&session_root)?,
+        session_root,
+        working_directory,
+    })
+}
+
+pub(super) fn discover_codex_session(
+    baseline: &CodexSessionBaseline,
+) -> Result<ProviderSessionDiscovery, ProviderSessionCaptureError> {
+    let mut candidates = Vec::new();
+    let current_rollouts = collect_rollout_paths(&baseline.session_root)?;
+    for path in current_rollouts.difference(&baseline.known_rollouts) {
+        let Some(meta) = read_codex_session_meta(path)? else {
+            continue;
+        };
+        let Some(cwd) = meta.cwd.as_deref() else {
+            continue;
+        };
+        let Some(id) = meta
+            .id
+            .as_deref()
+            .or(meta.session_id.as_deref())
+            .filter(|id| !id.trim().is_empty())
+        else {
+            continue;
+        };
+        if paths_match(Path::new(cwd), &baseline.working_directory) {
+            candidates.push(id.to_string());
+        }
+    }
+    unique_candidate(candidates)
+}
+
+fn collect_rollout_paths(
+    session_root: &Path,
+) -> Result<HashSet<PathBuf>, ProviderSessionCaptureError> {
+    if !session_root.exists() {
+        return Ok(HashSet::new());
+    }
+    let mut paths = HashSet::new();
+    collect_rollout_paths_at_depth(session_root, 0, &mut paths)?;
+    Ok(paths)
+}
+
+fn collect_rollout_paths_at_depth(
+    directory: &Path,
+    depth: usize,
+    paths: &mut HashSet<PathBuf>,
+) -> Result<(), ProviderSessionCaptureError> {
+    if depth > 4 {
+        return Ok(());
+    }
+    let entries = fs::read_dir(directory).map_err(|error| capture_error("Codex", error))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| capture_error("Codex", error))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|error| capture_error("Codex", error))?;
+        if file_type.is_dir() {
+            collect_rollout_paths_at_depth(&entry.path(), depth + 1, paths)?;
+            continue;
+        }
+        let path = entry.path();
+        let is_rollout = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"));
+        if is_rollout {
+            paths.insert(path);
+        }
+    }
+    Ok(())
+}
+
+fn read_codex_session_meta(
+    path: &Path,
+) -> Result<Option<CodexSessionMeta>, ProviderSessionCaptureError> {
+    let file = File::open(path).map_err(|error| capture_error("Codex", error))?;
+    let mut lines = BufReader::new(file).lines();
+    let Some(line) = lines.next() else {
+        return Ok(None);
+    };
+    let line = line.map_err(|error| capture_error("Codex", error))?;
+    let Ok(envelope) = serde_json::from_str::<CodexSessionEnvelope>(&line) else {
+        return Ok(None);
+    };
+    if envelope.event_type != "session_meta" {
+        return Ok(None);
+    }
+    Ok(Some(envelope.payload))
+}
+
+pub(super) fn capture_opencode_baseline(
+    database_path: PathBuf,
+    working_directory: PathBuf,
+) -> Result<OpenCodeSessionBaseline, ProviderSessionCaptureError> {
+    Ok(OpenCodeSessionBaseline {
+        known_ids: read_opencode_sessions(&database_path)?
+            .into_iter()
+            .map(|session| session.id)
+            .collect(),
+        database_path,
+        working_directory,
+        started_at_ms: unix_time_ms(),
+    })
+}
+
+pub(super) fn discover_opencode_session(
+    baseline: &OpenCodeSessionBaseline,
+) -> Result<ProviderSessionDiscovery, ProviderSessionCaptureError> {
+    let candidates = read_opencode_sessions(&baseline.database_path)?
+        .into_iter()
+        .filter(|session| !baseline.known_ids.contains(&session.id))
+        .filter(|session| session.created_at_ms >= baseline.started_at_ms.saturating_sub(2_000))
+        .filter(|session| {
+            paths_match(
+                Path::new(&session.working_directory),
+                &baseline.working_directory,
+            )
+        })
+        .map(|session| session.id)
+        .collect();
+    unique_candidate(candidates)
+}
+
+struct OpenCodeSessionRecord {
+    id: String,
+    working_directory: String,
+    created_at_ms: i64,
+}
+
+fn read_opencode_sessions(
+    database_path: &Path,
+) -> Result<Vec<OpenCodeSessionRecord>, ProviderSessionCaptureError> {
+    if !database_path.exists() {
+        return Ok(Vec::new());
+    }
+    let connection = Connection::open_with_flags(
+        database_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|error| capture_error("OpenCode", error))?;
+    let mut statement = connection
+        .prepare("SELECT id, directory, time_created FROM session")
+        .map_err(|error| capture_error("OpenCode", error))?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(OpenCodeSessionRecord {
+                id: row.get(0)?,
+                working_directory: row.get(1)?,
+                created_at_ms: row.get(2)?,
+            })
+        })
+        .map_err(|error| capture_error("OpenCode", error))?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|error| capture_error("OpenCode", error))
+}
+
+fn unique_candidate(
+    mut candidates: Vec<String>,
+) -> Result<ProviderSessionDiscovery, ProviderSessionCaptureError> {
+    candidates.sort();
+    candidates.dedup();
+    Ok(match candidates.len() {
+        0 => ProviderSessionDiscovery::Pending,
+        1 => ProviderSessionDiscovery::Found(candidates.remove(0)),
+        count => ProviderSessionDiscovery::Ambiguous(count),
+    })
+}
+
+fn codex_session_root() -> Option<PathBuf> {
+    if let Some(root) = env::var_os("CODEX_HOME").filter(|value| !value.is_empty()) {
+        return Some(PathBuf::from(root).join("sessions"));
+    }
+    user_home().map(|home| home.join(".codex").join("sessions"))
+}
+
+fn opencode_database_path() -> Option<PathBuf> {
+    env::var_os("XDG_DATA_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .map(|root| root.join("opencode").join("opencode.db"))
+        .or_else(|| {
+            user_home().map(|home| {
+                home.join(".local")
+                    .join("share")
+                    .join("opencode")
+                    .join("opencode.db")
+            })
+        })
+}
+
+fn user_home() -> Option<PathBuf> {
+    env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .or_else(|| env::var_os("USERPROFILE").filter(|value| !value.is_empty()))
+        .map(PathBuf::from)
+}
+
+fn paths_match(left: &Path, right: &Path) -> bool {
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => normalized_path(left) == normalized_path(right),
+    }
+}
+
+fn normalized_path(path: &Path) -> String {
+    let value = path.to_string_lossy().replace('\\', "/");
+    let value = value
+        .strip_prefix("//?/")
+        .unwrap_or(&value)
+        .trim_end_matches('/');
+    if cfg!(windows) {
+        value.to_lowercase()
+    } else {
+        value.to_string()
+    }
+}
+
+fn unix_time_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or_default()
+}
+
+fn capture_error(provider: &str, error: impl std::fmt::Display) -> ProviderSessionCaptureError {
+    ProviderSessionCaptureError {
+        message: format!("{provider} session metadata could not be read: {error}"),
+    }
+}

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/session_capture_tests.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/session_capture_tests.rs
@@ -1,0 +1,181 @@
+use super::session_capture::{
+    capture_codex_baseline, capture_opencode_baseline, discover_codex_session,
+    discover_opencode_session, ProviderSessionDiscovery,
+};
+use rusqlite::Connection;
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn temp_directory(label: &str) -> PathBuf {
+    let path =
+        std::env::temp_dir().join(format!("vanehub-{label}-{}", uuid::Uuid::new_v4().simple()));
+    fs::create_dir_all(&path).expect("create temp directory");
+    path
+}
+
+fn write_codex_rollout(root: &Path, name: &str, first_line: &str) {
+    let directory = root.join("2026").join("07").join("26");
+    fs::create_dir_all(&directory).expect("create rollout directory");
+    fs::write(directory.join(name), format!("{first_line}\n")).expect("write rollout");
+}
+
+fn codex_meta(id: &str, cwd: &Path) -> String {
+    json!({
+        "type": "session_meta",
+        "payload": {
+            "id": id,
+            "cwd": cwd,
+            "source": "cli"
+        }
+    })
+    .to_string()
+}
+
+#[test]
+fn codex_capture_finds_only_a_unique_new_matching_rollout() {
+    let root = temp_directory("codex-capture");
+    let project = root.join("project");
+    fs::create_dir_all(&project).expect("create project");
+    write_codex_rollout(
+        &root,
+        "rollout-existing.jsonl",
+        &codex_meta("existing", &project),
+    );
+    let baseline = capture_codex_baseline(root.clone(), project.clone()).expect("capture baseline");
+
+    assert_eq!(
+        discover_codex_session(&baseline).expect("pending discovery"),
+        ProviderSessionDiscovery::Pending
+    );
+    write_codex_rollout(&root, "rollout-malformed.jsonl", "{not-json");
+    write_codex_rollout(
+        &root,
+        "rollout-wrong-cwd.jsonl",
+        &codex_meta("wrong", &root.join("other")),
+    );
+    write_codex_rollout(
+        &root,
+        "rollout-new.jsonl",
+        &codex_meta("runtime-codex", &project),
+    );
+
+    assert_eq!(
+        discover_codex_session(&baseline).expect("unique discovery"),
+        ProviderSessionDiscovery::Found("runtime-codex".to_string())
+    );
+    fs::remove_dir_all(root).expect("remove temp directory");
+}
+
+#[test]
+fn codex_capture_rejects_ambiguous_matching_rollouts() {
+    let root = temp_directory("codex-ambiguous");
+    let project = root.join("project");
+    fs::create_dir_all(&project).expect("create project");
+    let baseline = capture_codex_baseline(root.clone(), project.clone()).expect("capture baseline");
+    write_codex_rollout(
+        &root,
+        "rollout-one.jsonl",
+        &codex_meta("runtime-one", &project),
+    );
+    write_codex_rollout(
+        &root,
+        "rollout-two.jsonl",
+        &codex_meta("runtime-two", &project),
+    );
+
+    assert_eq!(
+        discover_codex_session(&baseline).expect("ambiguous discovery"),
+        ProviderSessionDiscovery::Ambiguous(2)
+    );
+    fs::remove_dir_all(root).expect("remove temp directory");
+}
+
+fn create_opencode_database(path: &Path) -> Connection {
+    let connection = Connection::open(path).expect("open sqlite database");
+    connection
+        .execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL,
+                time_created INTEGER NOT NULL
+            );",
+        )
+        .expect("create session table");
+    connection
+}
+
+fn insert_opencode_session(
+    connection: &Connection,
+    id: &str,
+    directory: &Path,
+    created_at_ms: i64,
+) {
+    connection
+        .execute(
+            "INSERT INTO session (id, directory, time_created) VALUES (?1, ?2, ?3)",
+            rusqlite::params![id, directory.to_string_lossy(), created_at_ms],
+        )
+        .expect("insert session");
+}
+
+#[test]
+fn opencode_capture_finds_only_a_unique_new_matching_row() {
+    let root = temp_directory("opencode-capture");
+    let project = root.join("project");
+    fs::create_dir_all(&project).expect("create project");
+    let database_path = root.join("opencode.db");
+    let connection = create_opencode_database(&database_path);
+    insert_opencode_session(&connection, "ses_existing", &project, 1);
+    let baseline =
+        capture_opencode_baseline(database_path, project.clone()).expect("capture baseline");
+
+    assert_eq!(
+        discover_opencode_session(&baseline).expect("pending discovery"),
+        ProviderSessionDiscovery::Pending
+    );
+    insert_opencode_session(
+        &connection,
+        "ses_wrong",
+        &root.join("other"),
+        baseline.started_at_ms,
+    );
+    insert_opencode_session(&connection, "ses_new", &project, baseline.started_at_ms);
+
+    assert_eq!(
+        discover_opencode_session(&baseline).expect("unique discovery"),
+        ProviderSessionDiscovery::Found("ses_new".to_string())
+    );
+    drop(connection);
+    fs::remove_dir_all(root).expect("remove temp directory");
+}
+
+#[test]
+fn opencode_capture_rejects_stale_and_ambiguous_rows() {
+    let root = temp_directory("opencode-ambiguous");
+    let project = root.join("project");
+    fs::create_dir_all(&project).expect("create project");
+    let database_path = root.join("opencode.db");
+    let connection = create_opencode_database(&database_path);
+    let baseline =
+        capture_opencode_baseline(database_path, project.clone()).expect("capture baseline");
+    insert_opencode_session(
+        &connection,
+        "ses_stale",
+        &project,
+        baseline.started_at_ms - 10_000,
+    );
+    assert_eq!(
+        discover_opencode_session(&baseline).expect("stale discovery"),
+        ProviderSessionDiscovery::Pending
+    );
+    insert_opencode_session(&connection, "ses_one", &project, baseline.started_at_ms);
+    insert_opencode_session(&connection, "ses_two", &project, baseline.started_at_ms);
+
+    assert_eq!(
+        discover_opencode_session(&baseline).expect("ambiguous discovery"),
+        ProviderSessionDiscovery::Ambiguous(2)
+    );
+    drop(connection);
+    fs::remove_dir_all(root).expect("remove temp directory");
+}

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/tests.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/tests.rs
@@ -161,7 +161,6 @@ fn interactive_invocations_cover_fresh_and_resume_for_every_stable_provider() {
         (
             "claude-code",
             vec!["--chrome".to_string()],
-            vec!["--chrome".to_string()],
             vec![
                 "--chrome".to_string(),
                 "--resume".to_string(),
@@ -170,7 +169,6 @@ fn interactive_invocations_cover_fresh_and_resume_for_every_stable_provider() {
         ),
         (
             "codex-cli",
-            vec!["--strict-config".to_string()],
             vec!["--strict-config".to_string()],
             vec![
                 "--strict-config".to_string(),
@@ -181,7 +179,6 @@ fn interactive_invocations_cover_fresh_and_resume_for_every_stable_provider() {
         (
             "gemini-cli",
             vec!["--sandbox".to_string()],
-            vec!["--sandbox".to_string()],
             vec![
                 "--sandbox".to_string(),
                 "--resume".to_string(),
@@ -191,7 +188,6 @@ fn interactive_invocations_cover_fresh_and_resume_for_every_stable_provider() {
         (
             "opencode",
             vec!["--auto".to_string()],
-            vec!["--auto".to_string()],
             vec![
                 "--auto".to_string(),
                 "--session".to_string(),
@@ -199,9 +195,9 @@ fn interactive_invocations_cover_fresh_and_resume_for_every_stable_provider() {
             ],
         ),
     ];
-    assert_stable_agent_coverage(fixtures.iter().map(|(agent_id, _, _, _)| *agent_id));
+    assert_stable_agent_coverage(fixtures.iter().map(|(agent_id, _, _)| *agent_id));
 
-    for (agent_id, managed_args, fresh_args, resume_args) in fixtures {
+    for (agent_id, managed_args, resume_args) in fixtures {
         let fresh = build_interactive_invocation(
             agent_id,
             format!("C:/bin/{agent_id}.exe"),
@@ -209,7 +205,28 @@ fn interactive_invocations_cover_fresh_and_resume_for_every_stable_provider() {
             &managed_args,
         )
         .expect("fresh interactive invocation");
-        assert_eq!(fresh.args, fresh_args, "{agent_id} fresh");
+        match agent_id {
+            "claude-code" | "gemini-cli" => {
+                let assigned = fresh
+                    .assigned_runtime_session_id
+                    .as_deref()
+                    .expect("caller-assigned session id");
+                uuid::Uuid::parse_str(assigned).expect("provider-valid UUID");
+                assert_eq!(
+                    fresh.args,
+                    [
+                        managed_args.clone(),
+                        vec!["--session-id".to_string(), assigned.to_string()],
+                    ]
+                    .concat(),
+                    "{agent_id} fresh"
+                );
+            }
+            _ => {
+                assert_eq!(fresh.args, managed_args, "{agent_id} fresh");
+                assert_eq!(fresh.assigned_runtime_session_id, None);
+            }
+        }
 
         let resume = build_interactive_invocation(
             agent_id,
@@ -219,6 +236,30 @@ fn interactive_invocations_cover_fresh_and_resume_for_every_stable_provider() {
         )
         .expect("resume interactive invocation");
         assert_eq!(resume.args, resume_args, "{agent_id} resume");
+        assert_eq!(resume.assigned_runtime_session_id, None);
+    }
+}
+
+#[test]
+fn empty_interactive_runtime_session_id_is_treated_as_fresh() {
+    for agent_id in ["claude-code", "codex-cli", "gemini-cli", "opencode"] {
+        let invocation = build_interactive_invocation(
+            agent_id,
+            format!("C:/bin/{agent_id}.exe"),
+            Some("  "),
+            &[],
+        )
+        .expect("fresh interactive invocation");
+
+        assert!(
+            !invocation.args.iter().any(|argument| argument == "  "),
+            "{agent_id}"
+        );
+        assert_eq!(
+            invocation.assigned_runtime_session_id.is_some(),
+            matches!(agent_id, "claude-code" | "gemini-cli"),
+            "{agent_id}"
+        );
     }
 }
 

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/terminal_process.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/terminal_process.rs
@@ -1,4 +1,7 @@
-use super::providers::{build_interactive_invocation, output_parser_for, ProviderOutputEvent};
+use super::providers::{
+    build_interactive_invocation, output_parser_for, prepare_provider_session_capture,
+    ProviderOutputEvent, ProviderSessionCapture, ProviderSessionDiscovery,
+};
 use super::terminal_wrapper::{
     default_agent_terminal_shell, generate_agent_terminal_wrapper, AgentTerminalWrapperRequest,
 };
@@ -17,6 +20,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::{Duration, Instant};
 
 const RETAINED_TERMINAL_TRANSCRIPT_BYTES: usize = 1_000_000;
 
@@ -28,6 +32,7 @@ const TERMINAL_READ_BUFFER_BYTES: usize = 64 * 1024;
 /// Upper bound on an unterminated parse line, so newline-less output (e.g. `\r` progress
 /// bars) cannot grow the session-id parse buffer without bound.
 const MAX_PARSE_LINE_BYTES: usize = 256 * 1024;
+const PROVIDER_SESSION_DISCOVERY_INTERVAL: Duration = Duration::from_millis(250);
 
 struct ManagedAgentTerminal {
     terminal_id: String,
@@ -182,6 +187,48 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
         }
         let agent_id_for_error = request.agent.id.clone();
         let session_id_for_error = request.session.id.clone();
+        let provider_session_capture = if non_empty_runtime_session_id(
+            request.session.runtime_session_id.as_deref(),
+        )
+        .is_none()
+            && matches!(request.agent.id.as_str(), "codex-cli" | "opencode")
+        {
+            let working_directory = request
+                .session
+                .folder
+                .as_deref()
+                .filter(|folder| !folder.trim().is_empty())
+                .map(PathBuf::from)
+                .or_else(|| std::env::current_dir().ok());
+            match working_directory {
+                Some(working_directory) => {
+                    match prepare_provider_session_capture(&request.agent.id, working_directory) {
+                        Ok(capture) => capture,
+                        Err(error) => {
+                            self.record_log(
+                                AgentLogLevel::Warn,
+                                format!("Provider session capture is unavailable: {error}"),
+                                Some(&request.agent.id),
+                                Some(&request.session.id),
+                            );
+                            None
+                        }
+                    }
+                }
+                None => {
+                    self.record_log(
+                        AgentLogLevel::Warn,
+                        "Provider session capture is unavailable because the working directory could not be resolved."
+                            .to_string(),
+                        Some(&request.agent.id),
+                        Some(&request.session.id),
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
         let executable =
             normalize_interactive_executable(&request.agent.id, &request.cli_profile.executable);
         let invocation = build_interactive_invocation(
@@ -293,11 +340,15 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
             AgentRuntimeApplicationError::Process(message)
         })?;
         let child = Arc::new(Mutex::new(child));
+        let runtime_session_id =
+            non_empty_runtime_session_id(request.session.runtime_session_id.as_deref())
+                .map(str::to_string)
+                .or_else(|| invocation.assigned_runtime_session_id.clone());
         let terminal = ManagedAgentTerminal {
             terminal_id: terminal_id.clone(),
             session_id: request.session.id.clone(),
             agent_id: request.agent.id.clone(),
-            runtime_session_id: request.session.runtime_session_id.clone(),
+            runtime_session_id,
             last_active_at: now_timestamp(self.clock.as_ref()),
             size: request.size.clone(),
             master: pair.master,
@@ -318,6 +369,9 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
         drop(terminal_registry);
         thread::spawn(move || {
             let parser = output_parser_for(&agent_id);
+            let mut provider_session_capture = provider_session_capture;
+            let mut last_capture_attempt: Option<Instant> = None;
+            let mut capture_failure_logged = false;
             let mut buffer = [0u8; TERMINAL_READ_BUFFER_BYTES];
             // Reads land on arbitrary byte boundaries, so a multi-byte UTF-8 sequence
             // (中文 / emoji / TUI box-drawing) can be split across two reads. Carry the
@@ -367,8 +421,70 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
                                     },
                                 );
                                 let _ = events.publish_terminal(event);
+                                provider_session_capture = None;
                             }
                         });
+                        if provider_session_capture.is_some()
+                            && last_capture_attempt.is_none_or(|attempt| {
+                                attempt.elapsed() >= PROVIDER_SESSION_DISCOVERY_INTERVAL
+                            })
+                        {
+                            last_capture_attempt = Some(Instant::now());
+                            let discovery = provider_session_capture
+                                .as_ref()
+                                .map(ProviderSessionCapture::discover);
+                            match discovery {
+                                Some(Ok(ProviderSessionDiscovery::Found(runtime_session_id))) => {
+                                    let event = record_runtime_session_id(
+                                        terminals.as_ref(),
+                                        &terminal_id,
+                                        &session_id,
+                                        runtime_session_id,
+                                        |session_id, runtime_session_id| {
+                                            let _ = sessions.update_runtime_session_id(
+                                                session_id,
+                                                runtime_session_id,
+                                            );
+                                        },
+                                    );
+                                    let _ = events.publish_terminal(event);
+                                    record_provider_session_capture_log(
+                                        logging.as_ref(),
+                                        clock.as_ref(),
+                                        AgentLogLevel::Info,
+                                        "Captured exact provider session id.".to_string(),
+                                        &agent_id,
+                                        &session_id,
+                                    );
+                                    provider_session_capture = None;
+                                }
+                                Some(Ok(ProviderSessionDiscovery::Ambiguous(count))) => {
+                                    record_provider_session_capture_log(
+                                        logging.as_ref(),
+                                        clock.as_ref(),
+                                        AgentLogLevel::Warn,
+                                        format!(
+                                            "Provider session capture skipped because {count} matching new sessions were found."
+                                        ),
+                                        &agent_id,
+                                        &session_id,
+                                    );
+                                    provider_session_capture = None;
+                                }
+                                Some(Err(error)) if !capture_failure_logged => {
+                                    record_provider_session_capture_log(
+                                        logging.as_ref(),
+                                        clock.as_ref(),
+                                        AgentLogLevel::Warn,
+                                        format!("Provider session capture failed: {error}"),
+                                        &agent_id,
+                                        &session_id,
+                                    );
+                                    capture_failure_logged = true;
+                                }
+                                _ => {}
+                            }
+                        }
                     }
                     Err(_) => break,
                 }
@@ -528,6 +644,28 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
         }
         Ok(stopped)
     }
+}
+
+fn record_provider_session_capture_log(
+    logging: &dyn AgentLoggingPort,
+    clock: &dyn AgentClockPort,
+    level: AgentLogLevel,
+    message: String,
+    agent_id: &str,
+    session_id: &str,
+) {
+    let _ = logging.record(AgentLog {
+        level,
+        category: "session.agent_terminal".to_string(),
+        message,
+        agent_id: Some(agent_id.to_string()),
+        session_id: Some(session_id.to_string()),
+        operation_id: None,
+        run_id: None,
+        trace_id: None,
+        span_id: None,
+        occurred_at: clock.now(),
+    });
 }
 
 fn record_runtime_session_id(
@@ -745,6 +883,10 @@ fn safe_file_segment(value: &str) -> String {
         .collect()
 }
 
+fn non_empty_runtime_session_id(runtime_session_id: Option<&str>) -> Option<&str> {
+    runtime_session_id.filter(|session_id| !session_id.trim().is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -778,6 +920,16 @@ mod tests {
 
         assert_eq!(size.rows, 1);
         assert_eq!(size.cols, 500);
+    }
+
+    #[test]
+    fn blank_runtime_session_id_is_treated_as_missing() {
+        assert_eq!(non_empty_runtime_session_id(None), None);
+        assert_eq!(non_empty_runtime_session_id(Some(" \t")), None);
+        assert_eq!(
+            non_empty_runtime_session_id(Some("provider-session-1")),
+            Some("provider-session-1")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- assign provider-valid UUIDs for fresh Claude Code and Gemini CLI terminals and resume them by exact id
- discover Codex and OpenCode provider-allocated session ids from a pre-launch baseline plus working-directory metadata
- persist captured ids through the existing session gateway, refresh frontend session state through the existing event contract, and fail closed on ambiguous records
- add the OpenSpec change and deterministic provider-store fixtures without changing the frontend service interface or database schema

## Validation
- `npm run lint`
- `npm run test` (92 files, 301 tests)
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml` (720 passed, 3 ignored; architecture 9 passed)
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `openspec validate fix-cli-terminal-session-resume-capture --strict`
- `openspec validate --specs --strict` (69 passed)

## Review notes
- provider-global `resume --last` / `--continue` fallbacks are intentionally not used because they can restore another VaneHub session
- same-working-directory external-session races and retry behavior after an asynchronous persistence failure are known hardening points identified during verification