### PR TITLE
fix: repair Skill migration upgrade path

### DIFF
--- a/openspec/changes/harden-skill-management-reliability/design.md
+++ b/openspec/changes/harden-skill-management-reliability/design.md
@@ -92,7 +92,7 @@ Web/mock stores `{skill, document}` records, uses the same externally visible va
 
 ## Migration Plan
 
-1. Add indexes and migration cleanup for orphan bindings, API-Agent CLI bindings, and API-Agent mount-path rows; preserve all Skill source directories.
+1. Ensure the reliability migration creates the API-Agent Skill binding table before cleanup so databases that already recorded the historical Skill migration can upgrade safely, then add indexes and clean up orphan bindings, API-Agent CLI bindings, and API-Agent mount-path rows while preserving all Skill source directories.
 2. Add canonical location, Agent-kind validation, reserved-path validation, mutation serialization, narrow edit semantics, and restore/drift safety.
 3. Add batch repository/service/command/adapter DTOs while retaining old read commands temporarily for compatibility.
 4. Switch the settings UI to the batch overview and granular CLI binding mutations, then remove active use of per-Skill API binding queries.

--- a/openspec/changes/harden-skill-management-reliability/specs/skill-management/spec.md
+++ b/openspec/changes/harden-skill-management-reliability/specs/skill-management/spec.md
@@ -107,6 +107,14 @@ The system SHALL return the selected scope's Skills, CLI/API bindings, statistic
 - **WHEN** the overview contains many Skills
 - **THEN** native loading SHALL use batch binding queries rather than one query or IPC request per Skill
 
+### Requirement: Existing Skill database upgrade compatibility
+The system SHALL create all Skill binding storage required by a pending reliability migration before that migration cleans or indexes binding rows.
+
+#### Scenario: Upgrade a database created before API Skill bindings
+- **WHEN** an existing database has recorded migrations 1 through 36 but does not contain the API-Agent Skill binding table
+- **THEN** migration 37 SHALL create the missing table before cleanup
+- **AND** SHALL complete without deleting Skill source records or directories
+
 ### Requirement: Behavioral Web adapter parity
 The Web/mock adapter SHALL preserve Skill documents and enforce the same identity, scope, binding-type, lifecycle, validation, and cleanup outcomes as the native adapter, while simulating filesystem-only effects deterministically.
 

--- a/openspec/changes/harden-skill-management-reliability/tasks.md
+++ b/openspec/changes/harden-skill-management-reliability/tasks.md
@@ -49,3 +49,9 @@
 - [x] 7.4 Instrument the batch overview repository test to prove SQL statement count remains constant as Skill count grows.
 - [x] 7.5 Add native import tests for file-count, aggregate-size, and source/destination overlap limits, then rerun all required validation.
 - [x] 7.6 Apply repository rustfmt output and rerun native quality gates after the Linux CI formatting failure.
+
+## 8. Existing-database migration remediation
+
+- [x] 8.1 Create `skill_api_agent_bindings` idempotently at the start of migration 37 before its cleanup and index statements.
+- [x] 8.2 Add an upgrade regression test for a database with migrations 1-36 recorded and no `skill_api_agent_bindings` table.
+- [x] 8.3 Rerun the complete frontend, Rust, and strict OpenSpec validation suite and record the results.

--- a/openspec/changes/harden-skill-management-reliability/verification.md
+++ b/openspec/changes/harden-skill-management-reliability/verification.md
@@ -11,9 +11,9 @@ Verified on 2026-08-02.
 ## Native
 
 - `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`: passed.
-- `cargo test --manifest-path src-tauri/Cargo.toml`: passed, 1,030 tests passed and 3 fixture-only tests ignored; architecture tests also passed 11/11.
+- `cargo test --manifest-path src-tauri/Cargo.toml`: passed, 1,031 tests passed and 3 fixture-only tests ignored; architecture tests also passed 11/11.
 - `cargo check --manifest-path src-tauri/Cargo.toml`: passed.
-- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: passed.
+- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`: passed.
 
 ## Targeted Reliability Coverage
 
@@ -28,8 +28,10 @@ Verified on 2026-08-02.
 - Web Skill mutations enforce native-compatible id, required metadata, workspace normalization, source-kind, and observable import path validation.
 - The batch repository test traces executed SQLite statements and proves one and 100 Skills both require two list statements.
 - Import rollback tests cover more than 512 files, more than 16 MiB aggregate content, and source/destination overlap.
+- Migration 37 now creates `skill_api_agent_bindings` before cleanup, allowing databases that already recorded migrations 1-36 to upgrade without deleting existing Skill records.
+- The targeted pre-migration-37 upgrade regression passed, including preservation of an existing Skill record and recording the reliability migration.
 
 ## OpenSpec
 
 - `openspec validate harden-skill-management-reliability --strict`: passed.
-- `openspec validate --specs --strict`: passed, 81 specifications validated.
+- `openspec validate --specs --strict`: passed, 82 specifications validated.

--- a/src-tauri/src/contexts/tooling/skills/infrastructure/sqlite_repository.rs
+++ b/src-tauri/src/contexts/tooling/skills/infrastructure/sqlite_repository.rs
@@ -541,6 +541,16 @@ pub(crate) fn apply_reliability_schema(
 ) -> Result<(), crate::platform::database::DatabaseError> {
     connection.execute_batch(
         r#"
+        CREATE TABLE IF NOT EXISTS skill_api_agent_bindings (
+            skill_id TEXT NOT NULL,
+            scope TEXT NOT NULL,
+            workspace_path TEXT NOT NULL DEFAULT '',
+            agent_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (skill_id, scope, workspace_path, agent_id)
+        );
+
         DELETE FROM skill_agent_bindings
         WHERE NOT EXISTS (
             SELECT 1 FROM skills

--- a/src-tauri/src/platform/database/migrations.rs
+++ b/src-tauri/src/platform/database/migrations.rs
@@ -802,6 +802,71 @@ mod tests {
     }
 
     #[test]
+    fn skill_reliability_migration_upgrades_database_without_api_binding_table() {
+        let connection = Connection::open_in_memory().expect("in-memory database");
+        migrate(&connection).expect("current schema");
+        connection
+            .execute(
+                "INSERT INTO skills (id, scope, workspace_path, source, enabled, skill_dir, \
+                 skill_md_path, content_hash, metadata_json, created_at, updated_at) \
+                 VALUES (?1, 'global', '', 'user-created', 1, ?2, ?3, 'hash', '{}', ?4, ?4)",
+                params![
+                    "preserved-skill",
+                    "/managed/preserved-skill",
+                    "/managed/preserved-skill/SKILL.md",
+                    "2026-08-02T00:00:00Z"
+                ],
+            )
+            .expect("existing Skill record");
+        connection
+            .execute_batch(
+                r#"
+                DELETE FROM schema_migrations WHERE version = 37;
+                DROP TABLE skill_api_agent_bindings;
+                "#,
+            )
+            .expect("pre-migration-37 fixture");
+
+        let migration_state: (i64, i64) = connection
+            .query_row(
+                "SELECT COUNT(*), MAX(version) FROM schema_migrations",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("fixture migration state");
+        assert_eq!(migration_state, (36, 36));
+
+        migrate(&connection).expect("upgrade migration");
+
+        let api_binding_table: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type = 'table' AND name = 'skill_api_agent_bindings'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("API binding table");
+        let reliability_migration: String = connection
+            .query_row(
+                "SELECT name FROM schema_migrations WHERE version = 37",
+                [],
+                |row| row.get(0),
+            )
+            .expect("reliability migration");
+        let preserved_skill: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM skills WHERE id = 'preserved-skill'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("preserved Skill record");
+
+        assert_eq!(api_binding_table, 1);
+        assert_eq!(reliability_migration, "skill-management-reliability");
+        assert_eq!(preserved_skill, 1);
+    }
+
+    #[test]
     fn mcp_transport_migration_upgrades_an_old_database_and_journals_the_row() {
         let connection = Connection::open_in_memory().expect("in-memory database");
         mcp_migration_fixture(&connection);


### PR DESCRIPTION
Creates skill_api_agent_bindings before migration 37 cleanup so databases with migrations 1-36 can upgrade safely. Adds an upgrade regression test that preserves existing Skill records and updates the OpenSpec artifacts and verification evidence. Validation: npm lint/test/build; cargo fmt/test/check/clippy; strict change and main-spec validation.