### PR TITLE
fix: prevent settings hydration flash

### DIFF
--- a/openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/design.md
+++ b/openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/design.md
@@ -1,0 +1,67 @@
+## Context
+
+`SettingsProvider` initializes React state with `defaultAppSettings`, but it does not apply those values to the document during the initial render. Its children are rendered immediately, while the persisted settings read runs later in an effect through the active runtime adapter. The browser therefore paints the application with its default 16px root size and base theme before the provider writes the configured root font size and `data-theme`, causing a full rem-based layout reflow.
+
+Both the main application and floating-assistant surface mount the same provider. Desktop settings arrive asynchronously through the Tauri adapter and SQLite-backed command; Web/mock settings arrive through the interface-compatible Web adapter.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prevent settings-dependent application children from becoming visible before initial settings are normalized and applied.
+- Preserve successful restoration for both desktop and Web/mock runtimes.
+- Apply shared defaults before rendering when the initial settings read fails.
+- Keep the existing settings service and runtime adapter boundaries unchanged.
+- Cover the ordering contract with focused frontend tests.
+
+**Non-Goals:**
+
+- Change settings persistence, supported values, SQLite schema, or Tauri commands.
+- Add a general-purpose splash-screen framework.
+- Change optimistic settings updates after startup.
+- Alter the fixed xterm terminal font size.
+
+## Decisions
+
+1. Gate provider children on initial settings hydration.
+
+   `SettingsProvider` will continue mounting immediately so its effects can load settings, but it will return no formal application surface while the initial load is pending. After the selected persisted or fallback settings have been applied, the provider will clear its loading state and expose its children.
+
+   This keeps ownership of settings side effects in the provider, applies equally to the main and floating surfaces, and avoids moving runtime-specific knowledge into `main.tsx`.
+
+   Alternative considered: set `html { font-size: 14px }` in static CSS. That only masks the issue for the 14px default and still reflows users configured for 12px or 18px.
+
+   Alternative considered: replace `useEffect` with `useLayoutEffect`. The settings read remains asynchronous, so the browser can still paint before its promise resolves.
+
+2. Complete document side effects before releasing the hydration gate.
+
+   The provider will apply the root font size and theme synchronously and await the bundled i18next language change during initial hydration. Only after this work completes will settings state become visible to child consumers.
+
+   Alternative considered: render children with default context state while only hiding them with CSS. That still mounts settings-dependent components with incorrect values and can start avoidable queries or terminal work before hydration.
+
+3. Treat fallback application as successful hydration with an error.
+
+   If `getSettings` fails, the provider will apply `defaultAppSettings`, retain the error message, and then render. This preserves fail-open startup behavior without reintroducing an unconfigured first paint.
+
+4. Test the visibility and ordering contract at the provider boundary.
+
+   A deferred settings-service result will verify that children do not render while hydration is pending and that their first render observes the configured document settings. A rejected result will verify default application and error exposure.
+
+## Risks / Trade-offs
+
+- [A slow native settings read leaves the React root temporarily empty] → Keep the gate limited to the initial settings request; do not wait for independent Node.js discovery or other startup data.
+- [Server-render-only tests cannot run effects and would render an empty provider] → Exercise settings pages in the existing jsdom client environment and wait for hydration, matching the supported Vite/Tauri runtime.
+- [Awaiting language synchronization could marginally extend startup] → Resources are bundled locally, and correctness before first visibility is preferable to a language flash.
+- [A future settings read that never settles would keep the surface hidden] → Preserve adapter error propagation and cover successful and rejected completion; timeout policy remains an adapter/runtime concern.
+
+## Migration Plan
+
+1. Add provider hydration regression tests.
+2. Gate children until persisted or fallback settings are applied.
+3. Run focused tests, the complete frontend/Rust validation suite, and strict OpenSpec validation.
+
+Rollback is a frontend-only revert of the provider gate and tests; no stored data or native schema migration is involved.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/proposal.md
+++ b/openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The desktop and Web surfaces currently render their full React trees before persisted application settings are loaded and applied. Because the root font size initially falls back to the browser default and changes after the asynchronous settings read, startup visibly resizes the interface and can also flash the wrong theme or language.
+
+## What Changes
+
+- Add an explicit settings-hydration boundary that keeps the formal application surface hidden until normalized settings have been applied.
+- Apply persisted font size, theme, and language before rendering settings-dependent children.
+- Fall back to the shared default settings when the initial read fails, then render the application with the existing error state available to settings consumers.
+- Add focused frontend regression coverage for delayed successful hydration and failed hydration.
+- Preserve the existing settings service and desktop/Web runtime adapter boundaries.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `app-settings`: Require startup restoration or fallback settings to be applied before the formal application surface first becomes visible.
+
+## Impact
+
+- Affects both the Tauri desktop and Web/mock surfaces because both use `SettingsProvider`.
+- Primarily changes `src/settings/settings-provider.tsx` and its frontend tests.
+- Does not change Tauri commands, SQLite schemas, public service interfaces, or runtime adapter parity.
+- Introduces no new dependencies and keeps React components isolated from direct Tauri calls.

--- a/openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/specs/app-settings/spec.md
+++ b/openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/specs/app-settings/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Settings persistence
+The system SHALL persist common settings through the active runtime adapter and SHALL complete initial settings hydration before displaying the formal application surface.
+
+#### Scenario: Persist desktop setting
+- **WHEN** the application runs in the Tauri desktop runtime and a user saves a common setting
+- **THEN** the system SHALL persist the setting through a Tauri command backed by SQLite storage
+
+#### Scenario: Persist Web setting
+- **WHEN** the application runs in the browser Web runtime and a user saves a common setting
+- **THEN** the system SHALL persist the setting through the Web adapter without requiring a Tauri command
+
+#### Scenario: Restore saved settings
+- **WHEN** the application starts after common settings have been saved
+- **THEN** the system SHALL restore and apply the saved setting values for the active runtime
+- **AND** the formal application surface SHALL first become visible with the restored root font size, visual theme, and application language already applied
+
+#### Scenario: Fall back when initial settings cannot be loaded
+- **WHEN** the active runtime fails to load common settings during application startup
+- **THEN** the system SHALL apply the shared default settings before displaying the formal application surface
+- **AND** the settings provider SHALL retain a user-displayable error without preventing startup

--- a/openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/tasks.md
+++ b/openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/tasks.md
@@ -1,0 +1,23 @@
+## 1. Hydration Regression Coverage
+
+- [x] 1.1 Add a focused SettingsProvider test that defers the settings response and verifies children first render only after configured font size, theme, and language are applied.
+- [x] 1.2 Add failure-path coverage proving shared defaults and the load error are available when initial settings hydration fails.
+- [x] 1.3 Update the Basic Configuration rendering test to exercise the client-side hydrated provider lifecycle.
+
+## 2. Provider Hydration Boundary
+
+- [x] 2.1 Make initial settings application awaitable and complete it before clearing the provider loading state.
+- [x] 2.2 Gate settings-dependent children during initial hydration while preserving default fallback, event subscription, optimistic mutation, and desktop/Web adapter behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run focused SettingsProvider and Basic Configuration tests.
+- [x] 3.2 Run `npm run lint`, `npm run test`, and `npm run build`.
+- [x] 3.3 Run `cargo test`, `cargo check`, and `cargo clippy` against `src-tauri/Cargo.toml`.
+- [x] 3.4 Run strict validation for the change and all main specifications.
+
+## 4. Verification Warning Remediation
+
+- [x] 4.1 Add direct Web adapter coverage for a localStorage-backed save-and-read round trip.
+- [x] 4.2 Remove the unintended pnpm lockfile and clear no-content generated line-ending status.
+- [x] 4.3 Re-run focused and strict validation, then confirm only intended change files remain.

--- a/openspec/changes/archive/README.md
+++ b/openspec/changes/archive/README.md
@@ -78,5 +78,6 @@ Online archive location: `openspec/changes/archive/`
 | 2026-07-24 | optimize-rust-build-and-release | continuous-integration, native-app-packaging, native-build-optimization | `openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/` |
 | 2026-07-26 | fix-embedded-terminal-tui-contrast | session-workspace-tabs | `openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/` |
 | 2026-07-28 | dynamic-llm-model-discovery | cli-parameter-management, custom-model-display, native-model-discovery, session-chat-configuration | `openspec/changes/archive/2026-07-28-dynamic-llm-model-discovery/` |
+| 2026-07-28 | fix-settings-hydration-flash | app-settings | `openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/` |
 
 Cold-archive destinations are recorded in `openspec/archive-cold-migrations.md`.

--- a/openspec/changes/archive/archive-index.json
+++ b/openspec/changes/archive/archive-index.json
@@ -1098,6 +1098,19 @@
                                               "native-model-discovery",
                                               "session-chat-configuration"
                                           ]
+                     },
+                     {
+                         "archivedOn":  "2026-07-28",
+                         "changeName":  "fix-settings-hydration-flash",
+                         "path":  "openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/",
+                         "artifacts":  [
+                                           "proposal",
+                                           "design",
+                                           "tasks"
+                                       ],
+                         "capabilities":  [
+                                              "app-settings"
+                                          ]
                      }
                  ]
 }

--- a/openspec/specs/app-settings/spec.md
+++ b/openspec/specs/app-settings/spec.md
@@ -30,7 +30,7 @@ The system SHALL apply common settings through centralized side effects owned by
 - **THEN** the system SHALL update the document theme attribute used by CSS variable groups
 
 ### Requirement: Settings persistence
-The system SHALL persist common settings through the active runtime adapter.
+The system SHALL persist common settings through the active runtime adapter and SHALL complete initial settings hydration before displaying the formal application surface.
 
 #### Scenario: Persist desktop setting
 - **WHEN** the application runs in the Tauri desktop runtime and a user saves a common setting
@@ -43,6 +43,12 @@ The system SHALL persist common settings through the active runtime adapter.
 #### Scenario: Restore saved settings
 - **WHEN** the application starts after common settings have been saved
 - **THEN** the system SHALL restore and apply the saved setting values for the active runtime
+- **AND** the formal application surface SHALL first become visible with the restored root font size, visual theme, and application language already applied
+
+#### Scenario: Fall back when initial settings cannot be loaded
+- **WHEN** the active runtime fails to load common settings during application startup
+- **THEN** the system SHALL apply the shared default settings before displaying the formal application surface
+- **AND** the settings provider SHALL retain a user-displayable error without preventing startup
 
 ### Requirement: Node.js environment display
 The system SHALL expose read-only Node.js environment information for the Basic Configuration page.

--- a/src/services/web-settings-client.test.ts
+++ b/src/services/web-settings-client.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { webSettingsClient } from "./web-settings-client";
+
+describe("web-settings-client", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("persists a setting to localStorage and restores it through the Web adapter", async () => {
+    const savedSettings = await webSettingsClient.saveSetting({
+      key: "fontSize",
+      value: "12px",
+    });
+
+    expect(savedSettings.fontSize).toBe("12px");
+    await expect(webSettingsClient.getSettings()).resolves.toMatchObject({
+      fontSize: "12px",
+    });
+  });
+});

--- a/src/settings/pages/basic-settings-page.test.tsx
+++ b/src/settings/pages/basic-settings-page.test.tsx
@@ -1,16 +1,24 @@
-import { renderToString } from "react-dom/server";
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
 import "../../i18n";
 import { SettingsProvider } from "../settings-provider";
 import { BasicSettingsPage } from "./basic-settings-page";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 describe("BasicSettingsPage", () => {
-  it("renders log management policies and disables local open action in Web mock state", () => {
-    const html = renderToString(
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("renders log management policies and disables local open action in Web mock state", async () => {
+    const { container } = render(
       <SettingsProvider>
         <BasicSettingsPage />
       </SettingsProvider>,
     );
+    await screen.findByText("日志管理");
+    const html = container.innerHTML;
 
     expect(html).toContain("日志管理");
     expect(html).toContain("启动与系统行为");

--- a/src/settings/settings-provider.test.tsx
+++ b/src/settings/settings-provider.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { i18n } from "../i18n";
+import { settingsService } from "../services/runtime-settings-client";
+import { defaultAppSettings } from "../services/settings-service";
+import type { AppSettings } from "../types/settings";
+import { SettingsProvider, useSettings } from "./settings-provider";
+
+vi.mock("../services/runtime-settings-client", () => ({
+  settingsService: {
+    getSettings: vi.fn(),
+    getNodeInfo: vi.fn(),
+    subscribeSettingsEvents: vi.fn(),
+  },
+}));
+
+interface HydrationSnapshot {
+  contextFontSize: AppSettings["fontSize"];
+  documentFontSize: string;
+  error: string | null;
+  language: string;
+  theme: string | undefined;
+}
+
+function HydratedSurface({ onRender }: { onRender: (snapshot: HydrationSnapshot) => void }) {
+  const { error, settings } = useSettings();
+  onRender({
+    contextFontSize: settings.fontSize,
+    documentFontSize: document.documentElement.style.fontSize,
+    error,
+    language: i18n.language,
+    theme: document.documentElement.dataset.theme,
+  });
+  return <div data-testid="hydrated-surface">ready</div>;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("SettingsProvider hydration", () => {
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.mocked(settingsService.getNodeInfo).mockResolvedValue({
+      available: false,
+      path: null,
+      reason: "not available",
+      version: null,
+    });
+    vi.mocked(settingsService.subscribeSettingsEvents).mockResolvedValue(() => undefined);
+    document.documentElement.style.removeProperty("font-size");
+    delete document.documentElement.dataset.theme;
+    await i18n.changeLanguage("zh-CN");
+  });
+
+  afterEach(() => {
+    document.documentElement.style.removeProperty("font-size");
+    delete document.documentElement.dataset.theme;
+  });
+
+  it("does not render children until persisted settings are applied", async () => {
+    const pendingSettings = deferred<AppSettings>();
+    const onRender = vi.fn<(snapshot: HydrationSnapshot) => void>();
+    vi.mocked(settingsService.getSettings).mockReturnValue(pendingSettings.promise);
+
+    render(
+      <SettingsProvider>
+        <HydratedSurface onRender={onRender} />
+      </SettingsProvider>,
+    );
+
+    expect(screen.queryByTestId("hydrated-surface")).toBeNull();
+    expect(onRender).not.toHaveBeenCalled();
+
+    pendingSettings.resolve({
+      ...defaultAppSettings,
+      applicationLanguage: "en",
+      fontSize: "12px",
+      theme: "minimal",
+    });
+
+    await screen.findByTestId("hydrated-surface");
+    await waitFor(() => expect(onRender).toHaveBeenCalledTimes(1));
+    expect(onRender).toHaveBeenLastCalledWith({
+      contextFontSize: "12px",
+      documentFontSize: "12px",
+      error: null,
+      language: "en",
+      theme: "minimal",
+    });
+  });
+
+  it("applies defaults and exposes the load error before rendering children", async () => {
+    const onRender = vi.fn<(snapshot: HydrationSnapshot) => void>();
+    vi.mocked(settingsService.getSettings).mockRejectedValue(new Error("settings unavailable"));
+
+    render(
+      <SettingsProvider>
+        <HydratedSurface onRender={onRender} />
+      </SettingsProvider>,
+    );
+
+    await screen.findByTestId("hydrated-surface");
+    await waitFor(() => expect(onRender).toHaveBeenCalledTimes(1));
+    expect(onRender).toHaveBeenLastCalledWith({
+      contextFontSize: defaultAppSettings.fontSize,
+      documentFontSize: defaultAppSettings.fontSize,
+      error: "settings unavailable",
+      language: defaultAppSettings.applicationLanguage,
+      theme: defaultAppSettings.theme,
+    });
+  });
+});

--- a/src/settings/settings-provider.tsx
+++ b/src/settings/settings-provider.tsx
@@ -24,10 +24,10 @@ interface SettingsContextValue {
 
 const SettingsContext = createContext<SettingsContextValue | null>(null);
 
-function applySettings(settings: AppSettings) {
-  void i18n.changeLanguage(settings.applicationLanguage);
+async function applySettings(settings: AppSettings) {
   document.documentElement.style.fontSize = settings.fontSize;
   document.documentElement.dataset.theme = settings.theme;
+  await i18n.changeLanguage(settings.applicationLanguage);
 }
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -52,14 +52,16 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       try {
         const loadedSettings = normalizeAppSettings(await settingsService.getSettings());
         if (cancelled) return;
+        await applySettings(loadedSettings);
+        if (cancelled) return;
         setSettings(loadedSettings);
-        applySettings(loadedSettings);
         setError(null);
       } catch (err) {
         if (cancelled) return;
         const fallback = defaultAppSettings;
+        await applySettings(fallback);
+        if (cancelled) return;
         setSettings(fallback);
-        applySettings(fallback);
         setError(err instanceof Error ? err.message : String(err));
       } finally {
         if (!cancelled) setLoading(false);
@@ -81,7 +83,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
           const nextSettings = normalizeAppSettings(await settingsService.getSettings());
           if (!active) return;
           setSettings(nextSettings);
-          applySettings(nextSettings);
+          void applySettings(nextSettings);
           setError(null);
         } catch (err) {
           if (active) setError(err instanceof Error ? err.message : String(err));
@@ -105,14 +107,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       const previousSettings = settings;
       const optimisticSettings = normalizeAppSettings({ ...settings, [key]: value });
       setSettings(optimisticSettings);
-      applySettings(optimisticSettings);
+      void applySettings(optimisticSettings);
       try {
         const nextSettings = normalizeAppSettings(await settingsService.saveSetting({ key, value }));
         setSettings(nextSettings);
-        applySettings(nextSettings);
+        void applySettings(nextSettings);
       } catch (err) {
         setSettings(previousSettings);
-        applySettings(previousSettings);
+        void applySettings(previousSettings);
         setError(err instanceof Error ? err.message : String(err));
         throw err;
       } finally {
@@ -146,14 +148,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       const previousSettings = settings;
       const optimisticSettings = normalizeAppSettings({ ...settings, launchOnStartup: enabled });
       setSettings(optimisticSettings);
-      applySettings(optimisticSettings);
+      void applySettings(optimisticSettings);
       try {
         const nextSettings = normalizeAppSettings(await settingsService.setLaunchOnStartup(enabled));
         setSettings(nextSettings);
-        applySettings(nextSettings);
+        void applySettings(nextSettings);
       } catch (err) {
         setSettings(previousSettings);
-        applySettings(previousSettings);
+        void applySettings(previousSettings);
         setError(err instanceof Error ? err.message : String(err));
         throw err;
       } finally {
@@ -208,6 +210,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     [error, getDataManagementInfo, loading, nodeInfo, openDatabaseDirectory, openLogDirectory, refreshNodeInfo, reportClientLogEvent, resetSettings, saveSetting, scanNetworkProxies, setLaunchOnStartup, savingKey, settings, testNetworkProxy],
   );
 
+  if (loading) return null;
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
 }
 


### PR DESCRIPTION
## Summary

Prevent the startup font-size flash by keeping settings-dependent application surfaces behind the SettingsProvider hydration boundary until persisted font size, theme, and language side effects have completed.

- Await initial root font, theme, and i18n application before rendering children.
- Apply shared defaults before rendering when hydration fails, while retaining a user-displayable error.
- Cover delayed hydration, fallback behavior, hydrated Basic Configuration rendering, and Web localStorage persistence.
- Sync and archive the completed OpenSpec change, including the generated archive index.

## Related work

- Issue: Startup font briefly renders large before persisted settings load.
- OpenSpec change: `openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/`

## Risk and compatibility

The application surface can remain blank for the short initial settings read instead of rendering with incorrect defaults. If loading fails, shared defaults are applied before the surface appears and the existing error remains available. Desktop and Web adapters retain their existing contracts and persistence behavior. No database migration, native API change, or security-sensitive data is introduced. Reverting the single commit restores the previous eager-render behavior.

## Validation

- [x] `npm run lint`
- [x] `npm run test` — 94 files, 304 tests passed
- [x] `npm run contracts:check`
- [x] `npm run build`
- [x] Playwright E2E — GitHub CI passed; locally 53/54 passed in the full system-Chrome run and the lone unrelated Loop timing case passed on isolated retry
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 742 passed, 3 ignored; architecture 9/9
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml`
- [x] `openspec validate --specs --strict` — 71/71 passed
- [x] GitHub CI, CodeQL, dependency review, native coverage, and platform checks passed

## Screenshots or diagnostics

No screenshot is required; the regression is covered through hydration-boundary tests that assert the first child render observes the persisted settings.

## Checklist

- [x] The change follows `AGENTS.md` and `openspec/project.md`.
- [x] New behavior is covered by tests.
- [x] Documentation and both service adapters are updated where applicable.
- [x] No secrets, signing material, local databases, or sensitive logs are committed.