### PR TITLE
fix: preserve terminal usage integrity

### DIFF
--- a/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/design.md
+++ b/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/design.md
@@ -1,0 +1,54 @@
+## Context
+
+Interactive Agent terminals run behind `portable-pty` and therefore cannot reuse the managed pipeline's structured output parser. The current implementation periodically reads each CLI's persisted session store, creates an empty streaming assistant message before any usage exists, and updates `usage_records` through the sessions gateway. Three assumptions are unsafe: Gemini JSONL lines are revisions rather than immutable messages, working-directory/mtime lookup is not a provider-session identity, and an atomic stop flag does not prove the poll thread has stopped before the final read.
+
+The collection path is desktop-only. React continues to read summaries through `agentService`; Web/mock behavior is unchanged. `agent_runtime` owns provider file/process adapters, `sessions` owns message and usage persistence, and `execution_observability` owns telemetry contracts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce one correct cumulative terminal usage observation per VaneHub session and stable Agent id, including after provider-session resume.
+- Match Gemini's own last-write-wins JSONL materialization and exact runtime session identity.
+- Create a backing assistant message only after non-zero usage exists, reuse an existing terminal-usage message after restart, and propagate transaction failures.
+- Serialize periodic and final ingestion by joining the poll thread.
+- Record metadata-only terminal Session/Agent/opaque Tool boundary/Process lifecycle telemetry through existing ports.
+
+**Non-Goals:**
+
+- Parsing ANSI/TUI output into concrete tool or MCP events; the required terminal Tool/MCP boundary remains explicitly opaque.
+- Changing the frontend service contract, Tauri command DTOs, usage schema, or Web/mock behavior.
+- Mapping Gemini's `tool` token field until its additive semantics are verified.
+- Retrofitting or deleting historical empty placeholder messages created by released versions.
+
+## Decisions
+
+1. **Materialize Gemini records by id before aggregation.** Direct message lines replace the prior value for the same id; a `$set.messages` snapshot clears and replaces the materialized map, matching Gemini CLI's loader. Alternatives that sum token-bearing lines or merely deduplicate identical token tuples are rejected because later revisions can legitimately change tokens.
+
+2. **Resolve Gemini by exact provider runtime session id.** The terminal invocation already assigns or resumes a known id. The lookup reads top-level `session-*.jsonl` metadata and accepts only an exact `sessionId` match under the registered project slug. It does not fall back to most-recent mtime, which would prefer wrong data over missing data.
+
+3. **Reuse one terminal-usage message per VaneHub session and Agent without a schema change.** The sessions read port gains a narrow query for an existing `source = 'cli-session-log'` usage record. The runtime loads that id at terminal start; when absent, it creates the backing message lazily only after a non-zero observation. The retained terminal registry already prevents concurrent processes for one VaneHub session, and joining the poll removes the remaining in-process creation race. A generalized non-message usage subject remains a future schema redesign, not required to restore integrity now.
+
+4. **Separate observation from persistence.** Provider readers return `TerminalUsageTotals`; the shared persistence step owns lazy message creation and calls the sessions transaction port. Errors propagate to the caller and unified logging. Cache-only totals count as non-zero.
+
+5. **Own the poll thread handle.** The PTY reader sets the stop flag, joins the poll handle, then performs the final read. A panic is converted to a redacted warning while final ingestion still runs. This preserves terminal availability while establishing a happens-before boundary.
+
+6. **Use existing execution-observability ports.** Bootstrap injects execution identity, settings, and telemetry into the terminal runtime. Each fresh PTY process creates a metadata-only run with a Session root span, an Agent child span, an opaque Tool/MCP boundary child, and a Process Exec child. The opaque boundary represents the known interactive CLI boundary, not fabricated concrete tool calls. The process outcome finishes children then the run. Telemetry failure never changes terminal success. No raw command, path, prompt, or output is attached.
+
+## Risks / Trade-offs
+
+- [Risk] Existing databases can contain more than one historical `cli-session-log` row for a session. → Select the most recently updated matching message deterministically and update only it; preserve older history rather than deleting data in a corrective change.
+- [Risk] Gemini changes its unversioned recording format. → Keep permissive parsing, exact fixtures for revisions and snapshots, and degrade to no observation rather than guessing.
+- [Risk] Joining waits for an in-progress filesystem read. → Reads are local and bounded to one provider session file/row; poll shutdown does not hold the terminal registry lock.
+- [Risk] Terminal TUI does not expose structured tool/MCP lifecycle. → Emit the required Tool/MCP boundary with `opaque` fidelity and do not emit fabricated concrete tool-call children.
+- [Risk] A telemetry repository failure occurs during terminal startup or exit. → Ignore telemetry return values for execution outcome and rely on the composite telemetry diagnostic path.
+
+## Migration Plan
+
+- No SQLite schema migration is required.
+- Existing terminal usage rows remain readable. On the first post-upgrade refresh, the newest matching row becomes the stable update target.
+- Rollback restores the prior collector without data conversion; already-corrected totals remain valid usage rows.
+
+## Open Questions
+
+- A future proposal may generalize `usage_records` from message-only subjects to explicit assistant-response and terminal-session subjects. That is intentionally deferred because it requires a versioned table rebuild and UI accounting decisions.

--- a/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/proposal.md
+++ b/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Interactive terminal usage tracking can silently overcount Gemini CLI tool-call turns, attach usage to the wrong provider session, duplicate historical totals after resume, and report successful persistence when SQLite writes fail. The same lifecycle also creates empty streaming assistant placeholders and allows the periodic poll to race the final read, so the shipped usage statistics are not yet a trustworthy read model.
+
+## What Changes
+
+- Materialize Gemini CLI's append-only JSONL by message id with last-write-wins semantics, including `$set.messages` snapshots, before aggregating tokens.
+- Resolve Gemini chat files by the provider runtime session id already assigned to the terminal instead of guessing from working directory and modification time.
+- Make terminal usage persistence lazy and stable across terminal restarts, propagate persistence failures, preserve cache-only observations, and avoid empty streaming placeholder messages.
+- Own and join the periodic usage-poll thread before the exit-time read so older work cannot overwrite the final observation.
+- Correlate interactive Agent terminal and PTY process lifecycle telemetry using the existing execution-observability boundary, without capturing terminal content or inventing unobservable tool/MCP details.
+- Add regression tests for duplicate JSONL revisions, exact session selection, resume-safe upsert, persistence failures, cache-only observations, and poll shutdown ordering.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `usage-statistics`: Require interactive terminal usage to materialize provider-native revisions, bind to the exact provider session, update one stable observation across resume, and surface persistence failures.
+- `agent-terminal-runtime`: Require usage polling to stop and join before final ingestion and forbid terminal usage tracking from leaving empty streaming chat messages.
+- `agent-execution-observability`: Extend correlated Agent/process lifecycle telemetry to interactive embedded Agent terminals while retaining metadata-only privacy and fidelity rules.
+
+## Impact
+
+- Desktop/Tauri runtime only for collection and telemetry; Web/mock behavior and frontend service contracts remain unchanged.
+- Rust changes are scoped to `agent_runtime` terminal/session-capture infrastructure, its application ports, the published `sessions` API and SQLite repository queries, plus bootstrap telemetry assembly.
+- No React component gains a direct Tauri dependency and no Tauri command signature changes.
+- The existing `usage_records` schema is reused; no SQLite migration is required for this correction.
+- No new dependency is introduced.

--- a/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/specs/agent-execution-observability/spec.md
+++ b/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/specs/agent-execution-observability/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Correlated execution topology
+The system SHALL represent task execution, prompt assembly, Agent invocation, managed or interactive child-process execution, stream milestones, observable tool activity, observable MCP activity, coordination nodes, failover attempts, and terminal outcome as one correlated trace when those stages occur.
+
+#### Scenario: Agent CLI run completes
+- **WHEN** a submitted task invokes a managed Agent CLI process and completes
+- **THEN** the trace SHALL contain correlated Agent and process lifecycle spans or events with start, terminal status, and duration
+- **AND** the run SHALL retain safe links to the existing operation and provider runtime-session identifiers when available
+
+#### Scenario: Interactive Agent terminal process completes
+- **WHEN** the desktop runtime starts an embedded interactive Agent terminal and its PTY process later exits or is stopped
+- **THEN** the trace SHALL contain correlated Session, Agent, opaque Tool/MCP boundary, and Process Exec lifecycle spans with terminal status and duration
+- **AND** the run SHALL retain safe session, stable Agent, and provider runtime-session identifiers when available
+- **AND** it SHALL omit terminal content, full paths, raw command arguments, and environment values
+
+#### Scenario: Interactive child details are unavailable
+- **WHEN** an interactive terminal's TUI does not expose structured tool or MCP lifecycle data
+- **THEN** the runtime SHALL emit only the known terminal Tool/MCP boundary with `opaque` fidelity and SHALL NOT invent concrete tool-call or MCP-operation child spans
+- **AND** observation capability SHALL remain `opaque` or `inferred` according to the available evidence
+
+#### Scenario: Parallel or delegated work is observed
+- **WHEN** the runtime observes delegated, retried, parallel, or child-Agent work
+- **THEN** it SHALL preserve explicit parent-Agent, delegation, and attempt metadata when available
+- **AND** it SHALL use parent spans or span links without reusing the original run or trace identity for an independent retry
+
+#### Scenario: Coordination fallback is observed
+- **WHEN** a coordination node advances from its primary Agent to a fallback Agent
+- **THEN** both attempts SHALL remain correlated to the coordination run and node with distinct attempt spans or events
+- **AND** telemetry SHALL identify bounded candidate role, stable Agent id, failure classification, and attempt number without capturing raw instructions, context, or output

--- a/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/specs/agent-terminal-runtime/spec.md
+++ b/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/specs/agent-terminal-runtime/spec.md
@@ -1,0 +1,63 @@
+## MODIFIED Requirements
+
+### Requirement: Retained terminal lifecycle
+The desktop runtime SHALL retain Agent Terminal processes across session switching and page closure, then stop inactive processes after two hours or during application shutdown, including all terminal-owned background workers.
+
+#### Scenario: Switch session keeps process
+- **WHEN** the user switches away from a session with a live Agent Terminal process
+- **THEN** the process SHALL remain live and associated with that session
+- **AND** the next selection of that session SHALL attach to the retained process when it is still live
+
+#### Scenario: Idle timeout stops process
+- **WHEN** a retained Agent Terminal process has no attach, input, output, or resize activity for more than two hours
+- **THEN** the desktop runtime SHALL stop that process
+- **AND** the session SHALL remain resumable through its persisted runtime session id when one is available
+
+#### Scenario: Concurrent open attaches once
+- **WHEN** repeated or concurrent open requests target the same session while an Agent Terminal is starting
+- **THEN** the desktop runtime SHALL serialize the requests through the retained terminal registry
+- **AND** it SHALL spawn at most one live Agent CLI process for that session
+
+#### Scenario: Reattach restores terminal output
+- **WHEN** the user returns to a session with a live retained Agent Terminal process
+- **THEN** the runtime SHALL replay retained terminal output to the newly attached terminal view
+- **AND** the user SHALL see the prior terminal screen content instead of an empty terminal
+
+#### Scenario: Reattach uses fast path
+- **WHEN** the user returns to a session with a live retained Agent Terminal process
+- **THEN** the application service SHALL attach to the retained process before loading a fresh CLI profile or preparing a process launch
+- **AND** the terminal content replay SHALL be available without waiting for a full CLI startup path
+
+#### Scenario: Frontend paints cached content immediately
+- **WHEN** the Agent Terminal view remounts for a session with cached terminal output
+- **THEN** the frontend SHALL paint the cached terminal output before waiting for the native attach response
+- **AND** it SHALL avoid duplicating content when the native retained transcript replay arrives
+
+#### Scenario: Usage worker stops before final refresh
+- **WHEN** an Agent Terminal process exits or is stopped
+- **THEN** the runtime SHALL signal and join its periodic usage worker before starting the final usage refresh
+- **AND** an older periodic result SHALL NOT overwrite the final observation
+
+#### Scenario: Shutdown stops processes
+- **WHEN** the desktop application shuts down
+- **THEN** the native runtime SHALL stop all live Agent Terminal processes and terminal-owned background workers
+- **AND** it SHALL wait for child-process cleanup before releasing terminal state
+- **AND** it SHALL write redacted shutdown diagnostics through unified logging
+
+### Requirement: Terminal output persistence boundary
+The Agent Terminal runtime SHALL persist runtime session ids, reported usage, and redacted run diagnostics but SHALL NOT convert terminal transcript output or empty usage placeholders into chat messages.
+
+#### Scenario: Output is not written as messages
+- **WHEN** an Agent Terminal emits stdout or stderr content
+- **THEN** the desktop runtime SHALL display the content in the terminal stream
+- **AND** it SHALL NOT create or append `messages` rows for that transcript content
+
+#### Scenario: Empty usage does not create a streaming message
+- **WHEN** terminal usage polling has not found a non-zero provider observation
+- **THEN** the runtime SHALL NOT create an empty streaming assistant message for usage tracking
+- **AND** the session SHALL NOT remain in a streaming state because usage is unavailable
+
+#### Scenario: Diagnostics use unified logging
+- **WHEN** an Agent Terminal starts, fails, exits, is stopped by idle cleanup, or is stopped during shutdown
+- **THEN** the desktop runtime SHALL write redacted diagnostics through the unified logging service
+- **AND** it SHALL NOT create feature-local log files

--- a/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/specs/usage-statistics/spec.md
+++ b/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/specs/usage-statistics/spec.md
@@ -1,49 +1,4 @@
-# usage-statistics Specification
-
-## Purpose
-Defines the first-version usage statistics capability for summarizing persisted VaneHub chat message token usage in the settings center, including supported ranges, aggregation semantics, and documented accounting constraints.
-## Requirements
-### Requirement: Usage statistics summary
-The system SHALL provide separated reported-token and estimated-character usage statistics for VaneHub-managed assistant responses.
-
-#### Scenario: Display reported token usage
-- **WHEN** usage statistics are requested for a supported time range containing provider-reported usage
-- **THEN** the system SHALL return reported fresh-input, output, cache-read, cache-creation, and total token counts
-- **AND** reported total tokens SHALL equal the sum of those four token categories
-
-#### Scenario: Keep estimated activity separate
-- **WHEN** the selected range contains assistant responses whose usage is derived from character counting
-- **THEN** the system SHALL return estimated input, output, and total character counts separately from reported token counts
-- **AND** estimated characters SHALL NOT be added to any reported token total
-
-#### Scenario: Display coverage and breakdowns
-- **WHEN** usage statistics are requested for a supported time range
-- **THEN** the system SHALL return reported, estimated, and total counted response counts, counted sessions, daily trend points, and per-Agent breakdown rows keyed by stable Agent id
-- **AND** it SHALL return the percentage of counted responses backed by reported usage
-
-#### Scenario: Handle no usage data
-- **WHEN** no persisted usage records exist in the selected range
-- **THEN** the system SHALL return zero-valued reported, estimated, coverage, response, and session totals with empty trend and Agent breakdown arrays instead of failing the page
-
-### Requirement: Usage time ranges
-The system SHALL support usage time ranges for today, last seven days, last thirty days, and all time using the active runtime's user-local calendar.
-
-#### Scenario: Filter by bounded local-calendar range
-- **WHEN** a user selects today, last seven days, or last thirty days
-- **THEN** the system SHALL include usage whose occurrence time falls within that many local calendar dates including the current local date
-- **AND** desktop and Web/mock runtimes SHALL apply equivalent local-calendar semantics
-
-#### Scenario: Include all persisted usage
-- **WHEN** a user selects all time
-- **THEN** the system SHALL include all persisted VaneHub usage records without a lower date boundary
-
-### Requirement: First-version accounting constraints
-The system SHALL document and display that usage statistics cover VaneHub-managed sessions, distinguish reported tokens from estimated characters, and are not provider billing records.
-
-#### Scenario: Show accounting limitation
-- **WHEN** the Usage Statistics page renders
-- **THEN** it SHALL show localized explanatory text describing reported and estimated sources
-- **AND** it SHALL state that external-terminal history, billing reconciliation, monetary cost estimation, request-detail logs, and provider/model filtering are not included in this version
+## MODIFIED Requirements
 
 ### Requirement: Normalized response usage records
 The system SHALL persist at most one normalized usage record per VaneHub assistant response or interactive terminal usage subject without storing prompt, response, or terminal content in that record.
@@ -91,17 +46,6 @@ The system SHALL persist at most one normalized usage record per VaneHub assista
 - **THEN** the system SHALL include those reasoning tokens in the persisted reported output token count
 - **AND** the system SHALL NOT persist reasoning tokens as a distinct tracked category
 
-### Requirement: Historical usage quality preservation
-The system SHALL preserve positive legacy message usage as estimated character history during migration.
-
-#### Scenario: Backfill legacy message usage
-- **WHEN** the usage-record migration runs on an existing database
-- **THEN** each assistant message with positive legacy input or output values SHALL produce an idempotent estimated-character usage record attributed to its owning Agent and original creation time
-
-#### Scenario: Preserve empty legacy rows
-- **WHEN** an existing assistant message has no positive legacy usage value
-- **THEN** the migration SHALL NOT create a synthetic usage record for that message
-
 ### Requirement: Session usage summary
 The system SHALL provide a session-scoped usage summary for a single VaneHub-managed session without changing global usage statistics range behavior.
 
@@ -134,4 +78,3 @@ The system SHALL provide a session-scoped usage summary for a single VaneHub-man
 - **THEN** the system SHALL periodically re-read the CLI's own reported usage and refresh the persisted usage record without waiting for the session to stop
 - **AND** the session usage summary SHALL reflect the refreshed values on its next request
 - **AND** the periodic poll SHALL finish before the exit-time refresh begins
-

--- a/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/tasks.md
+++ b/openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/tasks.md
@@ -1,0 +1,24 @@
+## 1. Gemini provider session integrity
+
+- [x] 1.1 Materialize Gemini JSONL direct revisions and `$set.messages` snapshots by message id before token aggregation.
+- [x] 1.2 Resolve Gemini chat files by exact runtime session id and validate project slug/file boundaries.
+- [x] 1.3 Add regression tests for duplicate tool-call revisions, snapshots, exact session selection, and missing/ambiguous ids.
+
+## 2. Stable and honest usage persistence
+
+- [x] 2.1 Add a narrow sessions port/API/repository query for the existing terminal usage message of a VaneHub session and stable Agent.
+- [x] 2.2 Create the usage backing message lazily on the first non-zero observation and reuse it across polls and terminal restarts.
+- [x] 2.3 Propagate transaction failures and persist cache-only reported observations.
+- [x] 2.4 Add tests for restart-safe reuse, no empty streaming placeholder, cache-only usage, and persistence failure propagation.
+
+## 3. Terminal lifecycle and observability
+
+- [x] 3.1 Retain and join the periodic poll thread before final ingestion, with redacted diagnostics for worker failure.
+- [x] 3.2 Inject execution identity/settings/telemetry into the PTY runtime and emit metadata-only Session, Agent, opaque Tool/MCP boundary, and Process Exec lifecycle spans.
+- [x] 3.3 Add deterministic tests for poll shutdown ordering, telemetry topology/outcomes, and PTY cleanup behavior.
+
+## 4. Verification
+
+- [x] 4.1 Run Rust formatting, unit tests, architecture tests, check, and clippy with warnings denied.
+- [x] 4.2 Run frontend lint, tests, and production build to verify unchanged service/adaptor behavior.
+- [x] 4.3 Run `openspec validate fix-terminal-usage-integrity --strict` and `openspec validate --specs --strict`.

--- a/openspec/changes/archive/README.md
+++ b/openspec/changes/archive/README.md
@@ -85,5 +85,6 @@ Online archive location: `openspec/changes/archive/`
 | 2026-07-31 | establish-test-coverage-and-integration-gates | continuous-integration, frontend-runtime-architecture, native-runtime-architecture | `openspec/changes/archive/2026-07-31-establish-test-coverage-and-integration-gates/` |
 | 2026-07-31 | fix-cli-terminal-session-resume-capture | agent-terminal-runtime | `openspec/changes/archive/2026-07-31-fix-cli-terminal-session-resume-capture/` |
 | 2026-07-31 | pool-native-sqlite-connections | native-runtime-architecture | `openspec/changes/archive/2026-07-31-pool-native-sqlite-connections/` |
+| 2026-08-01 | fix-terminal-usage-integrity | agent-execution-observability, agent-terminal-runtime, usage-statistics | `openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/` |
 
 Cold-archive destinations are recorded in `openspec/archive-cold-migrations.md`.

--- a/openspec/changes/archive/archive-index.json
+++ b/openspec/changes/archive/archive-index.json
@@ -1192,6 +1192,21 @@
                          "capabilities":  [
                                               "native-runtime-architecture"
                                           ]
+                     },
+                     {
+                         "archivedOn":  "2026-08-01",
+                         "changeName":  "fix-terminal-usage-integrity",
+                         "path":  "openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/",
+                         "artifacts":  [
+                                           "proposal",
+                                           "design",
+                                           "tasks"
+                                       ],
+                         "capabilities":  [
+                                              "agent-execution-observability",
+                                              "agent-terminal-runtime",
+                                              "usage-statistics"
+                                          ]
                      }
                  ]
 }

--- a/openspec/specs/agent-execution-observability/spec.md
+++ b/openspec/specs/agent-execution-observability/spec.md
@@ -16,12 +16,23 @@ The system SHALL create one execution run with independent run, trace, and root 
 - **THEN** the system SHALL create the same execution-run contract with the corresponding source classification
 
 ### Requirement: Correlated execution topology
-The system SHALL represent task execution, prompt assembly, Agent invocation, managed child-process execution, stream milestones, tool activity, MCP activity, coordination nodes, failover attempts, and terminal outcome as one correlated trace when those stages occur.
+The system SHALL represent task execution, prompt assembly, Agent invocation, managed or interactive child-process execution, stream milestones, observable tool activity, observable MCP activity, coordination nodes, failover attempts, and terminal outcome as one correlated trace when those stages occur.
 
 #### Scenario: Agent CLI run completes
 - **WHEN** a submitted task invokes a managed Agent CLI process and completes
 - **THEN** the trace SHALL contain correlated Agent and process lifecycle spans or events with start, terminal status, and duration
 - **AND** the run SHALL retain safe links to the existing operation and provider runtime-session identifiers when available
+
+#### Scenario: Interactive Agent terminal process completes
+- **WHEN** the desktop runtime starts an embedded interactive Agent terminal and its PTY process later exits or is stopped
+- **THEN** the trace SHALL contain correlated Session, Agent, opaque Tool/MCP boundary, and Process Exec lifecycle spans with terminal status and duration
+- **AND** the run SHALL retain safe session, stable Agent, and provider runtime-session identifiers when available
+- **AND** it SHALL omit terminal content, full paths, raw command arguments, and environment values
+
+#### Scenario: Interactive child details are unavailable
+- **WHEN** an interactive terminal's TUI does not expose structured tool or MCP lifecycle data
+- **THEN** the runtime SHALL emit only the known terminal Tool/MCP boundary with `opaque` fidelity and SHALL NOT invent concrete tool-call or MCP-operation child spans
+- **AND** observation capability SHALL remain `opaque` or `inferred` according to the available evidence
 
 #### Scenario: Parallel or delegated work is observed
 - **WHEN** the runtime observes delegated, retried, parallel, or child-Agent work

--- a/openspec/specs/agent-terminal-runtime/spec.md
+++ b/openspec/specs/agent-terminal-runtime/spec.md
@@ -77,7 +77,7 @@ The Agent Terminal runtime SHALL persist provider runtime session ids when avail
 - **THEN** the desktop runtime SHALL start a fresh Agent CLI process for the selected stable agent id
 
 ### Requirement: Retained terminal lifecycle
-The desktop runtime SHALL retain Agent Terminal processes across session switching and page closure, then stop inactive processes after two hours or during application shutdown.
+The desktop runtime SHALL retain Agent Terminal processes across session switching and page closure, then stop inactive processes after two hours or during application shutdown, including all terminal-owned background workers.
 
 #### Scenario: Switch session keeps process
 - **WHEN** the user switches away from a session with a live Agent Terminal process
@@ -109,18 +109,29 @@ The desktop runtime SHALL retain Agent Terminal processes across session switchi
 - **THEN** the frontend SHALL paint the cached terminal output before waiting for the native attach response
 - **AND** it SHALL avoid duplicating content when the native retained transcript replay arrives
 
+#### Scenario: Usage worker stops before final refresh
+- **WHEN** an Agent Terminal process exits or is stopped
+- **THEN** the runtime SHALL signal and join its periodic usage worker before starting the final usage refresh
+- **AND** an older periodic result SHALL NOT overwrite the final observation
+
 #### Scenario: Shutdown stops processes
 - **WHEN** the desktop application shuts down
-- **THEN** the native runtime SHALL stop all live Agent Terminal processes
+- **THEN** the native runtime SHALL stop all live Agent Terminal processes and terminal-owned background workers
+- **AND** it SHALL wait for child-process cleanup before releasing terminal state
 - **AND** it SHALL write redacted shutdown diagnostics through unified logging
 
 ### Requirement: Terminal output persistence boundary
-The first Agent Terminal version SHALL persist runtime session ids and redacted run diagnostics but SHALL NOT convert terminal transcript output into chat messages.
+The Agent Terminal runtime SHALL persist runtime session ids, reported usage, and redacted run diagnostics but SHALL NOT convert terminal transcript output or empty usage placeholders into chat messages.
 
 #### Scenario: Output is not written as messages
 - **WHEN** an Agent Terminal emits stdout or stderr content
 - **THEN** the desktop runtime SHALL display the content in the terminal stream
 - **AND** it SHALL NOT create or append `messages` rows for that transcript content
+
+#### Scenario: Empty usage does not create a streaming message
+- **WHEN** terminal usage polling has not found a non-zero provider observation
+- **THEN** the runtime SHALL NOT create an empty streaming assistant message for usage tracking
+- **AND** the session SHALL NOT remain in a streaming state because usage is unavailable
 
 #### Scenario: Diagnostics use unified logging
 - **WHEN** an Agent Terminal starts, fails, exits, is stopped by idle cleanup, or is stopped during shutdown

--- a/src-tauri/src/bootstrap/agent_runtime.rs
+++ b/src-tauri/src/bootstrap/agent_runtime.rs
@@ -20,7 +20,8 @@ use crate::contexts::agent_runtime::infrastructure::{
     RuntimeAgentSkillAdapter, RuntimeEffectivePromptAdapter, SessionsAgentRuntimeAdapter,
     SqliteAgentMemoryRepository, SqliteAgentRuntimeRepository, SqliteCoordinationRepository,
     SqliteLoopRepository, StructuredLoopVerificationProcess, SystemAgentRuntimeClock,
-    TauriAgentRuntimeEventAdapter, UuidCoordinationIds, WorkspaceLoopProjectAdapter,
+    TauriAgentRuntimeEventAdapter, TerminalExecutionObservability, UuidCoordinationIds,
+    WorkspaceLoopProjectAdapter,
 };
 use crate::contexts::execution_observability::api::ExecutionTelemetryPort;
 use crate::contexts::execution_observability::infrastructure::{
@@ -150,6 +151,11 @@ pub(crate) fn assemble_agent_runtime_api(
         sessions.clone(),
         logging.clone(),
         clock.clone(),
+        TerminalExecutionObservability::new(
+            execution_ids.clone(),
+            timeline.clone(),
+            telemetry.clone(),
+        ),
         std::env::temp_dir().join("vanehub-agent-terminal-wrappers"),
     ));
     let loop_completions = Arc::new(InMemoryLoopRoleGenerationCompletions::default());

--- a/src-tauri/src/contexts/agent_runtime/application/ports.rs
+++ b/src-tauri/src/contexts/agent_runtime/application/ports.rs
@@ -322,6 +322,14 @@ pub(crate) trait AgentSessionGateway: Send + Sync {
         message_id: &str,
     ) -> Result<Option<AgentMessage>, AgentRuntimeApplicationError>;
 
+    fn find_terminal_usage_message(
+        &self,
+        _session_id: &str,
+        _agent_id: &str,
+    ) -> Result<Option<String>, AgentRuntimeApplicationError> {
+        Ok(None)
+    }
+
     fn append_content(
         &self,
         message_id: &str,

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/mod.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/mod.rs
@@ -32,6 +32,7 @@ mod schema;
 mod sessions_gateway;
 mod skill_gateway;
 mod sqlite_repository;
+mod terminal_observability;
 mod terminal_process;
 mod terminal_usage_ingestion;
 mod terminal_wrapper;
@@ -71,6 +72,7 @@ pub(crate) use schema::{apply_api_agent_schema, apply_openai_compatible_schema, 
 pub(crate) use sessions_gateway::SessionsAgentRuntimeAdapter;
 pub(crate) use skill_gateway::RuntimeAgentSkillAdapter;
 pub(crate) use sqlite_repository::SqliteAgentRuntimeRepository;
+pub(crate) use terminal_observability::TerminalExecutionObservability;
 pub(crate) use terminal_process::PortablePtyAgentTerminalRuntime;
 
 #[cfg(test)]

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/mod.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use output::{
     ProviderToolPhase,
 };
 pub(crate) use session_capture::{
-    codex_session_root, find_codex_rollout_since, find_gemini_chat_session_since,
+    codex_session_root, find_codex_rollout_since, find_gemini_chat_session,
     find_opencode_session_since, opencode_database_path, prepare_provider_session_capture,
     ProviderSessionCapture, ProviderSessionDiscovery,
 };

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/session_capture.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/session_capture.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -283,6 +283,12 @@ struct GeminiProjectsRegistry {
     projects: HashMap<String, String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct GeminiSessionMetadata {
+    #[serde(rename = "sessionId")]
+    session_id: Option<String>,
+}
+
 /// Post-hoc lookup for gemini-cli's own `ChatRecordingService` output, following the
 /// same working-directory + start-time pattern as `find_opencode_session_since` /
 /// `find_codex_rollout_since`. gemini-cli has no live `ProviderSessionCapture` poll to
@@ -296,46 +302,72 @@ struct GeminiProjectsRegistry {
 /// / `Storage.getProjectIdentifier`). This recently replaced an older pure-hash scheme
 /// (per a source comment: "Performs migration of legacy hash-based directories to the
 /// new slug-based format"), so no hash-based assumption is used here.
-pub(crate) fn find_gemini_chat_session_since(
+pub(crate) fn find_gemini_chat_session(
     working_directory: &Path,
-    since_ms: i64,
+    runtime_session_id: &str,
 ) -> Result<Option<PathBuf>, ProviderSessionCaptureError> {
     let Some(registry_path) = gemini_projects_registry_path() else {
         return Ok(None);
     };
-    let Some(slug) = read_gemini_project_slug(&registry_path, working_directory)? else {
+    let Some(gemini_home) = gemini_home_dir() else {
         return Ok(None);
     };
-    let Some(gemini_home) = gemini_home_dir() else {
+    find_gemini_chat_session_in_home(
+        &gemini_home,
+        &registry_path,
+        working_directory,
+        runtime_session_id,
+    )
+}
+
+pub(super) fn find_gemini_chat_session_in_home(
+    gemini_home: &Path,
+    registry_path: &Path,
+    working_directory: &Path,
+    runtime_session_id: &str,
+) -> Result<Option<PathBuf>, ProviderSessionCaptureError> {
+    let runtime_session_id = runtime_session_id.trim();
+    if runtime_session_id.is_empty() {
+        return Ok(None);
+    }
+    let Some(slug) = read_gemini_project_slug(registry_path, working_directory)? else {
         return Ok(None);
     };
     let chats_dir = gemini_home.join("tmp").join(slug).join("chats");
     if !chats_dir.exists() {
         return Ok(None);
     }
-    let since = UNIX_EPOCH + Duration::from_millis(since_ms.saturating_sub(2_000).max(0) as u64);
-    let mut candidates: Vec<(SystemTime, PathBuf)> = Vec::new();
+    let mut candidates = Vec::new();
     let entries = fs::read_dir(&chats_dir).map_err(|error| capture_error("Gemini", error))?;
     for entry in entries {
         let entry = entry.map_err(|error| capture_error("Gemini", error))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|error| capture_error("Gemini", error))?;
+        if !file_type.is_file() {
+            continue;
+        }
         let path = entry.path();
         let is_chat_file = path
             .file_name()
             .and_then(|name| name.to_str())
-            .is_some_and(|name| name.ends_with(".jsonl"));
+            .is_some_and(|name| name.starts_with("session-") && name.ends_with(".jsonl"));
         if !is_chat_file {
             continue;
         }
-        let modified = fs::metadata(&path)
-            .and_then(|metadata| metadata.modified())
-            .map_err(|error| capture_error("Gemini", error))?;
-        if modified < since {
-            continue;
+        if read_gemini_session_id(&path)?.as_deref() == Some(runtime_session_id) {
+            candidates.push(path);
         }
-        candidates.push((modified, path));
     }
-    candidates.sort_by_key(|(modified, _)| *modified);
-    Ok(candidates.pop().map(|(_, path)| path))
+    match candidates.len() {
+        0 => Ok(None),
+        1 => Ok(candidates.pop()),
+        count => Err(ProviderSessionCaptureError {
+            message: format!(
+                "Gemini session metadata is ambiguous: {count} chat files share one runtime session id"
+            ),
+        }),
+    }
 }
 
 pub(super) fn read_gemini_project_slug(
@@ -354,7 +386,28 @@ pub(super) fn read_gemini_project_slug(
         .projects
         .into_iter()
         .find(|(project_path, _)| paths_match(Path::new(project_path), working_directory))
-        .map(|(_, slug)| slug))
+        .map(|(_, slug)| slug)
+        .filter(|slug| valid_gemini_project_slug(slug)))
+}
+
+fn valid_gemini_project_slug(slug: &str) -> bool {
+    let mut components = Path::new(slug).components();
+    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
+}
+
+fn read_gemini_session_id(path: &Path) -> Result<Option<String>, ProviderSessionCaptureError> {
+    let file = File::open(path).map_err(|error| capture_error("Gemini", error))?;
+    let mut lines = BufReader::new(file).lines();
+    let Some(line) = lines.next() else {
+        return Ok(None);
+    };
+    let line = line.map_err(|error| capture_error("Gemini", error))?;
+    let Ok(metadata) = serde_json::from_str::<GeminiSessionMetadata>(&line) else {
+        return Ok(None);
+    };
+    Ok(metadata
+        .session_id
+        .filter(|session_id| !session_id.trim().is_empty()))
 }
 
 /// `~/.gemini`, exactly as gemini-cli's own `Storage.getGlobalGeminiDir()` resolves it

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/session_capture_tests.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/session_capture_tests.rs
@@ -1,6 +1,7 @@
 use super::session_capture::{
     capture_codex_baseline, capture_opencode_baseline, discover_codex_session,
-    discover_opencode_session, read_gemini_project_slug, ProviderSessionDiscovery,
+    discover_opencode_session, find_gemini_chat_session_in_home, read_gemini_project_slug,
+    ProviderSessionDiscovery,
 };
 use rusqlite::Connection;
 use serde_json::json;
@@ -222,6 +223,101 @@ fn gemini_project_slug_missing_registry_file_is_graceful() {
 
     let slug =
         read_gemini_project_slug(&registry_path, &root.join("aiproject")).expect("read registry");
+
+    assert_eq!(slug, None);
+    fs::remove_dir_all(root).expect("remove temp directory");
+}
+
+fn write_gemini_chat(gemini_home: &Path, slug: &str, name: &str, session_id: Option<&str>) {
+    let chats = gemini_home.join("tmp").join(slug).join("chats");
+    fs::create_dir_all(&chats).expect("create chats directory");
+    let metadata = session_id
+        .map(|session_id| json!({ "sessionId": session_id, "projectHash": "fixture" }).to_string())
+        .unwrap_or_else(|| "{not-json".to_string());
+    fs::write(chats.join(name), format!("{metadata}\n")).expect("write chat fixture");
+}
+
+#[test]
+fn gemini_chat_lookup_uses_exact_runtime_session_id() {
+    let root = temp_directory("gemini-exact-session");
+    let gemini_home = root.join(".gemini");
+    let project = root.join("project");
+    let registry_path = gemini_home.join("projects.json");
+    fs::create_dir_all(&gemini_home).expect("create gemini home");
+    write_gemini_projects_registry(&registry_path, &[(&project, "project")]);
+    write_gemini_chat(
+        &gemini_home,
+        "project",
+        "session-newer-wrong.jsonl",
+        Some("runtime-wrong"),
+    );
+    write_gemini_chat(
+        &gemini_home,
+        "project",
+        "session-exact.jsonl",
+        Some("runtime-exact"),
+    );
+
+    let found =
+        find_gemini_chat_session_in_home(&gemini_home, &registry_path, &project, "runtime-exact")
+            .expect("lookup")
+            .expect("exact session");
+
+    assert_eq!(
+        found.file_name().and_then(|name| name.to_str()),
+        Some("session-exact.jsonl")
+    );
+    fs::remove_dir_all(root).expect("remove temp directory");
+}
+
+#[test]
+fn gemini_chat_lookup_rejects_missing_and_ambiguous_session_ids() {
+    let root = temp_directory("gemini-session-edge-cases");
+    let gemini_home = root.join(".gemini");
+    let project = root.join("project");
+    let registry_path = gemini_home.join("projects.json");
+    fs::create_dir_all(&gemini_home).expect("create gemini home");
+    write_gemini_projects_registry(&registry_path, &[(&project, "project")]);
+    write_gemini_chat(
+        &gemini_home,
+        "project",
+        "session-one.jsonl",
+        Some("runtime-duplicate"),
+    );
+    write_gemini_chat(
+        &gemini_home,
+        "project",
+        "session-two.jsonl",
+        Some("runtime-duplicate"),
+    );
+
+    assert!(find_gemini_chat_session_in_home(
+        &gemini_home,
+        &registry_path,
+        &project,
+        "runtime-missing",
+    )
+    .expect("missing lookup")
+    .is_none());
+    let error = find_gemini_chat_session_in_home(
+        &gemini_home,
+        &registry_path,
+        &project,
+        "runtime-duplicate",
+    )
+    .expect_err("ambiguous lookup must fail");
+    assert!(error.to_string().contains("ambiguous"));
+    fs::remove_dir_all(root).expect("remove temp directory");
+}
+
+#[test]
+fn gemini_project_slug_rejects_path_components() {
+    let root = temp_directory("gemini-invalid-slug");
+    let project = root.join("project");
+    let registry_path = root.join("projects.json");
+    write_gemini_projects_registry(&registry_path, &[(&project, "../escape")]);
+
+    let slug = read_gemini_project_slug(&registry_path, &project).expect("read registry");
 
     assert_eq!(slug, None);
     fs::remove_dir_all(root).expect("remove temp directory");

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/sessions_gateway.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/sessions_gateway.rs
@@ -183,6 +183,16 @@ impl AgentSessionGateway for SessionsAgentRuntimeAdapter {
             .map_err(session_error)
     }
 
+    fn find_terminal_usage_message(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+    ) -> Result<Option<String>, AgentRuntimeApplicationError> {
+        self.sessions
+            .terminal_usage_message_id(session_id, agent_id)
+            .map_err(session_error)
+    }
+
     fn append_content(
         &self,
         message_id: &str,

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/terminal_observability.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/terminal_observability.rs
@@ -1,0 +1,268 @@
+use crate::contexts::agent_runtime::application::AgentClockPort;
+use crate::contexts::execution_observability::api::{
+    ExecutionContext, ExecutionFidelity, ExecutionIdentityPort, ExecutionRun,
+    ExecutionSettingsPort, ExecutionSource, ExecutionSpan, ExecutionStatus, ExecutionTelemetryPort,
+    ObservabilitySettings, SafeAttributeValue, SafeAttributes, SpanId,
+};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub(crate) struct TerminalExecutionObservability {
+    pub(super) execution_ids: Arc<dyn ExecutionIdentityPort>,
+    pub(super) execution_settings: Arc<dyn ExecutionSettingsPort>,
+    pub(super) telemetry: Arc<dyn ExecutionTelemetryPort>,
+}
+
+impl TerminalExecutionObservability {
+    pub(crate) fn new(
+        execution_ids: Arc<dyn ExecutionIdentityPort>,
+        execution_settings: Arc<dyn ExecutionSettingsPort>,
+        telemetry: Arc<dyn ExecutionTelemetryPort>,
+    ) -> Self {
+        Self {
+            execution_ids,
+            execution_settings,
+            telemetry,
+        }
+    }
+}
+
+pub(super) struct TerminalExecutionTrace {
+    pub(super) session: ExecutionContext,
+    agent: ExecutionContext,
+    tool: ExecutionContext,
+    pub(super) process: ExecutionContext,
+}
+
+pub(super) fn start_terminal_execution_trace(
+    execution_ids: &dyn ExecutionIdentityPort,
+    telemetry: &dyn ExecutionTelemetryPort,
+    clock: &dyn AgentClockPort,
+    settings: &ObservabilitySettings,
+    session_id: &str,
+    agent_id: &str,
+    provider_session_id: Option<&str>,
+) -> TerminalExecutionTrace {
+    let started_at = clock.now();
+    let session = execution_ids.next_context(
+        settings.capture_policy,
+        settings.sampling_ratio,
+        settings.mcp_relay_enabled,
+    );
+    let agent = child_context(&session, execution_ids.next_span_id());
+    let tool = child_context(&agent, execution_ids.next_span_id());
+    let process = child_context(&tool, execution_ids.next_span_id());
+    let attributes = safe_attributes(agent_id);
+    let _ = telemetry.start_run(&ExecutionRun {
+        context: session.clone(),
+        source: ExecutionSource::Desktop,
+        status: ExecutionStatus::Running,
+        started_at: started_at.clone(),
+        ended_at: None,
+        error_classification: None,
+        session_id: Some(session_id.to_string()),
+        user_message_id: None,
+        assistant_message_id: None,
+        operation_id: None,
+        agent_id: Some(agent_id.to_string()),
+        provider_session_id: provider_session_id.map(str::to_string),
+        attributes: attributes.clone(),
+        links: Vec::new(),
+    });
+    for span in [
+        span(
+            session.clone(),
+            None,
+            "vanehub.session.agent_terminal",
+            ExecutionFidelity::Native,
+            &started_at,
+            attributes.clone(),
+        ),
+        span(
+            agent.clone(),
+            Some(session.span_id.clone()),
+            "vanehub.agent.terminal",
+            ExecutionFidelity::Native,
+            &started_at,
+            attributes.clone(),
+        ),
+        span(
+            tool.clone(),
+            Some(agent.span_id.clone()),
+            "vanehub.tool.terminal_cli",
+            ExecutionFidelity::Opaque,
+            &started_at,
+            attributes.clone(),
+        ),
+        span(
+            process.clone(),
+            Some(tool.span_id.clone()),
+            "vanehub.process.exec",
+            ExecutionFidelity::Native,
+            &started_at,
+            attributes,
+        ),
+    ] {
+        let _ = telemetry.start_span(&span);
+    }
+    TerminalExecutionTrace {
+        session,
+        agent,
+        tool,
+        process,
+    }
+}
+
+pub(super) fn finish_terminal_execution_trace(
+    telemetry: &dyn ExecutionTelemetryPort,
+    clock: &dyn AgentClockPort,
+    trace: &TerminalExecutionTrace,
+    status: ExecutionStatus,
+    error_classification: Option<&str>,
+) {
+    let ended_at = clock.now();
+    for context in [&trace.process, &trace.tool, &trace.agent, &trace.session] {
+        let _ = telemetry.finish_span(
+            &context.run_id,
+            &context.span_id,
+            status,
+            &ended_at,
+            error_classification,
+        );
+    }
+    let _ = telemetry.finish_run(
+        &trace.session.run_id,
+        status,
+        &ended_at,
+        error_classification,
+    );
+}
+
+fn span(
+    context: ExecutionContext,
+    parent_span_id: Option<SpanId>,
+    name: &str,
+    fidelity: ExecutionFidelity,
+    started_at: &str,
+    attributes: SafeAttributes,
+) -> ExecutionSpan {
+    ExecutionSpan {
+        context,
+        parent_span_id,
+        name: name.to_string(),
+        status: ExecutionStatus::Running,
+        fidelity,
+        started_at: started_at.to_string(),
+        ended_at: None,
+        error_classification: None,
+        attributes,
+        links: Vec::new(),
+    }
+}
+
+fn child_context(parent: &ExecutionContext, span_id: SpanId) -> ExecutionContext {
+    ExecutionContext {
+        run_id: parent.run_id.clone(),
+        trace_id: parent.trace_id.clone(),
+        span_id,
+        capture_policy: parent.capture_policy,
+        sampling_per_million: parent.sampling_per_million,
+        mcp_relay_enabled: parent.mcp_relay_enabled,
+    }
+}
+
+fn safe_attributes(agent_id: &str) -> SafeAttributes {
+    SafeAttributes::try_from_entries([
+        (
+            "vanehub.stage".to_string(),
+            SafeAttributeValue::String("agent_terminal".to_string()),
+        ),
+        (
+            "vanehub.agent.id".to_string(),
+            SafeAttributeValue::String(agent_id.to_string()),
+        ),
+    ])
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contexts::execution_observability::application::test_adapter::{
+        CapturedTelemetryRecord, CapturingExecutionTelemetry,
+    };
+    use crate::contexts::execution_observability::infrastructure::RandomExecutionIdentity;
+
+    struct FixedClock;
+
+    impl AgentClockPort for FixedClock {
+        fn now(&self) -> String {
+            "2026-08-01T10:00:00+00:00".to_string()
+        }
+    }
+
+    #[test]
+    fn preserves_session_agent_tool_process_hierarchy() {
+        let telemetry = CapturingExecutionTelemetry::default();
+        let trace = start_terminal_execution_trace(
+            &RandomExecutionIdentity,
+            &telemetry,
+            &FixedClock,
+            &Default::default(),
+            "session-1",
+            "codex-cli",
+            Some("provider-session-1"),
+        );
+        finish_terminal_execution_trace(
+            &telemetry,
+            &FixedClock,
+            &trace,
+            ExecutionStatus::Succeeded,
+            None,
+        );
+
+        let records = telemetry.records().expect("telemetry records");
+        let started = records
+            .iter()
+            .filter_map(|record| match record {
+                CapturedTelemetryRecord::SpanStarted(span) => Some(span),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(started.len(), 4);
+        assert_eq!(started[0].name, "vanehub.session.agent_terminal");
+        assert_eq!(started[0].parent_span_id, None);
+        assert_eq!(started[1].name, "vanehub.agent.terminal");
+        assert_eq!(
+            started[1].parent_span_id,
+            Some(started[0].context.span_id.clone())
+        );
+        assert_eq!(started[2].name, "vanehub.tool.terminal_cli");
+        assert_eq!(started[2].fidelity, ExecutionFidelity::Opaque);
+        assert_eq!(
+            started[2].parent_span_id,
+            Some(started[1].context.span_id.clone())
+        );
+        assert_eq!(started[3].name, "vanehub.process.exec");
+        assert_eq!(
+            started[3].parent_span_id,
+            Some(started[2].context.span_id.clone())
+        );
+        assert_eq!(
+            started[3]
+                .attributes
+                .entries()
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec!["vanehub.agent.id".to_string(), "vanehub.stage".to_string()]
+        );
+        assert!(matches!(
+            records.last(),
+            Some(CapturedTelemetryRecord::RunFinished {
+                status: ExecutionStatus::Succeeded,
+                ..
+            })
+        ));
+    }
+}

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/terminal_process.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/terminal_process.rs
@@ -2,9 +2,13 @@ use super::providers::{
     build_interactive_invocation, output_parser_for, prepare_provider_session_capture,
     ProviderOutputEvent, ProviderSessionCapture, ProviderSessionDiscovery,
 };
+use super::terminal_observability::{
+    finish_terminal_execution_trace, start_terminal_execution_trace,
+    TerminalExecutionObservability, TerminalExecutionTrace,
+};
 use super::terminal_usage_ingestion::{
-    create_terminal_usage_placeholder, ingest_claude_terminal_usage, ingest_codex_terminal_usage,
-    ingest_gemini_terminal_usage, ingest_opencode_terminal_usage,
+    ingest_claude_terminal_usage, ingest_codex_terminal_usage, ingest_gemini_terminal_usage,
+    ingest_opencode_terminal_usage, load_terminal_usage_message_id,
 };
 use super::terminal_wrapper::{
     default_agent_terminal_shell, generate_agent_terminal_wrapper, AgentTerminalWrapperRequest,
@@ -17,6 +21,7 @@ use crate::contexts::agent_runtime::application::{
     StopAgentTerminalRequest,
 };
 use crate::contexts::agent_runtime::domain::AgentLifecycle;
+use crate::contexts::execution_observability::api::ExecutionStatus;
 use crate::platform::filesystem::normalize_windows_extended_length_path;
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use std::collections::HashMap;
@@ -66,6 +71,7 @@ pub(crate) struct PortablePtyAgentTerminalRuntime {
     sessions: Arc<dyn AgentSessionGateway>,
     logging: Arc<dyn AgentLoggingPort>,
     clock: Arc<dyn AgentClockPort>,
+    observability: TerminalExecutionObservability,
     wrapper_dir: PathBuf,
 }
 
@@ -75,6 +81,7 @@ impl PortablePtyAgentTerminalRuntime {
         sessions: Arc<dyn AgentSessionGateway>,
         logging: Arc<dyn AgentLoggingPort>,
         clock: Arc<dyn AgentClockPort>,
+        observability: TerminalExecutionObservability,
         wrapper_dir: PathBuf,
     ) -> Self {
         Self {
@@ -84,6 +91,7 @@ impl PortablePtyAgentTerminalRuntime {
             sessions,
             logging,
             clock,
+            observability,
             wrapper_dir,
         }
     }
@@ -126,6 +134,35 @@ impl PortablePtyAgentTerminalRuntime {
             span_id: None,
             occurred_at: self.clock.now(),
         });
+    }
+
+    fn start_terminal_execution(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        provider_session_id: Option<&str>,
+    ) -> TerminalExecutionTrace {
+        let settings = match self.observability.execution_settings.load_settings() {
+            Ok(settings) => settings,
+            Err(error) => {
+                self.record_log(
+                    AgentLogLevel::Warn,
+                    format!("Execution observability settings are unavailable: {error}"),
+                    Some(agent_id),
+                    Some(session_id),
+                );
+                Default::default()
+            }
+        };
+        start_terminal_execution_trace(
+            self.observability.execution_ids.as_ref(),
+            self.observability.telemetry.as_ref(),
+            self.clock.as_ref(),
+            &settings,
+            session_id,
+            agent_id,
+            provider_session_id,
+        )
     }
 }
 
@@ -316,7 +353,7 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
         if let Some(folder) = normalized_folder.as_deref() {
             command.cwd(folder);
         }
-        let child = pair.slave.spawn_command(command).map_err(|error| {
+        let mut child = pair.slave.spawn_command(command).map_err(|error| {
             let message = format!(
                 "Failed to spawn Agent terminal process for {}: {error}",
                 redacted_command
@@ -330,31 +367,44 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
             AgentRuntimeApplicationError::Process(message)
         })?;
         drop(pair.slave);
-        let mut reader = pair.master.try_clone_reader().map_err(|error| {
-            let message = format!("Failed to attach Agent terminal reader: {error}");
-            self.record_log(
-                AgentLogLevel::Error,
-                message.clone(),
-                Some(&request.agent.id),
-                Some(&request.session.id),
-            );
-            AgentRuntimeApplicationError::Process(message)
-        })?;
-        let writer = pair.master.take_writer().map_err(|error| {
-            let message = format!("Failed to attach Agent terminal writer: {error}");
-            self.record_log(
-                AgentLogLevel::Error,
-                message.clone(),
-                Some(&request.agent.id),
-                Some(&request.session.id),
-            );
-            AgentRuntimeApplicationError::Process(message)
-        })?;
+        let mut reader = match pair.master.try_clone_reader() {
+            Ok(reader) => reader,
+            Err(error) => {
+                cleanup_unattached_terminal_child(child.as_mut());
+                let message = format!("Failed to attach Agent terminal reader: {error}");
+                self.record_log(
+                    AgentLogLevel::Error,
+                    message.clone(),
+                    Some(&request.agent.id),
+                    Some(&request.session.id),
+                );
+                return Err(AgentRuntimeApplicationError::Process(message));
+            }
+        };
+        let writer = match pair.master.take_writer() {
+            Ok(writer) => writer,
+            Err(error) => {
+                cleanup_unattached_terminal_child(child.as_mut());
+                let message = format!("Failed to attach Agent terminal writer: {error}");
+                self.record_log(
+                    AgentLogLevel::Error,
+                    message.clone(),
+                    Some(&request.agent.id),
+                    Some(&request.session.id),
+                );
+                return Err(AgentRuntimeApplicationError::Process(message));
+            }
+        };
         let child = Arc::new(Mutex::new(child));
         let runtime_session_id =
             non_empty_runtime_session_id(request.session.runtime_session_id.as_deref())
                 .map(str::to_string)
                 .or_else(|| invocation.assigned_runtime_session_id.clone());
+        let terminal_execution = self.start_terminal_execution(
+            &request.session.id,
+            &request.agent.id,
+            runtime_session_id.as_deref(),
+        );
         let terminal = ManagedAgentTerminal {
             terminal_id: terminal_id.clone(),
             session_id: request.session.id.clone(),
@@ -374,6 +424,7 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
         let sessions = self.sessions.clone();
         let logging = self.logging.clone();
         let clock = self.clock.clone();
+        let telemetry = self.observability.telemetry.clone();
         let terminals = self.terminals.clone();
         let session_id = request.session.id;
         let agent_id = request.agent.id;
@@ -384,23 +435,25 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
             .filter(|f| !f.trim().is_empty())
             .map(str::to_string);
         let started_at_ms = now_timestamp_ms(self.clock.as_ref());
-        // Created once, up front, so both the periodic poll below and the final
-        // exit-time read reuse the same message id — required for `upsert_usage`'s
-        // `ON CONFLICT(message_id)` to update one row instead of one per poll.
+        // Recover the backing row when a terminal is restarted. When no row exists,
+        // the first non-zero usage sample creates it lazily so opening and closing an
+        // idle terminal does not leave a ghost assistant message in the transcript.
         let usage_tracking_message_id = if matches!(
             agent_id.as_str(),
             "claude-code" | "opencode" | "codex-cli" | "gemini-cli"
         ) {
-            match create_terminal_usage_placeholder(sessions.as_ref(), &session_id) {
-                Ok(message_id) => Some(message_id),
+            match load_terminal_usage_message_id(sessions.as_ref(), &session_id, &agent_id) {
+                Ok(message_id) => Some(Arc::new(Mutex::new(message_id))),
                 Err(error) => {
                     self.record_log(
                         AgentLogLevel::Warn,
-                        format!("Failed to create terminal usage placeholder message: {error}"),
+                        format!("Failed to recover terminal usage message: {error}"),
                         Some(&agent_id),
                         Some(&session_id),
                     );
-                    None
+                    // Keep tracking enabled: persistence retries the lookup before it
+                    // creates a replacement row, preserving restart idempotency.
+                    Some(Arc::new(Mutex::new(None)))
                 }
             }
         } else {
@@ -415,7 +468,7 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
         // of output (or exit). This timer thread is intentionally independent of PTY
         // activity so it keeps checking on a fixed cadence regardless.
         let usage_poll_alive = Arc::new(AtomicBool::new(true));
-        if let Some(message_id) = usage_tracking_message_id.clone() {
+        let usage_poll_handle = if let Some(message_id) = usage_tracking_message_id.clone() {
             let agent_id = agent_id.clone();
             let session_folder = session_folder.clone();
             let runtime_session_id = runtime_session_id.clone();
@@ -424,19 +477,19 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
             let clock = clock.clone();
             let session_id = session_id.clone();
             let alive = usage_poll_alive.clone();
-            thread::spawn(move || {
+            Some(thread::spawn(move || {
                 // Ticks in short increments so the thread notices the terminal has
                 // exited promptly instead of sleeping a full interval before checking.
                 const TICK: Duration = Duration::from_millis(250);
                 let mut waited = Duration::ZERO;
-                while alive.load(Ordering::Relaxed) {
+                while alive.load(Ordering::Acquire) {
                     thread::sleep(TICK);
                     waited += TICK;
                     if waited < TERMINAL_USAGE_POLL_INTERVAL {
                         continue;
                     }
                     waited = Duration::ZERO;
-                    if !alive.load(Ordering::Relaxed) {
+                    if !alive.load(Ordering::Acquire) {
                         break;
                     }
                     let result = run_terminal_usage_ingestion(
@@ -445,7 +498,7 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
                         runtime_session_id.as_deref(),
                         started_at_ms,
                         sessions.as_ref(),
-                        &message_id,
+                        message_id.as_ref(),
                         &session_id,
                         clock.as_ref(),
                     );
@@ -460,8 +513,10 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
                         );
                     }
                 }
-            });
-        }
+            }))
+        } else {
+            None
+        };
         drop(terminal_registry);
         thread::spawn(move || {
             let parser = output_parser_for(&agent_id);
@@ -588,7 +643,16 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
 
             // Stop the independent usage-poll thread now that the terminal has
             // definitely exited, so it doesn't race the exit-time read below.
-            usage_poll_alive.store(false, Ordering::Relaxed);
+            if stop_terminal_usage_poll(usage_poll_alive.as_ref(), usage_poll_handle) {
+                record_provider_session_capture_log(
+                    logging.as_ref(),
+                    clock.as_ref(),
+                    AgentLogLevel::Warn,
+                    "Terminal usage polling thread panicked before shutdown.".to_string(),
+                    &agent_id,
+                    &session_id,
+                );
+            }
             let exit_result = child
                 .lock()
                 .map_err(|error| error.to_string())
@@ -611,14 +675,14 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
             // — that poll only samples while fresh PTY output is arriving, so it can miss
             // a session whose own log/DB row appears after the last visible output but
             // before Stop.
-            if let Some(message_id) = usage_tracking_message_id.as_deref() {
+            if let Some(message_id) = usage_tracking_message_id.as_ref() {
                 let result = run_terminal_usage_ingestion(
                     &agent_id,
                     session_folder.as_deref(),
                     runtime_session_id.as_deref(),
                     started_at_ms,
                     sessions.as_ref(),
-                    message_id,
+                    message_id.as_ref(),
                     &session_id,
                     clock.as_ref(),
                 );
@@ -645,6 +709,18 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
                 AgentTerminalState::Failed => AgentLifecycle::Failed,
                 _ => AgentLifecycle::Stopped,
             };
+            let execution_status = match state {
+                AgentTerminalState::Failed => ExecutionStatus::Failed,
+                _ => ExecutionStatus::Succeeded,
+            };
+            let error_classification = error.as_ref().map(|_| "agent_terminal_process_failed");
+            finish_terminal_execution_trace(
+                telemetry.as_ref(),
+                clock.as_ref(),
+                &terminal_execution,
+                execution_status,
+                error_classification,
+            );
             let _ = sessions.update_lifecycle(&session_id, lifecycle);
             let _ = events.publish_terminal(AgentTerminalEvent::State {
                 terminal_id,
@@ -663,9 +739,9 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
                 agent_id: Some(agent_id),
                 session_id: Some(session_id),
                 operation_id: None,
-                run_id: None,
-                trace_id: None,
-                span_id: None,
+                run_id: Some(terminal_execution.session.run_id.as_str().to_string()),
+                trace_id: Some(terminal_execution.session.trace_id.as_str().to_string()),
+                span_id: Some(terminal_execution.process.span_id.as_str().to_string()),
                 occurred_at: clock.now(),
             });
         });
@@ -788,7 +864,7 @@ fn run_terminal_usage_ingestion(
     runtime_session_id: Option<&str>,
     started_at_ms: i64,
     sessions: &dyn AgentSessionGateway,
-    message_id: &str,
+    message_id: &Mutex<Option<String>>,
     session_id: &str,
     clock: &dyn AgentClockPort,
 ) -> Option<Result<bool, AgentRuntimeApplicationError>> {
@@ -822,15 +898,17 @@ fn run_terminal_usage_ingestion(
             agent_id,
             clock,
         )),
-        "gemini-cli" => Some(ingest_gemini_terminal_usage(
-            session_folder,
-            started_at_ms,
-            sessions,
-            message_id,
-            session_id,
-            agent_id,
-            clock,
-        )),
+        "gemini-cli" => runtime_session_id.map(|runtime_session_id| {
+            ingest_gemini_terminal_usage(
+                session_folder,
+                runtime_session_id,
+                sessions,
+                message_id,
+                session_id,
+                agent_id,
+                clock,
+            )
+        }),
         _ => None,
     }
 }
@@ -940,6 +1018,18 @@ fn terminate_terminal_child(
     }
     let _ = child.wait();
     Ok(())
+}
+
+fn cleanup_unattached_terminal_child(child: &mut dyn Child) {
+    if child.try_wait().ok().flatten().is_none() {
+        let _ = child.kill();
+    }
+    let _ = child.wait();
+}
+
+fn stop_terminal_usage_poll(alive: &AtomicBool, handle: Option<thread::JoinHandle<()>>) -> bool {
+    alive.store(false, Ordering::Release);
+    handle.map(|handle| handle.join().is_err()).unwrap_or(false)
 }
 
 fn agent_terminal_session(terminal: &ManagedAgentTerminal) -> AgentTerminalSession {
@@ -1379,6 +1469,32 @@ mod tests {
         assert!(transcript.len() <= RETAINED_TERMINAL_TRANSCRIPT_BYTES);
         assert!(transcript.is_char_boundary(0));
         assert!(!transcript.contains("older"));
+    }
+
+    #[test]
+    fn stopping_usage_poll_joins_before_returning() {
+        let alive = Arc::new(AtomicBool::new(true));
+        let finished = Arc::new(AtomicBool::new(false));
+        let worker_alive = alive.clone();
+        let worker_finished = finished.clone();
+        let handle = thread::spawn(move || {
+            while worker_alive.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+            worker_finished.store(true, Ordering::Release);
+        });
+
+        assert!(!stop_terminal_usage_poll(alive.as_ref(), Some(handle)));
+        assert!(finished.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn unattached_child_cleanup_waits_for_process_exit() {
+        let mut child = dummy_child();
+
+        cleanup_unattached_terminal_child(child.as_mut());
+
+        assert!(child.try_wait().expect("child status").is_some());
     }
 
     fn dummy_child() -> Box<dyn Child + Send + Sync> {

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/terminal_usage_ingestion.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/terminal_usage_ingestion.rs
@@ -1,5 +1,5 @@
 use super::providers::{
-    codex_session_root, find_codex_rollout_since, find_gemini_chat_session_since,
+    codex_session_root, find_codex_rollout_since, find_gemini_chat_session,
     find_opencode_session_since, opencode_database_path,
 };
 use crate::contexts::agent_runtime::application::{
@@ -8,9 +8,11 @@ use crate::contexts::agent_runtime::application::{
 };
 use rusqlite::{Connection, OpenFlags, OptionalExtension};
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::fs;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct TerminalUsageTotals {
@@ -22,14 +24,13 @@ struct TerminalUsageTotals {
 
 /// Reads the claude-code session JSONL and upserts one aggregated usage record under
 /// `message_id`. Safe to call repeatedly (e.g. every few seconds while the terminal is
-/// open, and once more at exit): `message_id` is a stable id created once per terminal
-/// session by `create_terminal_usage_placeholder`, so each call updates the same row
-/// via `upsert_usage`'s `ON CONFLICT(message_id)` instead of accumulating duplicates.
+/// open, and once more at exit): the shared message state is recovered across restarts
+/// and created only when non-zero usage exists, so each call updates the same row.
 pub(crate) fn ingest_claude_terminal_usage(
     session_folder: Option<&str>,
     runtime_session_id: &str,
     sessions: &dyn AgentSessionGateway,
-    message_id: &str,
+    message_id: &Mutex<Option<String>>,
     session_id: &str,
     agent_id: &str,
     clock: &dyn AgentClockPort,
@@ -60,13 +61,13 @@ pub(crate) fn ingest_claude_terminal_usage(
 /// only samples while fresh PTY output is arriving and can miss a session whose DB row
 /// appears after the last visible output, before the user stops the terminal). Doing
 /// the directory+time lookup here instead has no such race and is cheap enough to repeat
-/// on every periodic poll as well as once more at exit; `message_id` is the stable id
-/// from `create_terminal_usage_placeholder`, so repeated calls update the same row.
+/// on every periodic poll as well as once more at exit; repeated calls update the same
+/// recovered or lazily-created row.
 pub(crate) fn ingest_opencode_terminal_usage(
     session_folder: Option<&str>,
     started_at_ms: i64,
     sessions: &dyn AgentSessionGateway,
-    message_id: &str,
+    message_id: &Mutex<Option<String>>,
     session_id: &str,
     agent_id: &str,
     clock: &dyn AgentClockPort,
@@ -110,13 +111,13 @@ pub(crate) fn ingest_opencode_terminal_usage(
 ///
 /// Uses the same post-hoc lookup as opencode rather than `ProviderSessionCapture`'s
 /// live poll, for the same reason: no race, and cheap enough to repeat on every
-/// periodic poll as well as once more at exit; `message_id` is the stable id from
-/// `create_terminal_usage_placeholder`, so repeated calls update the same row.
+/// periodic poll as well as once more at exit; repeated calls update the same recovered
+/// or lazily-created row.
 pub(crate) fn ingest_codex_terminal_usage(
     session_folder: Option<&str>,
     started_at_ms: i64,
     sessions: &dyn AgentSessionGateway,
-    message_id: &str,
+    message_id: &Mutex<Option<String>>,
     session_id: &str,
     agent_id: &str,
     clock: &dyn AgentClockPort,
@@ -159,13 +160,12 @@ pub(crate) fn ingest_codex_terminal_usage(
 ///
 /// Uses the same post-hoc lookup as opencode/codex-cli; gemini-cli has no live
 /// `ProviderSessionCapture` poll to race against in the first place, so this is simply
-/// the only lookup. `message_id` is the stable id from
-/// `create_terminal_usage_placeholder`, so repeated calls update the same row.
+/// the only lookup. Repeated calls update the same recovered or lazily-created row.
 pub(crate) fn ingest_gemini_terminal_usage(
     session_folder: Option<&str>,
-    started_at_ms: i64,
+    runtime_session_id: &str,
     sessions: &dyn AgentSessionGateway,
-    message_id: &str,
+    message_id: &Mutex<Option<String>>,
     session_id: &str,
     agent_id: &str,
     clock: &dyn AgentClockPort,
@@ -176,7 +176,7 @@ pub(crate) fn ingest_gemini_terminal_usage(
     else {
         return Ok(false);
     };
-    let Some(chat_path) = find_gemini_chat_session_since(&cwd, started_at_ms)
+    let Some(chat_path) = find_gemini_chat_session(&cwd, runtime_session_id)
         .map_err(|e| AgentRuntimeApplicationError::Process(e.to_string()))?
     else {
         return Ok(false);
@@ -196,24 +196,12 @@ pub(crate) fn ingest_gemini_terminal_usage(
     )
 }
 
-/// Creates the placeholder assistant message that periodic and exit-time usage polls
-/// repeatedly update in place. A single stable id is required so `upsert_usage`'s
-/// `ON CONFLICT(message_id)` updates the same row on every poll instead of
-/// accumulating a new row every few seconds; `MessageStatus::can_transition_to`
-/// explicitly allows `Completed -> Completed`, so re-completing this same message
-/// on each poll is a valid, non-erroring transition.
-pub(crate) fn create_terminal_usage_placeholder(
+pub(crate) fn load_terminal_usage_message_id(
     sessions: &dyn AgentSessionGateway,
     session_id: &str,
-) -> Result<String, AgentRuntimeApplicationError> {
-    let message = sessions.create_message(NewAgentMessage {
-        session_id: session_id.to_string(),
-        role: "assistant".to_string(),
-        status: "streaming".to_string(),
-        content: String::new(),
-        file_references: Vec::new(),
-    })?;
-    Ok(message.id)
+    agent_id: &str,
+) -> Result<Option<String>, AgentRuntimeApplicationError> {
+    sessions.find_terminal_usage_message(session_id, agent_id)
 }
 
 /// Returns whether a usage record was actually persisted, so callers can log the
@@ -222,17 +210,47 @@ pub(crate) fn create_terminal_usage_placeholder(
 fn persist_terminal_usage(
     totals: TerminalUsageTotals,
     sessions: &dyn AgentSessionGateway,
-    message_id: &str,
+    message_id: &Mutex<Option<String>>,
     session_id: &str,
     agent_id: &str,
     source: &str,
     clock: &dyn AgentClockPort,
 ) -> Result<bool, AgentRuntimeApplicationError> {
-    if totals.input_tokens == 0 && totals.output_tokens == 0 {
+    if totals.input_tokens == 0
+        && totals.output_tokens == 0
+        && totals.cache_read_tokens == 0
+        && totals.cache_creation_tokens == 0
+    {
         return Ok(false);
     }
+    let mut message_id = message_id.lock().map_err(|_| {
+        AgentRuntimeApplicationError::Process(
+            "Terminal usage message state is unavailable.".to_string(),
+        )
+    })?;
+    if message_id.is_none() {
+        *message_id = match sessions.find_terminal_usage_message(session_id, agent_id)? {
+            Some(existing) => Some(existing),
+            None => Some(
+                sessions
+                    .create_message(NewAgentMessage {
+                        session_id: session_id.to_string(),
+                        role: "assistant".to_string(),
+                        status: "completed".to_string(),
+                        content: String::new(),
+                        file_references: Vec::new(),
+                    })?
+                    .id,
+            ),
+        };
+    }
+    let message_id = message_id.clone().ok_or_else(|| {
+        AgentRuntimeApplicationError::Process(
+            "Failed to create terminal usage message.".to_string(),
+        )
+    })?;
     let usage = AgentUsageRecord {
-        message_id: message_id.to_string(),
+        message_id: message_id.clone(),
         session_id: session_id.to_string(),
         agent_id: agent_id.to_string(),
         provider_id: None,
@@ -245,8 +263,8 @@ fn persist_terminal_usage(
         source: source.to_string(),
         occurred_at: clock.now(),
     };
-    let _ = sessions.complete_message(CompleteAgentMessage {
-        message_id: message_id.to_string(),
+    sessions.complete_message(CompleteAgentMessage {
+        message_id,
         session_id: session_id.to_string(),
         content: String::new(),
         thinking_content: None,
@@ -257,7 +275,7 @@ fn persist_terminal_usage(
             output: totals.output_tokens,
         }),
         usage: Some(usage),
-    });
+    })?;
     Ok(true)
 }
 
@@ -472,12 +490,20 @@ fn aggregate_codex_usage(
 /// are skipped by the `type == "gemini"` filter below, same as `type: "user"` lines.
 #[derive(Debug, Deserialize)]
 struct GeminiChatMessageLine {
+    id: Option<String>,
     #[serde(rename = "type")]
     message_type: Option<String>,
     tokens: Option<GeminiMessageTokens>,
+    #[serde(rename = "$set")]
+    set: Option<GeminiSetRecord>,
 }
 
 #[derive(Debug, Deserialize)]
+struct GeminiSetRecord {
+    messages: Option<Vec<GeminiChatMessageLine>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 struct GeminiMessageTokens {
     input: Option<i64>,
     output: Option<i64>,
@@ -499,7 +525,7 @@ fn aggregate_gemini_usage(
     file: fs::File,
 ) -> Result<TerminalUsageTotals, AgentRuntimeApplicationError> {
     let reader = std::io::BufReader::new(file);
-    let mut totals = TerminalUsageTotals::default();
+    let mut messages: HashMap<String, Option<GeminiMessageTokens>> = HashMap::new();
     for line in reader.lines() {
         let line = line.map_err(|e| {
             AgentRuntimeApplicationError::Process(format!(
@@ -507,26 +533,48 @@ fn aggregate_gemini_usage(
                 path.display()
             ))
         })?;
-        let Ok(event) = serde_json::from_str::<GeminiChatMessageLine>(&line) else {
+        let Ok(record) = serde_json::from_str::<GeminiChatMessageLine>(&line) else {
             continue;
         };
-        if event.message_type.as_deref() != Some("gemini") {
-            continue;
-        }
-        let Some(tokens) = event.tokens else {
-            continue;
-        };
+        materialize_gemini_record(record, &mut messages);
+    }
+    let mut totals = TerminalUsageTotals::default();
+    for tokens in messages.into_values().flatten() {
         let input = tokens.input.unwrap_or(0).max(0);
-        let output = tokens.output.unwrap_or(0).max(0) + tokens.thoughts.unwrap_or(0).max(0);
+        let output = tokens
+            .output
+            .unwrap_or(0)
+            .max(0)
+            .saturating_add(tokens.thoughts.unwrap_or(0).max(0));
         let cached = tokens.cached.unwrap_or(0).max(0);
         if input == 0 && output == 0 && cached == 0 {
             continue;
         }
-        totals.input_tokens += input;
-        totals.output_tokens += output;
-        totals.cache_read_tokens += cached;
+        totals.input_tokens = totals.input_tokens.saturating_add(input);
+        totals.output_tokens = totals.output_tokens.saturating_add(output);
+        totals.cache_read_tokens = totals.cache_read_tokens.saturating_add(cached);
     }
     Ok(totals)
+}
+
+fn materialize_gemini_record(
+    record: GeminiChatMessageLine,
+    messages: &mut HashMap<String, Option<GeminiMessageTokens>>,
+) {
+    if let Some(snapshot) = record.set.and_then(|set| set.messages) {
+        messages.clear();
+        for message in snapshot {
+            materialize_gemini_record(message, messages);
+        }
+        return;
+    }
+    if record.message_type.as_deref() != Some("gemini") {
+        return;
+    }
+    let Some(id) = record.id.filter(|id| !id.trim().is_empty()) else {
+        return;
+    };
+    messages.insert(id, record.tokens);
 }
 
 #[cfg(test)]
@@ -537,14 +585,13 @@ mod tests {
     use std::io::Write;
     use std::sync::Mutex;
 
-    /// Minimal `AgentSessionGateway` fake exercising only the two methods the
-    /// terminal usage ingestion path calls, to verify that polling reuses a single
-    /// message id (one `create_message`, many `complete_message` calls) instead of
-    /// creating a fresh message every poll.
+    /// Minimal gateway fake for restart recovery and repeated-poll persistence.
     #[derive(Default)]
     struct FakeSessionGateway {
         created: Mutex<Vec<NewAgentMessage>>,
         completed: Mutex<Vec<CompleteAgentMessage>>,
+        existing: Mutex<Option<String>>,
+        fail_completion: bool,
     }
 
     impl AgentSessionGateway for FakeSessionGateway {
@@ -600,6 +647,14 @@ mod tests {
             })
         }
 
+        fn find_terminal_usage_message(
+            &self,
+            _session_id: &str,
+            _agent_id: &str,
+        ) -> Result<Option<String>, AgentRuntimeApplicationError> {
+            Ok(self.existing.lock().expect("existing").clone())
+        }
+
         fn find_message(
             &self,
             _message_id: &str,
@@ -643,6 +698,11 @@ mod tests {
             &self,
             message: CompleteAgentMessage,
         ) -> Result<AgentMessage, AgentRuntimeApplicationError> {
+            if self.fail_completion {
+                return Err(AgentRuntimeApplicationError::Process(
+                    "completion failed".to_string(),
+                ));
+            }
             self.completed
                 .lock()
                 .expect("completed")
@@ -706,25 +766,32 @@ mod tests {
     }
 
     #[test]
-    fn create_terminal_usage_placeholder_creates_exactly_one_streaming_message() {
+    fn zero_totals_do_not_create_a_backing_message() {
         let gateway = FakeSessionGateway::default();
+        let clock = FixedClock;
+        let message_id = Mutex::new(None);
 
-        let message_id = create_terminal_usage_placeholder(&gateway, "session-1").expect("create");
+        let persisted = persist_terminal_usage(
+            TerminalUsageTotals::default(),
+            &gateway,
+            &message_id,
+            "session-1",
+            "codex-cli",
+            "cli-session-log",
+            &clock,
+        )
+        .expect("zero totals still return Ok");
 
-        assert_eq!(message_id, "placeholder-message");
-        let created = gateway.created.lock().expect("created");
-        assert_eq!(created.len(), 1);
-        assert_eq!(created[0].session_id, "session-1");
-        assert_eq!(created[0].role, "assistant");
-        assert_eq!(created[0].status, "streaming");
+        assert!(!persisted);
+        assert!(gateway.created.lock().expect("created").is_empty());
+        assert!(gateway.completed.lock().expect("completed").is_empty());
     }
 
     #[test]
     fn repeated_persist_calls_with_the_same_message_id_update_in_place() {
         let gateway = FakeSessionGateway::default();
         let clock = FixedClock;
-        let message_id =
-            create_terminal_usage_placeholder(&gateway, "session-1").expect("placeholder");
+        let message_id = Mutex::new(None);
 
         let first = TerminalUsageTotals {
             input_tokens: 100,
@@ -762,35 +829,107 @@ mod tests {
 
         assert!(first_persisted);
         assert!(second_persisted);
-        // Exactly one placeholder message was ever created…
+        // Exactly one completed backing message was ever created…
         assert_eq!(gateway.created.lock().expect("created").len(), 1);
+        assert_eq!(
+            gateway.created.lock().expect("created")[0].status,
+            "completed"
+        );
         // …and both polls completed that same message id, letting the DB's
         // `ON CONFLICT(message_id)` upsert keep only the latest totals.
         let completed = gateway.completed.lock().expect("completed");
         assert_eq!(completed.len(), 2);
-        assert_eq!(completed[0].message_id, message_id);
-        assert_eq!(completed[1].message_id, message_id);
+        assert_eq!(completed[0].message_id, "placeholder-message");
+        assert_eq!(completed[1].message_id, "placeholder-message");
         assert_eq!(completed[1].usage.as_ref().expect("usage").input_count, 400);
     }
 
     #[test]
-    fn zero_totals_are_not_persisted_and_do_not_touch_the_gateway() {
-        let gateway = FakeSessionGateway::default();
+    fn restart_reuses_the_existing_terminal_usage_message() {
+        let gateway = FakeSessionGateway {
+            existing: Mutex::new(Some("persisted-message".to_string())),
+            ..Default::default()
+        };
         let clock = FixedClock;
+        let message_id = Mutex::new(None);
 
         let persisted = persist_terminal_usage(
-            TerminalUsageTotals::default(),
+            TerminalUsageTotals {
+                input_tokens: 1,
+                ..Default::default()
+            },
             &gateway,
-            "some-message-id",
+            &message_id,
             "session-1",
             "codex-cli",
             "cli-session-log",
             &clock,
         )
-        .expect("zero totals still return Ok");
+        .expect("existing row is reused");
 
-        assert!(!persisted);
-        assert!(gateway.completed.lock().expect("completed").is_empty());
+        assert!(persisted);
+        assert!(gateway.created.lock().expect("created").is_empty());
+        assert_eq!(
+            gateway.completed.lock().expect("completed")[0].message_id,
+            "persisted-message"
+        );
+    }
+
+    #[test]
+    fn cache_only_totals_are_persisted() {
+        let gateway = FakeSessionGateway::default();
+        let clock = FixedClock;
+        let message_id = Mutex::new(None);
+
+        let persisted = persist_terminal_usage(
+            TerminalUsageTotals {
+                cache_read_tokens: 5,
+                ..Default::default()
+            },
+            &gateway,
+            &message_id,
+            "session-1",
+            "codex-cli",
+            "cli-session-log",
+            &clock,
+        )
+        .expect("cache-only usage persists");
+
+        assert!(persisted);
+        assert_eq!(
+            gateway.completed.lock().expect("completed")[0]
+                .usage
+                .as_ref()
+                .expect("usage")
+                .cache_read_count,
+            5
+        );
+    }
+
+    #[test]
+    fn completion_failure_is_propagated() {
+        let gateway = FakeSessionGateway {
+            fail_completion: true,
+            ..Default::default()
+        };
+        let clock = FixedClock;
+        let message_id = Mutex::new(None);
+
+        let error = persist_terminal_usage(
+            TerminalUsageTotals {
+                input_tokens: 1,
+                ..Default::default()
+            },
+            &gateway,
+            &message_id,
+            "session-1",
+            "codex-cli",
+            "cli-session-log",
+            &clock,
+        )
+        .expect_err("persistence errors must not be swallowed");
+
+        assert!(error.to_string().contains("completion failed"));
     }
 
     #[test]
@@ -989,6 +1128,59 @@ mod tests {
         assert_eq!(totals.output_tokens, 100);
         assert_eq!(totals.cache_read_tokens, 10);
         assert_eq!(totals.cache_creation_tokens, 0);
+    }
+
+    #[test]
+    fn gemini_usage_keeps_only_the_latest_revision_for_each_message_id() {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        writeln!(
+            file,
+            r#"{{"id":"msg1","type":"gemini","tokens":{{"input":100,"output":20,"cached":5,"thoughts":10}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            r#"{{"id":"msg1","type":"gemini","toolCalls":[{{"id":"tool1"}}],"tokens":{{"input":100,"output":20,"cached":5,"thoughts":10}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            r#"{{"id":"msg2","type":"gemini","tokens":{{"input":50,"output":7,"cached":0,"thoughts":3}}}}"#
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let totals =
+            aggregate_gemini_usage(file.path(), std::fs::File::open(file.path()).expect("open"))
+                .expect("aggregate");
+
+        assert_eq!(totals.input_tokens, 150);
+        assert_eq!(totals.output_tokens, 40);
+        assert_eq!(totals.cache_read_tokens, 5);
+    }
+
+    #[test]
+    fn gemini_usage_set_messages_snapshot_replaces_prior_materialized_messages() {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        writeln!(
+            file,
+            r#"{{"id":"obsolete","type":"gemini","tokens":{{"input":900,"output":900}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            r#"{{"$set":{{"messages":[{{"id":"current","type":"gemini","tokens":{{"input":12,"output":8,"cached":2,"thoughts":1}}}},{{"id":"user","type":"user"}}]}}}}"#
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let totals =
+            aggregate_gemini_usage(file.path(), std::fs::File::open(file.path()).expect("open"))
+                .expect("aggregate");
+
+        assert_eq!(totals.input_tokens, 12);
+        assert_eq!(totals.output_tokens, 9);
+        assert_eq!(totals.cache_read_tokens, 2);
     }
 
     #[test]

--- a/src-tauri/src/contexts/sessions/api.rs
+++ b/src-tauri/src/contexts/sessions/api.rs
@@ -307,6 +307,14 @@ impl SessionsApi {
         self.service.session_usage_summary(session_id)
     }
 
+    pub(crate) fn terminal_usage_message_id(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+    ) -> Result<Option<String>, SessionsError> {
+        self.service.terminal_usage_message_id(session_id, agent_id)
+    }
+
     pub(crate) fn run_maintenance(
         &self,
         policy: ArchivalPolicy,

--- a/src-tauri/src/contexts/sessions/application/ports.rs
+++ b/src-tauri/src/contexts/sessions/application/ports.rs
@@ -116,6 +116,14 @@ pub(crate) trait SessionUsageRepository: Send + Sync {
         session_id: &str,
         generated_at: &str,
     ) -> Result<SessionUsageSummary, SessionsApplicationError>;
+
+    fn terminal_usage_message_id(
+        &self,
+        _session_id: &str,
+        _agent_id: &str,
+    ) -> Result<Option<String>, SessionsApplicationError> {
+        Ok(None)
+    }
 }
 
 pub(crate) trait SessionTransactionPort: Send + Sync {

--- a/src-tauri/src/contexts/sessions/application/service.rs
+++ b/src-tauri/src/contexts/sessions/application/service.rs
@@ -912,6 +912,20 @@ impl SessionsApplicationService {
             .summary_for_session(session.id(), &self.ports.clock.now())
     }
 
+    pub(crate) fn terminal_usage_message_id(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+    ) -> Result<Option<String>, SessionsApplicationError> {
+        let session = self.load_session(session_id)?;
+        if session.agent_id != agent_id {
+            return Ok(None);
+        }
+        self.ports
+            .usage
+            .terminal_usage_message_id(session.id(), agent_id)
+    }
+
     pub(crate) fn run_maintenance(
         &self,
         policy: ArchivalPolicy,

--- a/src-tauri/src/contexts/sessions/infrastructure/tests.rs
+++ b/src-tauri/src/contexts/sessions/infrastructure/tests.rs
@@ -634,6 +634,67 @@ fn message_and_usage_commit_together_and_usage_is_message_owned() {
 }
 
 #[test]
+fn terminal_usage_message_lookup_returns_the_newest_matching_row() {
+    let fixture = fixture("sessions-terminal-usage-lookup");
+    let repository = &fixture.repository;
+    let session = session_record(
+        "session-terminal-usage",
+        SessionLifecycle::Idle,
+        "Terminal Usage",
+        "2026-07-18T10:00:00+00:00",
+    );
+    SessionTransactionPort::create_session(repository, &session, SessionActivation::PreserveActive)
+        .expect("create session");
+
+    for (message_id, updated_at, source) in [
+        (
+            "message-terminal-older",
+            "2026-07-18T10:01:00+00:00",
+            "cli-session-log",
+        ),
+        (
+            "message-terminal-newer",
+            "2026-07-18T10:02:00+00:00",
+            "cli-session-log",
+        ),
+        (
+            "message-provider-newest",
+            "2026-07-18T10:03:00+00:00",
+            "provider",
+        ),
+    ] {
+        let streaming = message_record(
+            message_id,
+            session.id(),
+            MessageRole::Assistant,
+            MessageStatus::Streaming,
+            "",
+        );
+        SessionMessageRepository::insert(repository, &streaming).expect("insert message");
+        let mut completed = streaming;
+        completed
+            .message
+            .transition_to(MessageStatus::Completed)
+            .expect("complete transition");
+        completed.updated_at = updated_at.to_string();
+        let mut usage = usage_record(message_id, session.id(), "codex-cli");
+        usage.source = source.to_string();
+        SessionTransactionPort::complete_message(repository, &completed, Some(&usage))
+            .expect("complete with usage");
+    }
+
+    let found =
+        SessionUsageRepository::terminal_usage_message_id(repository, session.id(), "codex-cli")
+            .expect("lookup terminal usage message");
+    assert_eq!(found.as_deref(), Some("message-terminal-newer"));
+    assert_eq!(
+        SessionUsageRepository::terminal_usage_message_id(repository, session.id(), "gemini-cli",)
+            .expect("lookup other agent"),
+        None
+    );
+}
+
+#[test]
 fn deleting_an_assistant_message_deletes_only_its_owned_usage_record() {
     let fixture = fixture("sessions-message-owned-usage");
     let repository = &fixture.repository;

--- a/src-tauri/src/contexts/sessions/infrastructure/usage.rs
+++ b/src-tauri/src/contexts/sessions/infrastructure/usage.rs
@@ -5,7 +5,7 @@ use crate::contexts::sessions::application::{
     SessionUsageStatistics, SessionUsageSummary, SessionUsageUnit, SessionsApplicationError,
     UsageStatisticsRange,
 };
-use rusqlite::{params, params_from_iter, Connection, Row, Transaction};
+use rusqlite::{params, params_from_iter, Connection, OptionalExtension, Row, Transaction};
 
 pub(crate) fn apply_schema(
     connection: &Connection,
@@ -224,6 +224,28 @@ impl SessionUsageRepository for SqliteSessionsRepository {
             response_count,
             generated_at: generated_at.to_string(),
         })
+    }
+
+    fn terminal_usage_message_id(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+    ) -> Result<Option<String>, SessionsApplicationError> {
+        self.connection()?
+            .query_row(
+                "SELECT usage_records.message_id
+                 FROM usage_records
+                 INNER JOIN messages ON messages.id = usage_records.message_id
+                 WHERE usage_records.session_id = ?1
+                   AND usage_records.agent_id = ?2
+                   AND usage_records.source = 'cli-session-log'
+                 ORDER BY messages.updated_at DESC, usage_records.message_id DESC
+                 LIMIT 1",
+                params![session_id, agent_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(repository_error)
     }
 }
 


### PR DESCRIPTION
## Summary

Describe the user-visible outcome and why this change is needed.

## Related work

- Issue:
- OpenSpec change:

## Risk and compatibility

Describe affected platforms, migrations, security considerations, and rollback options.

## Validation

- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run contracts:check`
- [ ] `npm run build`
- [ ] `npx playwright test` (when UI behavior changes)
- [ ] Rust fmt, check, Clippy, and tests (when native code changes)
- [ ] Strict OpenSpec validation

## Screenshots or diagnostics

Add redacted evidence when it helps reviewers. Do not include credentials, personal data, or unredacted logs.

## Checklist

- [ ] The change follows `AGENTS.md` and `openspec/project.md`.
- [ ] New behavior is covered by tests.
- [ ] Documentation and both service adapters are updated where applicable.
- [ ] No secrets, signing material, local databases, or sensitive logs are committed.
