### PR TITLE
feat(release): publish unsigned GitHub preview releases

### DIFF
--- a/.github/PREVIEW_RELEASE_NOTES.md
+++ b/.github/PREVIEW_RELEASE_NOTES.md
@@ -1,0 +1,68 @@
+> **This is a preview build.** The packages below are **unsigned and un-notarized**. Your operating system will warn you before running them, and the steps to proceed are in [Installing](#installing). Expect rough edges, and expect to reinstall rather than update — no automatic updater is configured.
+
+## What works
+
+- **Delivered:** CLI management, single-Agent sessions, interactive Agent terminals, session organization, project/worktree and SSH workspace tools, settings, MCP/SDK/Skills/Prompt Hooks/extensions, IM connectors, scheduled tasks, notifications, usage reporting, and unified redacted logs.
+- **Preview:** Multi-Agent coordination has native and Web/mock service contracts, but the create-session UI still disables Multi Agent mode.
+- **Not available yet:** the Multi-Agent coordination UI, and Japanese application UI resources — Japanese currently covers the README only.
+
+## Downloads
+
+| Platform | Asset | Notes |
+| --- | --- | --- |
+| Windows x64 | `.exe` installer (NSIS) | Installs per-user; no administrator rights required |
+| macOS Apple Silicon | `.dmg` | Intel Macs are not covered by this build |
+| Linux x64 | `.deb` and AppImage | AppImage runs without installation |
+
+No `.msi` is published: the Windows Installer format cannot represent a pre-release version number. No `.rpm` is published: the RPM version field cannot contain the hyphen a pre-release version requires. Use the `.exe` installer and the AppImage respectively.
+
+## Installing
+
+### macOS
+
+A `.dmg` downloaded through a browser is quarantined, and because this build is not notarized macOS reports that the application **"is damaged and can't be opened"**. The application is not damaged — that is the message macOS uses for un-notarized software.
+
+Drag the app to `/Applications` as usual, then clear the quarantine attribute:
+
+```bash
+xattr -cr "/Applications/VaneHub AI.app"
+```
+
+Open the application normally afterward.
+
+### Windows
+
+SmartScreen shows **"Windows protected your PC"** because the installer carries no Authenticode signature. Choose **More info**, then **Run anyway**.
+
+### Linux
+
+Install the `.deb` with your package manager, or mark the AppImage executable and run it directly:
+
+```bash
+chmod +x VaneHub-AI-*.AppImage
+./VaneHub-AI-*.AppImage
+```
+
+Binaries are built on the current Ubuntu runner image and link against its glibc, so older distributions may refuse to start them.
+
+## Verifying your download
+
+Every asset is listed in `SHA256SUMS`, published alongside them. Download it and check the file you retrieved:
+
+```bash
+sha256sum --check --ignore-missing SHA256SUMS
+```
+
+An SPDX SBOM and GitHub build-provenance attestations are also attached. You can verify provenance with:
+
+```bash
+gh attestation verify <downloaded-file> --repo cdavid817/vanehub-ai
+```
+
+Checksums, the SBOM, and attestations establish that these files came from this repository's build. **They do not replace operating-system code signing or Apple notarization**, and they do not remove the warnings described above.
+
+## Reporting problems
+
+Open a [bug report](https://github.com/cdavid817/vanehub-ai/issues/new?template=bug.yml) and include the version from this release, your operating system, and the relevant excerpt from the application logs. For a feature idea, use the [feature request](https://github.com/cdavid817/vanehub-ai/issues/new?template=feature.yml) template. Please report security issues privately through a [security advisory](https://github.com/cdavid817/vanehub-ai/security/advisories/new) rather than a public issue.
+
+---

--- a/.github/PREVIEW_RELEASE_NOTES.md
+++ b/.github/PREVIEW_RELEASE_NOTES.md
@@ -11,7 +11,8 @@
 | Platform | Asset | Notes |
 | --- | --- | --- |
 | Windows x64 | `.exe` installer (NSIS) | Installs per-user; no administrator rights required |
-| macOS Apple Silicon | `.dmg` | Intel Macs are not covered by this build |
+| macOS Apple Silicon | `aarch64` `.dmg` | |
+| macOS Intel | `x64` `.dmg` | |
 | Linux x64 | `.deb` and AppImage | AppImage runs without installation |
 
 No `.msi` is published: the Windows Installer format cannot represent a pre-release version number. No `.rpm` is published: the RPM version field cannot contain the hyphen a pre-release version requires. Use the `.exe` installer and the AppImage respectively.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Coverage policy regression tests
         run: npm run coverage:policy:test
 
+      - name: Release version sync regression tests
+        run: npm run version:unit:test
+
       - name: Vitest with coverage
         run: npm run test:coverage
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -52,6 +52,11 @@ jobs:
             runner: macos-14
             rust_target: aarch64-apple-darwin
             npm_script: package:macos:arm64
+          - platform: macos
+            arch: x64
+            runner: macos-15-intel
+            rust_target: x86_64-apple-darwin
+            npm_script: package:macos:x64
           - platform: linux
             arch: x64
             runner: ubuntu-latest

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -186,9 +186,22 @@ jobs:
         shell: bash
         run: |
           mapfile -d '' assets < <(find release-assets -type f -print0)
-          gh release create "${GITHUB_REF_NAME}" \
-            "${assets[@]}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --title "VaneHub AI ${GITHUB_REF_NAME}" \
-            --generate-notes \
+
+          args=(
+            --repo "${GITHUB_REPOSITORY}"
+            --title "VaneHub AI ${GITHUB_REF_NAME}"
+            --generate-notes
             --verify-tag
+          )
+
+          # Semantic versioning introduces a pre-release identifier with a hyphen and permits one
+          # in no other version component, so the tag alone decides this and there is no separate
+          # input a maintainer can forget to set.
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            echo "Publishing ${GITHUB_REF_NAME} as a pre-release."
+            args+=(--prerelease --latest=false --notes-file .github/PREVIEW_RELEASE_NOTES.md)
+          else
+            echo "Publishing ${GITHUB_REF_NAME} as a stable release."
+          fi
+
+          gh release create "${GITHUB_REF_NAME}" "${assets[@]}" "${args[@]}"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,7 +29,7 @@ jobs:
           cache: npm
 
       - name: Validate synchronized project versions
-        run: npm run version:check -- ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        run: npm run version:check
 
   package:
     name: Package (${{ matrix.platform }}-${{ matrix.arch }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,6 @@ openspec validate --specs --strict
 
 上面这些之外,CI 还有几条本地不必每次跑、但相应改动落到你手上时必须跑的:
 
-- `npm run test:coverage`(CI 用它取代 `npm run test`,带覆盖率门槛)、`npm run coverage:policy:test`、`npm run contracts:check`
+- `npm run test:coverage`(CI 用它取代 `npm run test`,带覆盖率门槛)、`npm run coverage:policy:test`、`npm run version:unit:test`、`npm run contracts:check`
 - UI 行为变更时:`npx playwright test`(CI 的 e2e job 恒跑,本地在改动 UI 行为时必须跑)
 - 起了 proposal 时:`openspec validate <change-name> --strict`——CI 对 `openspec/changes/*` 下每个变更逐个校验,`--specs --strict` 不覆盖这一层

--- a/README.ja.md
+++ b/README.ja.md
@@ -12,11 +12,11 @@
 
 単一の React インターフェースと明確な Web/mock・Tauri runtime 境界を通じて AI Coding Agent を管理する、デスクトップ優先のワークスペースです。
 
-<!-- docs-fact:project-version value:0.1.0 -->
+<!-- docs-fact:project-version value:0.1.0-preview.1 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-0.1.0--preview.1-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)
@@ -27,6 +27,14 @@
 ## 概要
 
 VaneHub AI は Claude Code、OpenCode、Codex CLI、Gemini CLI を共有デスクトップワークスペースに統合します。React コンポーネントを native API に直接依存させず、CLI の可用性、セッション、ターミナル実行、プロジェクトと worktree、設定、ツール、可観測性、デスクトップ統合を管理します。
+
+<!-- docs-section:download -->
+
+## ダウンロード
+
+ビルド済みのデスクトップパッケージは [Releases ページ](https://github.com/cdavid817/vanehub-ai/releases)で公開しています。Windows は `.exe` インストーラー、macOS は `.dmg`、Linux は `.deb` と AppImage です。`.msi` と `.rpm` は公開していません。
+
+現在のビルドは署名なしのプレビューです。Windows と macOS は実行前に警告を表示します。プラットフォームごとの手順は release notes に記載しています。インストール前に、公開されている `SHA256SUMS` でダウンロードを検証してください。
 
 <!-- docs-section:feature-status -->
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
 Desktop-first workspace for managing AI coding agents through one React interface and explicit Web/mock and Tauri runtime boundaries.
 
-<!-- docs-fact:project-version value:0.1.0 -->
+<!-- docs-fact:project-version value:0.1.0-preview.1 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-0.1.0--preview.1-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)
@@ -27,6 +27,14 @@ Desktop-first workspace for managing AI coding agents through one React interfac
 ## Overview
 
 VaneHub AI brings Claude Code, OpenCode, Codex CLI, and Gemini CLI into a shared desktop workspace. It manages CLI availability, sessions, terminal execution, projects and worktrees, settings, tools, observability, and desktop integrations without letting React components depend directly on native APIs.
+
+<!-- docs-section:download -->
+
+## Download
+
+Prebuilt desktop packages are published on the [Releases page](https://github.com/cdavid817/vanehub-ai/releases): a Windows `.exe` installer, a macOS `.dmg`, and Linux `.deb` and AppImage builds. No `.msi` or `.rpm` is published.
+
+The current build is an unsigned preview. Windows and macOS warn before running it, and the release notes carry the steps for each platform. Verify your download against the published `SHA256SUMS` before installing.
 
 <!-- docs-section:feature-status -->
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,11 +12,11 @@
 
 通过统一 React 界面和明确的 Web/mock、Tauri runtime 边界管理 AI Coding Agent 的桌面优先工作台。
 
-<!-- docs-fact:project-version value:0.1.0 -->
+<!-- docs-fact:project-version value:0.1.0-preview.1 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-0.1.0--preview.1-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)
@@ -27,6 +27,14 @@
 ## 项目简介
 
 VaneHub AI 把 Claude Code、OpenCode、Codex CLI 和 Gemini CLI 汇集到统一桌面工作台中。它管理 CLI 可用性、会话、终端执行、项目与 worktree、设置、工具、可观测性和桌面集成，同时避免 React 组件直接依赖 native API。
+
+<!-- docs-section:download -->
+
+## 下载
+
+预构建的桌面安装包发布在 [Releases 页面](https://github.com/cdavid817/vanehub-ai/releases)：Windows `.exe` 安装器、macOS `.dmg`，以及 Linux 的 `.deb` 与 AppImage。不发布 `.msi` 和 `.rpm`。
+
+当前构建是未签名的预览版。Windows 与 macOS 在运行前会给出警告，各平台的处理步骤记录在 release notes 中。安装前请用发布的 `SHA256SUMS` 校验下载文件。
 
 <!-- docs-section:feature-status -->
 

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -7,11 +7,47 @@ The `Package Desktop Apps` workflow uses an unprivileged `build-preview` environ
 1. Synchronize the version in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.
 2. Run `npm run version:check` and the full validation suite.
 3. Merge the reviewed version change to `main`.
-4. Create and push an annotated `v<version>` tag from the reviewed commit.
-5. Approve the `release` environment deployment if environment reviewers are configured.
-6. Verify packages, `SHA256SUMS`, the SPDX SBOM, GitHub artifact attestations, and generated release notes.
+4. Rehearse the build matrix with a manual run before tagging.
+5. Create and push an annotated `v<version>` tag from the reviewed commit.
+6. Approve the `release` environment deployment if environment reviewers are configured.
+7. Verify packages, `SHA256SUMS`, the SPDX SBOM, GitHub artifact attestations, and generated release notes.
 
 The publish job cannot run until all Windows, macOS, and Linux jobs finish successfully. It uses short-lived GitHub OIDC identity for attestations and does not require a stored GitHub token.
+
+## Rehearsing without a tag
+
+Start `Package Desktop Apps` manually from GitHub Actions against a branch. The run validates that the three version declarations agree, builds every matrix target, and uploads artifacts, but publishes nothing — the publish job is gated on a tag.
+
+Version validation resolves the release tag from an explicit argument first, and falls back to `GITHUB_REF_NAME` only when `GITHUB_REF_TYPE` is `tag`. A branch reference is therefore never compared against a version. Reproduce either path locally:
+
+```bash
+GITHUB_REF_TYPE=branch GITHUB_REF_NAME=main npm run version:check
+npm run version:check -- v<version>
+```
+
+Use a rehearsal to confirm that installers actually install before spending a tag on it. A failed publish leaves a pushed tag with no release, which is only recoverable by deleting the tag and re-tagging.
+
+## Preview releases
+
+Preview and release-candidate builds use a semantic-versioning pre-release identifier — `0.1.0-preview.1`, `0.1.0-rc.1` — declared identically in all three manifests and in the tag. `npm run version:check` compares the tag verbatim, so a pre-release identifier is never normalized away.
+
+The publish job derives pre-release status from the tag alone: a tag containing a hyphen is published with `--prerelease` and `--latest=false`, so a preview never displaces a stable download. No separate workflow input controls this.
+
+For a pre-release, `.github/PREVIEW_RELEASE_NOTES.md` is prepended to the generated notes. That file is where the unsigned-package disclosure and the per-platform installation steps live, so it is reviewed like any other repository file rather than authored inside a workflow run. Keep it version-independent: refer to assets by format, never by filename.
+
+## Distributable formats
+
+`bundle.targets` in `src-tauri/tauri.conf.json` declares an explicit list rather than `"all"`:
+
+| Platform | Produced | Not produced |
+| --- | --- | --- |
+| Windows | NSIS `.exe` installer | `.msi` |
+| macOS | `.app`, `.dmg` | — |
+| Linux | `.deb`, AppImage | `.rpm` |
+
+Both exclusions follow from the pre-release version scheme. `tauri-bundler` aborts an MSI build when the pre-release identifier is not numeric, because the Windows Installer `ProductVersion` field accepts only `major.minor.patch[.build]`. The RPM `Version` field cannot contain a hyphen at all, and the bundler passes the version through unsanitized. Users who would take an `.msi` are served by the NSIS installer, which installs per-user without administrator rights; users who would take an `.rpm` are served by the AppImage.
+
+Restoring either format requires a version without a pre-release identifier, and is a separate decision once the preview program ends.
 
 ## Native build profile
 
@@ -45,3 +81,5 @@ The repository does not currently define a Windows Authenticode provider. Before
 The environment should allow deployment only from protected `v*` tags. Add a human reviewer when a second trusted maintainer is available. A required self-review is intentionally not configured because it would make a single-maintainer repository impossible to release.
 
 Until valid platform credentials are configured, packages may be unsigned. Release notes must say so clearly; the checksums, SBOM, and GitHub attestations establish integrity but do not replace operating-system code signing or Apple notarization.
+
+A bare disclosure is not enough for a public download. An unsigned build must also publish the steps a downloader needs to get past the protection each platform raises: macOS reports an un-notarized application as damaged until its quarantine attribute is cleared, and Windows SmartScreen blocks an unsigned installer behind a secondary confirmation. `.github/PREVIEW_RELEASE_NOTES.md` carries both, and must be updated whenever the signing situation changes.

--- a/openspec/changes/publish-github-preview-release/.openspec.yaml
+++ b/openspec/changes/publish-github-preview-release/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/publish-github-preview-release/design.md
+++ b/openspec/changes/publish-github-preview-release/design.md
@@ -113,8 +113,13 @@ The notes file stays version-independent so it does not need editing per preview
 
 Rollback: delete the tag and the GitHub Release. Because no updater is configured, no installed client polls for or auto-applies a release, so a withdrawn preview cannot propagate to users who already installed it — they simply keep the build they have.
 
+### Cover Intel Macs in the preview matrix
+
+`macos-x64` joins the build matrix on the `macos-15-intel` runner. `package:macos:x64` already existed in `package.json` and only the matrix entry was missing, so an Intel Mac user would otherwise have had no download at all — the worst outcome for a public preview, worse than the unsigned warning.
+
+The runner label matters here: `macos-13` has been retired, so `macos-15-intel` is the available Intel image. The alternative was cross-compiling `x86_64-apple-darwin` on an arm64 runner, which avoids depending on an Intel runner label but ships a binary that no job ever executed on its target architecture. For a preview whose purpose is to collect real installation feedback, a natively built package is worth the extra job.
+
 ## Open Questions
 
-- Should `macos-x64` join the build matrix? `package:macos:x64` already exists in `package.json` and the matrix omits it, leaving Intel Mac users with no download. Adding it is a four-line matrix entry; the cost is build minutes.
 - Which minimum Linux distribution should preview builds support? This decides whether the Linux job pins an older runner image or whether the release notes state a minimum glibc.
 - Does the preview program need a feedback channel beyond the existing issue templates — for example a discussion category, which `gh release create --discussion-category` could attach automatically?

--- a/openspec/changes/publish-github-preview-release/design.md
+++ b/openspec/changes/publish-github-preview-release/design.md
@@ -1,0 +1,120 @@
+## Context
+
+`.github/workflows/package.yml` already implements the full release path: a `v*` tag triggers a three-platform build matrix, then a publish job that emits `SHA256SUMS`, an SPDX SBOM, build-provenance attestations, and a GitHub Release. The `release` GitHub environment exists and restricts deployment to `v*` tags; `build-preview` exists with no restriction. `docs/release-signing.md` documents the intended sequence.
+
+Nothing in that path has ever run. `gh run list --workflow=package.yml` and `gh release list` are both empty, and no signing secrets are configured (`gh secret list` is empty), so every package will be unsigned and un-notarized.
+
+Two facts constrain the version scheme, both verified against `tauri-bundler` source rather than assumed:
+
+`crates/tauri-bundler/src/bundle/windows/msi/mod.rs` — `convert_version()` aborts the build:
+
+```rust
+if !version.pre.is_empty() {
+  let pre = version.pre.parse::<u64>();
+  if pre.is_ok() && pre.unwrap() <= 65535 {
+    return Ok(format!("{}.{}.{}.{}", version.major, version.minor, version.patch, version.pre));
+  } else {
+    crate::error::bail!("optional pre-release identifier in app version must be \
+      numeric-only and cannot be greater than 65535 for msi target");
+  }
+}
+```
+
+`crates/tauri-bundler/src/bundle/windows/nsis/mod.rs` — `try_add_numeric_build_number()` ignores the pre-release identifier entirely and emits `major.minor.patch.0` for `VIProductVersion`. It never fails on it.
+
+A repository-wide search for `version.pre` inside `tauri-bundler` matches only the MSI module, which is the negative evidence that no other bundler rejects a pre-release identifier.
+
+`crates/tauri-bundler/src/bundle/linux/rpm.rs` passes `settings.version_string()` to `rpm::PackageBuilder::new` with no sanitization. The RPM `Version` field cannot contain a hyphen, and every semantic-versioning pre-release identifier is introduced by one. Whether `rpm-rs` rejects this or silently emits a package with an unparseable version was not determined.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Publish repeated public preview builds whose version number identifies exactly which preview a bug report refers to.
+- Keep the three version declarations synchronized, preserving the existing `desktop-release-delivery` guarantee rather than weakening it to accommodate previews.
+- Make the build matrix rehearsable without creating a tag.
+- Give a first-time downloader on an unsigned build enough instruction to actually install and run the application.
+
+**Non-Goals:**
+
+- Code signing, Apple notarization, and Windows Authenticode. Deliberately deferred; the release notes disclose the consequence instead.
+- The Tauri updater. `TAURI_SIGNING_PRIVATE_KEY` is already wired into the workflow environment but `tauri.conf.json` declares no updater plugin, so it is currently inert. It stays inert.
+- Translating release notes. The canonical README is English and release notes follow it.
+- Restoring MSI and RPM once a non-pre-release version ships. That is a separate decision once the preview program ends.
+- Any change to desktop or Web runtime behavior. This change does not touch React components, frontend service interfaces, Tauri adapters, Rust commands, or SQLite.
+
+## Decisions
+
+### Readable pre-release identifiers, at the cost of two bundle formats
+
+Version becomes `0.1.0-preview.1`, incrementing through `preview.2`, `rc.1`, and so on until `0.1.0`. `bundle.targets` changes from `"all"` to the explicit list `["nsis", "app", "dmg", "deb", "appimage"]`, dropping `msi` and `rpm`.
+
+`BundleTarget` accepts either `"all"` or a list of `BundleType` (`deb`, `rpm`, `appimage`, `msi`, `nsis`, `app`, `dmg`), and targets that do not apply to the running platform are skipped, so one declared list serves all three platforms. Listing both `app` and `dmg` reproduces what `"all"` produced on macOS.
+
+Alternatives considered:
+
+- **Numeric-only pre-release (`0.1.0-1`, `0.1.0-2`)** keeps MSI, since `convert_version()` accepts a numeric identifier and maps it to `0.1.0.1`. Rejected: it does not survive the stated release plan. `rc.1` is not numeric, so the scheme breaks the first time a release candidate is cut, and `0.1.0-1` does not tell a bug reporter whether they are on a preview or a candidate. It also does not rescue RPM, which fails on the hyphen regardless of what follows it.
+- **Keep `0.1.0` in all three manifests and put the suffix only in the tag.** No bundler is affected and `targets: "all"` survives. Rejected: `preview.1` and `preview.2` would both report `0.1.0` in the installed application, which defeats the purpose of a preview program, and it requires loosening `check-version-sync.mjs` from exact equality to prefix matching — trading a strong invariant for a weaker one.
+- **Build metadata (`0.1.0+preview.1`).** Rejected: MSI applies the same numeric-only constraint to `version.build`, and build metadata is excluded from semantic-versioning precedence, so it does not order releases.
+
+RPM is dropped rather than tested because the failure mode that matters is the silent one — an installable package whose version string cannot be compared by `dnf`. AppImage already covers RPM-based distributions.
+
+### Detect pre-release from the tag, not from a separate input
+
+The publish job passes `--prerelease` when the tag name contains a hyphen. Semantic versioning guarantees a pre-release identifier is introduced by a hyphen and that no other version component may contain one, so the tag alone is sufficient and there is nothing for a maintainer to forget to set. The `release` environment already restricts deployment to `v*` tags, so the tag namespace this rule interprets is constrained.
+
+`--latest=false` is passed alongside it. GitHub does not promote a pre-release to latest, but the `--latest` default is documented as "automatic based on date and version", and pinning it removes the ambiguity.
+
+### Fix the untagged validation path in the script, not only in the workflow
+
+`scripts/check-version-sync.mjs` resolves the tag as `process.argv[2] ?? process.env.GITHUB_REF_NAME`. On a `workflow_dispatch` run against a branch, `package.yml` substitutes an empty argument, `argv[2]` is `undefined`, and the fallback yields the branch name — `main` — which is then compared against `v0.1.0` and fails. This is why no rehearsal is currently possible.
+
+The fallback is corrected to apply only when `GITHUB_REF_TYPE` is `tag`. Fixing the workflow's argument passing alone would leave a script that silently reinterprets a branch name as a release tag for any future caller; fixing the script makes the invariant hold regardless of who calls it, and the workflow's conditional argument becomes redundant rather than load-bearing.
+
+### Compare README version facts after un-escaping the badge
+
+`check-readme-parity.mjs` extracts the visible version from the badge URL with `/badge\/version-([0-9]+\.[0-9]+\.[0-9]+)-/i` and compares it to the `docs-fact:project-version` marker, which in turn is compared to `package.json`. Shields.io requires a literal hyphen in a static badge to be escaped as `--`, so the badge URL becomes `badge/version-0.1.0--preview.1-blue.svg`. The current pattern captures `0.1.0` from that string and reports a mismatch against `0.1.0-preview.1`.
+
+The pattern is extended to capture the escaped pre-release segment, and the captured value is un-escaped (`--` to `-`) before comparison. Comparing the un-escaped form rather than escaping the manifest value keeps the shields.io encoding rule confined to one place.
+
+This must land in the same commit as the README edits. `npm run docs:check` runs in CI (`.github/workflows/ci.yml:156`), so a version bump without the pattern change, or a pattern change without the badge updates, breaks the branch.
+
+### Ship release notes from a tracked file, prepended to generated notes
+
+Preview-specific guidance lives in `.github/PREVIEW_RELEASE_NOTES.md` so it is reviewable, diffable, and cannot drift from the workflow that consumes it. The publish job prepends it to the auto-generated pull-request summary.
+
+`gh release create --help` documents the prepend behavior for `--notes` specifically and does not name `--notes-file`. The implementation uses `--notes-file` and the rehearsal must confirm that generated notes are appended rather than replaced. If they are replaced, the fallback is to fetch generated notes explicitly and concatenate before publishing:
+
+```bash
+gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+  -f tag_name="${GITHUB_REF_NAME}" --jq .body > generated-notes.md
+cat .github/PREVIEW_RELEASE_NOTES.md generated-notes.md > release-notes.md
+```
+
+The notes file stays version-independent so it does not need editing per preview: it refers to assets by format rather than by filename, and the `xattr` path is the installed application path, not a download path.
+
+## Risks / Trade-offs
+
+- **The first tagged run is still the first tagged run.** → The rehearsal fix makes a `workflow_dispatch` run exercise validate, all three builds, and artifact upload. Only the publish job remains untested, because it is gated on `github.ref_type == 'tag'`. That residual exposure is accepted; a failed publish leaves a pushed tag with no release, which is recoverable by deleting the tag and re-tagging.
+- **MSI and RPM consumers lose their format.** → Windows NSIS installs per-user without administrator rights and is Tauri's recommended Windows installer; AppImage runs on RPM-based distributions. Both exclusions are documented as accepted limitations under the `native-app-packaging` requirement that already forbids silently treating an unsupported combination as supported.
+- **macOS remains the weakest download.** An un-notarized application from a browser download carries a quarantine attribute and reports being damaged. → The release notes carry the `xattr -cr` instruction. This is a disclosure, not a fix, and conversion on macOS will be poor until an Apple Developer certificate is provisioned.
+- **Linux binaries inherit the runner's glibc.** Building on `ubuntu-latest` produces binaries that will not start on older distributions. → Out of scope for this change; recorded as an open question rather than silently shipped.
+- **The main branch advertises a pre-release version.** The README badge on the default branch will read `0.1.0-preview.1`. → Intended. The badge links to `package.json` and reflects it accurately.
+- **`--notes-file` composition with `--generate-notes` is unverified.** → Rehearsal step with a documented fallback, above.
+
+## Migration Plan
+
+1. Land the workflow validation fix first, on its own, so a rehearsal becomes possible before anything else changes.
+2. Run `workflow_dispatch` on `main` and confirm all three matrix jobs upload artifacts.
+3. Land the version bump, bundle target list, parity pattern, README updates, and release notes file together — the parity check couples them.
+4. Verify locally that a Windows package builds and installs, which is the only way to confirm the NSIS path end to end with a pre-release version.
+5. Run `workflow_dispatch` again and install the downloaded artifacts on real machines.
+6. Tag `v0.1.0-preview.1` and push.
+
+Rollback: delete the tag and the GitHub Release. Because no updater is configured, no installed client polls for or auto-applies a release, so a withdrawn preview cannot propagate to users who already installed it — they simply keep the build they have.
+
+## Open Questions
+
+- Should `macos-x64` join the build matrix? `package:macos:x64` already exists in `package.json` and the matrix omits it, leaving Intel Mac users with no download. Adding it is a four-line matrix entry; the cost is build minutes.
+- Which minimum Linux distribution should preview builds support? This decides whether the Linux job pins an older runner image or whether the release notes state a minimum glibc.
+- Does the preview program need a feedback channel beyond the existing issue templates — for example a discussion category, which `gh release create --discussion-category` could attach automatically?

--- a/openspec/changes/publish-github-preview-release/proposal.md
+++ b/openspec/changes/publish-github-preview-release/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The release pipeline in `.github/workflows/package.yml` has never executed once: `gh run list --workflow=package.yml` and `gh release list` are both empty. Its only untagged rehearsal path is broken, so the first real execution would be a tag push that publishes directly to a public repository with no way to rehearse first.
+
+The project also needs to ship repeated public preview builds (`preview.1`, `preview.2`, `rc.1`) before `0.1.0`. The current pipeline cannot express a preview: it publishes every tag as a full latest release, and the Windows MSI bundler rejects a semantic-versioning pre-release identifier outright, so a preview version number cannot even be built.
+
+## What Changes
+
+- Adopt semantic-versioning pre-release identifiers (`0.1.0-preview.1`) as the release version for preview builds, kept synchronized across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.
+- **BREAKING** for distributable formats: restrict the Tauri bundle target set so preview and release builds no longer produce Windows MSI or Linux RPM packages. `tauri-bundler` aborts the MSI build on a non-numeric pre-release identifier, and the RPM `Version` field cannot contain the hyphen every pre-release identifier carries. Windows ships the NSIS installer; Linux ships `.deb` and AppImage.
+- Repair the release workflow's untagged validation path so a manual `workflow_dispatch` run can rehearse the full build matrix without creating a tag.
+- Publish pre-release tags as GitHub pre-releases rather than latest releases, so a preview never displaces a stable download.
+- Publish release notes that state the packages are unsigned and un-notarized, and that carry per-platform installation guidance for the resulting Gatekeeper and SmartScreen prompts.
+- Accept pre-release version identifiers in the README parity check, and route README readers to downloadable releases; no README currently links to the Releases page.
+
+## Capabilities
+
+### New Capabilities
+
+None. This change adjusts requirements on existing release, packaging, and documentation capabilities.
+
+### Modified Capabilities
+
+- `desktop-release-delivery`: version synchronization must accept pre-release identifiers; pre-release tags must publish as GitHub pre-releases; the workflow must offer a rehearsal path that validates without a tag; unsigned distribution must be disclosed with actionable installation guidance instead of a bare statement.
+- `native-app-packaging`: the bundle target set becomes an explicit declared list rather than every target the bundler supports, and the excluded formats must be documented as an accepted limitation rather than silently dropped.
+- `multilingual-readme`: the parity check must treat a pre-release version as a valid canonical manifest fact, and each README must route readers to published downloads.
+
+## Impact
+
+**Runtime scope: neither.** This change touches build configuration, release automation, and documentation only. It does not modify desktop runtime or Web runtime behavior, React components, frontend service interfaces, Tauri adapters, Rust commands, or SQLite schema, and therefore does not affect frontend/backend isolation or any runtime adapter boundary.
+
+Affected files:
+
+- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock` — version declaration
+- `src-tauri/tauri.conf.json` — version declaration and `bundle.targets`
+- `.github/workflows/package.yml` — validation path, pre-release publication, release notes source
+- `scripts/check-readme-parity.mjs`, `scripts/check-readme-parity.node-test.mjs` — version fact pattern
+- `README.md`, `README.zh-CN.md`, `README.ja.md` — version fact, version badge, download routing
+- `docs/release-signing.md` — preview release procedure
+
+Downstream consumers: users who require an MSI or RPM package lose that format. Anyone consuming `SHA256SUMS`, the SPDX SBOM, or build provenance attestations is unaffected; those steps stay in place for preview releases.

--- a/openspec/changes/publish-github-preview-release/specs/desktop-release-delivery/spec.md
+++ b/openspec/changes/publish-github-preview-release/specs/desktop-release-delivery/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: Synchronized release version
+The release workflow MUST reject a tag when its semantic version does not match the versions declared in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`. A semantic-versioning pre-release identifier MUST be treated as part of the version and MUST be present identically in all three declarations and in the tag.
+
+#### Scenario: Release versions disagree
+- **WHEN** a release tag or one of the three version declarations differs
+- **THEN** the release workflow SHALL fail before building distributable artifacts
+
+#### Scenario: Pre-release version is synchronized
+- **WHEN** a tag carrying a pre-release identifier matches all three version declarations exactly
+- **THEN** the version check SHALL pass without stripping or normalizing the pre-release identifier
+
+#### Scenario: Pre-release identifier differs from the tag
+- **WHEN** the three declarations agree on a base version but their pre-release identifier differs from the tag's
+- **THEN** the release workflow SHALL fail before building distributable artifacts
+
+### Requirement: GitHub Release publication
+Successful tagged builds SHALL create a GitHub Release with generated notes, downloadable binaries, checksums, SBOM metadata, and integrity attestations. The tag MAY carry a semantic-versioning pre-release identifier.
+
+#### Scenario: Valid version tag is pushed
+- **WHEN** a version tag matches all project version declarations and all builds succeed
+- **THEN** the workflow SHALL publish exactly one GitHub Release for that tag
+
+## ADDED Requirements
+
+### Requirement: Pre-release publication marking
+The release workflow SHALL determine a release's pre-release status from the published tag alone and SHALL mark a release carrying a pre-release identifier as a GitHub pre-release that is not promoted to the repository's latest release.
+
+#### Scenario: Pre-release tag is published
+- **WHEN** the published tag carries a semantic-versioning pre-release identifier
+- **THEN** the resulting GitHub Release SHALL be marked as a pre-release
+- **AND** it SHALL NOT be marked as the repository's latest release
+
+#### Scenario: Stable tag is published
+- **WHEN** the published tag carries no pre-release identifier
+- **THEN** the resulting GitHub Release SHALL NOT be marked as a pre-release
+
+#### Scenario: Maintainer omits an explicit pre-release setting
+- **WHEN** a maintainer pushes a pre-release tag without configuring any additional workflow input
+- **THEN** the release SHALL still be marked as a pre-release
+
+### Requirement: Untagged release rehearsal
+The release workflow SHALL support a manual run that validates project versions and exercises the full build matrix without requiring a tag, and version validation MUST NOT interpret a branch reference as a release tag.
+
+#### Scenario: Manual run on a branch
+- **WHEN** a maintainer starts the release workflow manually against a branch
+- **THEN** version validation SHALL verify that the three version declarations agree
+- **AND** it SHALL NOT compare the branch name against a version
+
+#### Scenario: Manual run builds every declared target
+- **WHEN** a manual run passes version validation
+- **THEN** the workflow SHALL run every declared platform build and upload its artifacts
+
+#### Scenario: Manual run does not publish
+- **WHEN** a manual run completes successfully without a tag
+- **THEN** the workflow SHALL NOT create a GitHub Release
+
+### Requirement: Unsigned distribution disclosure
+When release artifacts are produced without code-signing or notarization credentials, the release notes SHALL state that the packages are unsigned and SHALL provide the per-platform steps a downloader needs to install and launch the application despite operating-system protections.
+
+#### Scenario: Unsigned release is published
+- **WHEN** a release is published without signing credentials
+- **THEN** its notes SHALL state that the packages are unsigned and un-notarized
+- **AND** they SHALL explain that checksums, SBOM metadata, and attestations establish integrity but do not replace operating-system code signing
+
+#### Scenario: Downloader installs an unsigned package
+- **WHEN** a downloader follows the published notes on macOS, Windows, or Linux
+- **THEN** the notes SHALL identify the protection prompt that platform presents
+- **AND** they SHALL give the concrete step required to proceed
+
+#### Scenario: Release notes are reviewed before publication
+- **WHEN** the installation guidance changes
+- **THEN** it SHALL be reviewed as a tracked repository file rather than authored inside the workflow run

--- a/openspec/changes/publish-github-preview-release/specs/multilingual-readme/spec.md
+++ b/openspec/changes/publish-github-preview-release/specs/multilingual-readme/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: README structural and factual parity
+The multilingual README set SHALL preserve equivalent section order, command examples, repository-relative link targets, version facts, and delivered-versus-planned feature classifications across all supported languages. A version fact SHALL be compared by its declared value, independent of any presentation encoding a badge service requires.
+
+#### Scenario: Validate equivalent README structure
+- **WHEN** the documentation parity check runs
+- **THEN** it SHALL compare stable section identifiers and their order across all three README files
+- **AND** it SHALL report the file and missing, additional, or reordered section when parity fails
+
+#### Scenario: Validate stable technical content
+- **WHEN** a command block, relative documentation link, version fact, or roadmap classification differs between README languages
+- **THEN** the documentation parity check SHALL fail with a reviewable description of the mismatch
+
+#### Scenario: Validate canonical manifest facts
+- **WHEN** a stable README fact is owned by a repository manifest
+- **THEN** the documentation parity check SHALL compare the canonical value with that manifest
+- **AND** it SHALL fail when the README value is stale even if all translations share the same stale value
+
+#### Scenario: Validate a pre-release version fact
+- **WHEN** the manifest version carries a semantic-versioning pre-release identifier
+- **THEN** the documentation parity check SHALL accept the README version fact that matches it exactly
+- **AND** it SHALL decode the badge's escaped presentation before comparison rather than failing on the encoding
+
+#### Scenario: Pre-release version fact is stale
+- **WHEN** the manifest version's pre-release identifier advances and a README still declares the previous one
+- **THEN** the documentation parity check SHALL fail
+
+#### Scenario: Translate narrative content
+- **WHEN** equivalent narrative text is expressed differently for linguistic quality
+- **THEN** parity validation SHALL allow the translated wording
+- **AND** reviewers SHALL remain responsible for semantic translation quality
+
+### Requirement: Concise README documentation routing
+Each README SHALL act as a concise project entry point and SHALL route detailed user, developer, contribution, troubleshooting, and release information to the appropriate maintained guide. Each README SHALL also route a reader to published downloads when the project publishes installable releases.
+
+#### Scenario: Reader seeks first-use instructions
+- **WHEN** a reader follows the quick-start or user-guide navigation from a README
+- **THEN** the target SHALL identify the applicable language and runtime
+- **AND** it SHALL not require the reader to infer whether a step applies to desktop or Web/mock mode
+
+#### Scenario: Developer seeks architecture details
+- **WHEN** a developer follows the developer-guide navigation from a README
+- **THEN** the target SHALL provide the curated mdBook guide and a discoverable link to the generated native API reference
+
+#### Scenario: Reader seeks a download
+- **WHEN** a reader opens any supported README while installable releases are published
+- **THEN** the README SHALL route them to the published releases
+- **AND** it SHALL identify that the current published build is a preview when the latest published release is a pre-release
+
+#### Scenario: Download routing stays in parity
+- **WHEN** download routing is added or changed in the canonical README
+- **THEN** the equivalent routing SHALL appear in every supported language
+- **AND** the parity check SHALL fail when a language is missing it

--- a/openspec/changes/publish-github-preview-release/specs/native-app-packaging/spec.md
+++ b/openspec/changes/publish-github-preview-release/specs/native-app-packaging/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Declared distributable format set
+The Tauri bundle configuration SHALL declare an explicit set of distributable formats rather than requesting every format the bundler supports. A format that cannot be produced from the project's declared version scheme SHALL be excluded from that set instead of being attempted and allowed to fail.
+
+#### Scenario: Package build runs with a declared format set
+- **WHEN** a local or workflow package command runs on a supported host platform
+- **THEN** the bundler SHALL produce only the declared formats applicable to that platform
+
+#### Scenario: Format is incompatible with the declared version
+- **WHEN** a distributable format cannot represent the project's declared version, including a semantic-versioning pre-release identifier
+- **THEN** that format SHALL be excluded from the declared set
+- **AND** the exclusion SHALL be recorded as a known limitation rather than left to fail during a release build
+
+#### Scenario: Every supported platform retains an installable format
+- **WHEN** formats are excluded from the declared set
+- **THEN** Windows, macOS, and Linux SHALL each retain at least one installable distributable format
+
+## MODIFIED Requirements
+
+### Requirement: Packaging documentation
+The system SHALL document local prerequisites, local packaging commands, GitHub Actions behavior, artifact locations, produced distributable formats, excluded formats and the reason for each exclusion, and known platform or architecture limitations.
+
+#### Scenario: Maintainer reads packaging documentation
+- **WHEN** a maintainer follows the packaging documentation
+- **THEN** they can identify required local tooling, the command to run, and where to find generated artifacts
+
+#### Scenario: Maintainer reviews CI documentation
+- **WHEN** a maintainer reviews the CI packaging documentation
+- **THEN** they can identify workflow triggers, artifact naming, and unsupported or credential-dependent release steps
+
+#### Scenario: Maintainer looks for an excluded format
+- **WHEN** a maintainer or downloader looks for a distributable format the project does not produce
+- **THEN** the documentation SHALL identify that the format is not produced and why
+- **AND** it SHALL identify the format that serves the same platform instead

--- a/openspec/changes/publish-github-preview-release/tasks.md
+++ b/openspec/changes/publish-github-preview-release/tasks.md
@@ -49,6 +49,7 @@ Every edit in this group must be applied to `README.md`, `README.zh-CN.md`, and 
 - [x] 6.1 In the `publish` job of `.github/workflows/package.yml`, derive pre-release status from whether the tag name contains a hyphen
 - [x] 6.2 Pass `--prerelease` and `--latest=false` when the tag carries a pre-release identifier, and neither when it does not
 - [x] 6.3 Pass `.github/PREVIEW_RELEASE_NOTES.md` via `--notes-file` alongside `--generate-notes`
+- [x] 6.5 Add a `macos-x64` matrix entry on the `macos-15-intel` runner so Intel Macs have a download, and list it in the release notes download table
 - [ ] 6.4 Confirm during rehearsal that generated notes are appended rather than replaced; if replaced, switch to fetching notes via `gh api .../releases/generate-notes` and concatenating before publishing, as recorded in `design.md`
 
 ## 7. Update release documentation
@@ -73,7 +74,7 @@ Every edit in this group must be applied to `README.md`, `README.zh-CN.md`, and 
 
 ## 9. Rehearse and release
 
-- [ ] 9.1 Run `workflow_dispatch` on `main` after all groups have merged, and confirm every matrix job uploads artifacts
+- [ ] 9.1 Run `workflow_dispatch` against the change branch before merging, and confirm every matrix job uploads artifacts
 - [ ] 9.2 Download the Windows, macOS, and Linux artifacts and install each on a real machine, following the published guidance verbatim
 - [ ] 9.3 Confirm the macOS `xattr` step actually resolves the quarantine prompt on a clean machine
 - [ ] 9.4 Create and push the annotated tag `v0.1.0-preview.1`

--- a/openspec/changes/publish-github-preview-release/tasks.md
+++ b/openspec/changes/publish-github-preview-release/tasks.md
@@ -1,0 +1,87 @@
+## 1. Restore the rehearsal path
+
+Land this group on its own. Every later verification step depends on being able to run the workflow without a tag.
+
+- [x] 1.1 Change `scripts/check-version-sync.mjs` so the `GITHUB_REF_NAME` fallback applies only when `GITHUB_REF_TYPE` is `tag`, leaving an explicit CLI argument authoritative
+- [x] 1.2 Add a unit test covering three cases: explicit tag argument, `GITHUB_REF_TYPE=branch` with `GITHUB_REF_NAME=main` (must pass), and `GITHUB_REF_TYPE=tag` with a mismatched tag (must fail)
+- [x] 1.3 Simplify the `validate` job's argument in `.github/workflows/package.yml` now that the script no longer depends on the conditional expression for correctness
+- [x] 1.4 Verify locally: `npm run version:check`, then `GITHUB_REF_TYPE=branch GITHUB_REF_NAME=main npm run version:check`
+- [ ] 1.5 Merge to `main`, then run `workflow_dispatch` on `main` and confirm `validate` passes and all three matrix jobs upload artifacts
+
+## 2. Adopt the pre-release version and declared bundle targets
+
+- [x] 2.1 Set `version` to `0.1.0-preview.1` in `package.json`
+- [x] 2.2 Set `[package] version` to `0.1.0-preview.1` in `src-tauri/Cargo.toml` and refresh `src-tauri/Cargo.lock`
+- [x] 2.3 Set `version` to `0.1.0-preview.1` in `src-tauri/tauri.conf.json`
+- [x] 2.4 Replace `"targets": "all"` with `["nsis", "app", "dmg", "deb", "appimage"]` in `src-tauri/tauri.conf.json`
+- [x] 2.5 Verify `npm run version:check` passes and `npm run version:check -- v0.1.0-preview.1` passes
+
+## 3. Accept pre-release version facts in README parity
+
+Tasks 3 and 4 must land in the same commit as task 2. `npm run docs:check` runs in CI and couples them.
+
+- [x] 3.1 Extend the `project-version` badge pattern in `scripts/check-readme-parity.mjs` to capture a shields.io-escaped pre-release segment, and un-escape `--` to `-` before comparing against the `docs-fact` marker
+- [x] 3.2 Add cases to `scripts/check-readme-parity.node-test.mjs` for a matching pre-release version, a stale pre-release identifier, and a stable version (no regression)
+- [x] 3.3 Verify `npm run docs:unit:test` passes
+
+## 4. Update the multilingual README set
+
+Every edit in this group must be applied to `README.md`, `README.zh-CN.md`, and `README.ja.md` together; `sections`, `commands`, and `links` arrays must stay identical across all three.
+
+- [x] 4.1 Update the `docs-fact:project-version` marker to `0.1.0-preview.1` in all three READMEs
+- [x] 4.2 Update the version badge URL to `badge/version-0.1.0--preview.1-blue.svg` in all three READMEs
+- [x] 4.3 Add a download section routing readers to the Releases page, stating that the current published build is an unsigned preview, in all three READMEs
+- [x] 4.4 Verify `npm run docs:check` and `npm run docs:links:check` pass
+
+## 5. Author the preview release notes
+
+- [x] 5.1 Create `.github/PREVIEW_RELEASE_NOTES.md` stating the build is a preview and that packages are unsigned and un-notarized
+- [x] 5.2 Add the feature boundary section, reusing the delivered / preview / planned classification already maintained in `README.md`
+- [x] 5.3 Add macOS guidance: the quarantine prompt reporting a damaged application, and `xattr -cr "/Applications/VaneHub AI.app"`
+- [x] 5.4 Add Windows guidance: the SmartScreen prompt and the "More info" then "Run anyway" path for the NSIS installer
+- [x] 5.5 Add Linux guidance covering the `.deb` and AppImage assets, and state that no `.rpm` or `.msi` is published and which asset serves those users instead
+- [x] 5.6 Add `SHA256SUMS` verification steps and state that checksums, SBOM, and attestations establish integrity but do not replace code signing
+- [x] 5.7 Add the feedback route to the existing issue templates
+- [x] 5.8 Keep the file version-independent: refer to assets by format, never by filename
+
+## 6. Publish pre-releases correctly
+
+- [x] 6.1 In the `publish` job of `.github/workflows/package.yml`, derive pre-release status from whether the tag name contains a hyphen
+- [x] 6.2 Pass `--prerelease` and `--latest=false` when the tag carries a pre-release identifier, and neither when it does not
+- [x] 6.3 Pass `.github/PREVIEW_RELEASE_NOTES.md` via `--notes-file` alongside `--generate-notes`
+- [ ] 6.4 Confirm during rehearsal that generated notes are appended rather than replaced; if replaced, switch to fetching notes via `gh api .../releases/generate-notes` and concatenating before publishing, as recorded in `design.md`
+
+## 7. Update release documentation
+
+- [x] 7.1 Add the preview release sequence to `docs/release-signing.md`, including the untagged rehearsal step
+- [x] 7.2 Document the declared bundle target set in `docs/release-signing.md` or `docs/build-performance.md`, naming MSI and RPM as excluded and stating why
+- [x] 7.3 State in the same document that unsigned preview packages require the published installation guidance
+
+## 8. Verification
+
+- [x] 8.1 Run `npm run lint:ci`
+- [x] 8.2 Run `npm run test`
+- [x] 8.3 Run `npm run build`
+- [x] 8.4 Run `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
+- [x] 8.5 Run `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
+- [x] 8.6 Run `cargo test --manifest-path src-tauri/Cargo.toml`
+- [x] 8.7 Run `cargo check --manifest-path src-tauri/Cargo.toml`
+- [x] 8.8 Run `npm run docs:check` and `npm run coverage:policy:test`
+- [x] 8.9 Run `openspec validate publish-github-preview-release --strict` and `openspec validate --specs --strict`
+- [x] 8.10 Run `npm run package:windows:x64` locally and confirm the NSIS installer is produced and no MSI step is attempted
+- [ ] 8.11 Install the local NSIS build, launch it, create a session, and run one Agent end to end
+
+## 9. Rehearse and release
+
+- [ ] 9.1 Run `workflow_dispatch` on `main` after all groups have merged, and confirm every matrix job uploads artifacts
+- [ ] 9.2 Download the Windows, macOS, and Linux artifacts and install each on a real machine, following the published guidance verbatim
+- [ ] 9.3 Confirm the macOS `xattr` step actually resolves the quarantine prompt on a clean machine
+- [ ] 9.4 Create and push the annotated tag `v0.1.0-preview.1`
+- [ ] 9.5 Confirm the published release is marked as a pre-release, is not marked latest, and carries the preview notes above the generated notes
+- [ ] 9.6 Confirm `SHA256SUMS`, the SPDX SBOM, and the attestations are attached, and run `gh attestation verify` against one asset
+
+## 10. Archive
+
+- [ ] 10.1 Replace the `TBD` Purpose in `openspec/specs/desktop-release-delivery/spec.md` with the capability's actual purpose
+- [ ] 10.2 Replace the `TBD` Purpose in `openspec/specs/multilingual-readme/spec.md` with the capability's actual purpose
+- [ ] 10.3 Run `openspec archive publish-github-preview-release`, then `powershell -ExecutionPolicy Bypass -File scripts/Update-OpenSpecArchiveIndex.ps1`, and commit the main specs, archive directory, and index together

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanehub-ai",
-  "version": "0.1.0",
+  "version": "0.1.0-preview.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "package:linux:x64": "tauri build --target x86_64-unknown-linux-gnu",
     "package:linux:arm64": "tauri build --target aarch64-unknown-linux-gnu",
     "version:check": "node scripts/check-version-sync.mjs",
+    "version:unit:test": "node --test scripts/check-version-sync.node-test.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "coverage:check:frontend": "node scripts/check-coverage-policy.mjs --kind frontend --report coverage/frontend/coverage-summary.json",

--- a/scripts/check-readme-parity.mjs
+++ b/scripts/check-readme-parity.mjs
@@ -10,11 +10,24 @@ const requiredFactIds = [
   "react-major",
   "node-minimum",
 ];
+// Shields.io renders a literal hyphen in a static badge only when it is escaped as `--`, so a
+// pre-release version reaches the badge URL encoded and must be decoded before being compared
+// against the manifest value it mirrors.
+function decodeShieldsSegment(value) {
+  return value.replaceAll("--", "-");
+}
+
 const visibleFactPatterns = new Map([
-  ["project-version", /badge\/version-([0-9]+\.[0-9]+\.[0-9]+)-/i],
-  ["tauri-major", /badge\/Tauri-([0-9]+\.x)-/i],
-  ["react-major", /badge\/React-([0-9]+\.x)-/i],
-  ["node-minimum", /Node\.js\s+([0-9]+\+)/i],
+  [
+    "project-version",
+    {
+      pattern: /badge\/version-([0-9]+\.[0-9]+\.[0-9]+(?:--[0-9A-Za-z.]+)*)-/i,
+      decode: decodeShieldsSegment,
+    },
+  ],
+  ["tauri-major", { pattern: /badge\/Tauri-([0-9]+\.x)-/i, decode: decodeShieldsSegment }],
+  ["react-major", { pattern: /badge\/React-([0-9]+\.x)-/i, decode: decodeShieldsSegment }],
+  ["node-minimum", { pattern: /Node\.js\s+([0-9]+\+)/i }],
 ]);
 
 function collect(pattern, content, transform = (match) => match[1]) {
@@ -101,8 +114,9 @@ function validateFacts(file, content, facts, errors, expectedManifestFacts) {
     if (!factMap.has(id)) errors.push(`${file}: missing stable documentation fact "${id}".`);
   }
 
-  for (const [id, pattern] of visibleFactPatterns) {
-    const visibleValue = content.match(pattern)?.[1];
+  for (const [id, { pattern, decode }] of visibleFactPatterns) {
+    const rendered = content.match(pattern)?.[1];
+    const visibleValue = rendered && decode ? decode(rendered) : rendered;
     if (!visibleValue) {
       errors.push(`${file}: visible value for stable documentation fact "${id}" is missing.`);
     } else if (factMap.get(id) !== visibleValue) {

--- a/scripts/check-readme-parity.node-test.mjs
+++ b/scripts/check-readme-parity.node-test.mjs
@@ -23,14 +23,14 @@ npm run dev
 \`\`\`
 `;
 
-function fixture(contents = [base, base, base]) {
+function fixture(contents = [base, base, base], version = "0.1.0") {
   const root = mkdtempSync(join(tmpdir(), "vanehub-readme-parity-"));
   const files = ["README.md", "README.zh-CN.md", "README.ja.md"];
   files.forEach((file, index) => writeFileSync(join(root, file), contents[index], "utf8"));
   writeFileSync(
     join(root, "package.json"),
     JSON.stringify({
-      version: "0.1.0",
+      version,
       dependencies: {
         "@tauri-apps/api": "^2.0.0",
         react: "^19.2.8",
@@ -39,6 +39,14 @@ function fixture(contents = [base, base, base]) {
     "utf8",
   );
   return { root, files };
+}
+
+// Shields.io escapes a literal hyphen as `--`, so the badge and the fact marker never carry the
+// same spelling of a pre-release version.
+function withVersion(content, version) {
+  return content
+    .replace("project-version value:0.1.0", `project-version value:${version}`)
+    .replace("badge/version-0.1.0-", `badge/version-${version.replaceAll("-", "--")}-`);
 }
 
 test("accepts translated prose with matching stable facts", () => {
@@ -72,6 +80,42 @@ test("reports a visible badge that drifts from its stable fact marker", () => {
   assert.throws(
     () => checkReadmeParity(files, root),
     /README\.zh-CN\.md: visible fact "react-major" is "18\.x"/,
+  );
+});
+
+test("accepts a pre-release version whose badge escapes the hyphen", () => {
+  const preview = withVersion(base, "0.1.0-preview.1");
+  const { root, files } = fixture([preview, preview, preview], "0.1.0-preview.1");
+  assert.doesNotThrow(() => checkReadmeParity(files, root));
+});
+
+test("accepts a multi-segment pre-release identifier", () => {
+  const candidate = withVersion(base, "0.1.0-rc.1");
+  const { root, files } = fixture([candidate, candidate, candidate], "0.1.0-rc.1");
+  assert.doesNotThrow(() => checkReadmeParity(files, root));
+});
+
+test("reports a stale pre-release identifier against package.json", () => {
+  const stale = withVersion(base, "0.1.0-preview.1");
+  const { root, files } = fixture([stale, stale, stale], "0.1.0-preview.2");
+  assert.throws(
+    () => checkReadmeParity(files, root),
+    /README\.md: stable fact "project-version" differs from package\.json/,
+  );
+});
+
+test("reports a badge that drops the pre-release identifier its marker declares", () => {
+  const mismatched = withVersion(base, "0.1.0-preview.1").replace(
+    "badge/version-0.1.0--preview.1-",
+    "badge/version-0.1.0-",
+  );
+  const { root, files } = fixture(
+    [mismatched, mismatched, mismatched],
+    "0.1.0-preview.1",
+  );
+  assert.throws(
+    () => checkReadmeParity(files, root),
+    /README\.md: visible fact "project-version" is "0\.1\.0", but its marker is "0\.1\.0-preview\.1"/,
   );
 });
 

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -1,40 +1,64 @@
-import { readFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import console from "node:console";
 import process from "node:process";
 
-const packageJson = JSON.parse(await readFile("package.json", "utf8"));
-const tauriConfig = JSON.parse(
-  await readFile("src-tauri/tauri.conf.json", "utf8"),
-);
-const cargoToml = await readFile("src-tauri/Cargo.toml", "utf8");
-const cargoPackage = cargoToml.match(
-  /\[package\][\s\S]*?^version\s*=\s*"([^"]+)"/m,
-);
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
-if (!cargoPackage) {
-  throw new Error("Could not read the [package] version from src-tauri/Cargo.toml");
+function readCargoPackageVersion(root) {
+  const cargoToml = readFileSync(resolve(root, "src-tauri", "Cargo.toml"), "utf8");
+  const cargoPackage = cargoToml.match(/\[package\][\s\S]*?^version\s*=\s*"([^"]+)"/m);
+  if (!cargoPackage) {
+    throw new Error("Could not read the [package] version from src-tauri/Cargo.toml");
+  }
+  return cargoPackage[1];
 }
 
-const versions = new Map([
-  ["package.json", packageJson.version],
-  ["src-tauri/Cargo.toml", cargoPackage[1]],
-  ["src-tauri/tauri.conf.json", tauriConfig.version],
-]);
-const uniqueVersions = new Set(versions.values());
-
-if (uniqueVersions.size !== 1) {
-  const details = [...versions]
-    .map(([file, version]) => `${file}: ${String(version)}`)
-    .join("\n");
-  throw new Error(`Project versions are not synchronized:\n${details}`);
+// GitHub sets GITHUB_REF_NAME for every ref, so falling back to it unconditionally made a
+// workflow_dispatch run compare a branch name against `v<version>` and fail. That left the
+// release workflow with no way to rehearse a build without first pushing a tag.
+export function resolveReleaseTag(argv = process.argv, env = process.env) {
+  const explicit = argv[2];
+  if (explicit) return explicit;
+  return env.GITHUB_REF_TYPE === "tag" ? env.GITHUB_REF_NAME : undefined;
 }
 
-const version = packageJson.version;
-const suppliedTag = process.argv[2] ?? process.env.GITHUB_REF_NAME;
-if (suppliedTag && suppliedTag !== `v${version}`) {
-  throw new Error(
-    `Release tag ${suppliedTag} does not match synchronized version v${version}`,
+export function checkVersionSync(root = repositoryRoot, tag = undefined) {
+  const packageJson = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+  const tauriConfig = JSON.parse(
+    readFileSync(resolve(root, "src-tauri", "tauri.conf.json"), "utf8"),
   );
+
+  const versions = new Map([
+    ["package.json", packageJson.version],
+    ["src-tauri/Cargo.toml", readCargoPackageVersion(root)],
+    ["src-tauri/tauri.conf.json", tauriConfig.version],
+  ]);
+
+  if (new Set(versions.values()).size !== 1) {
+    const details = [...versions]
+      .map(([file, version]) => `${file}: ${String(version)}`)
+      .join("\n");
+    throw new Error(`Project versions are not synchronized:\n${details}`);
+  }
+
+  const version = packageJson.version;
+  // A pre-release identifier is part of the version, so the tag must carry it verbatim
+  // rather than being normalized away.
+  if (tag && tag !== `v${version}`) {
+    throw new Error(`Release tag ${tag} does not match synchronized version v${version}`);
+  }
+  return version;
 }
 
-console.log(`Version ${version} is synchronized across npm, Cargo, and Tauri.`);
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    const version = checkVersionSync(repositoryRoot, resolveReleaseTag());
+    console.log(`Version ${version} is synchronized across npm, Cargo, and Tauri.`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-version-sync.node-test.mjs
+++ b/scripts/check-version-sync.node-test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { checkVersionSync, resolveReleaseTag } from "./check-version-sync.mjs";
+
+function fixture({
+  packageVersion = "0.1.0-preview.1",
+  cargoVersion = packageVersion,
+  tauriVersion = packageVersion,
+} = {}) {
+  const root = mkdtempSync(join(tmpdir(), "vanehub-version-sync-"));
+  mkdirSync(join(root, "src-tauri"));
+  writeFileSync(join(root, "package.json"), JSON.stringify({ version: packageVersion }), "utf8");
+  writeFileSync(
+    join(root, "src-tauri", "Cargo.toml"),
+    `[package]\nname = "vanehub-ai"\nversion = "${cargoVersion}"\n`,
+    "utf8",
+  );
+  writeFileSync(
+    join(root, "src-tauri", "tauri.conf.json"),
+    JSON.stringify({ version: tauriVersion }),
+    "utf8",
+  );
+  return root;
+}
+
+test("an explicit tag argument takes precedence over the environment", () => {
+  const env = { GITHUB_REF_TYPE: "tag", GITHUB_REF_NAME: "v9.9.9" };
+  assert.equal(resolveReleaseTag(["node", "script", "v0.1.0-preview.1"], env), "v0.1.0-preview.1");
+});
+
+test("a branch ref is not resolved as a release tag", () => {
+  const env = { GITHUB_REF_TYPE: "branch", GITHUB_REF_NAME: "main" };
+  assert.equal(resolveReleaseTag(["node", "script"], env), undefined);
+});
+
+test("a tag ref is resolved from the environment", () => {
+  const env = { GITHUB_REF_TYPE: "tag", GITHUB_REF_NAME: "v0.1.0-preview.1" };
+  assert.equal(resolveReleaseTag(["node", "script"], env), "v0.1.0-preview.1");
+});
+
+test("a manual run on a branch validates versions without comparing a tag", () => {
+  const root = fixture();
+  const tag = resolveReleaseTag(["node", "script"], {
+    GITHUB_REF_TYPE: "branch",
+    GITHUB_REF_NAME: "main",
+  });
+  assert.equal(checkVersionSync(root, tag), "0.1.0-preview.1");
+});
+
+test("a matching pre-release tag passes without normalizing the identifier", () => {
+  const root = fixture();
+  assert.equal(checkVersionSync(root, "v0.1.0-preview.1"), "0.1.0-preview.1");
+});
+
+test("a tag whose pre-release identifier differs is rejected", () => {
+  const root = fixture();
+  assert.throws(
+    () => checkVersionSync(root, "v0.1.0-preview.2"),
+    /Release tag v0\.1\.0-preview\.2 does not match synchronized version v0\.1\.0-preview\.1/,
+  );
+});
+
+test("a tag that drops the pre-release identifier is rejected", () => {
+  const root = fixture();
+  assert.throws(() => checkVersionSync(root, "v0.1.0"), /does not match synchronized version/);
+});
+
+test("declarations that disagree on the pre-release identifier are rejected", () => {
+  const root = fixture({ tauriVersion: "0.1.0" });
+  assert.throws(
+    () => checkVersionSync(root, "v0.1.0-preview.1"),
+    /Project versions are not synchronized[\s\S]*src-tauri\/tauri\.conf\.json: 0\.1\.0/,
+  );
+});
+
+test("a stable version still validates against its tag", () => {
+  const root = fixture({ packageVersion: "0.1.0" });
+  assert.equal(checkVersionSync(root, "v0.1.0"), "0.1.0");
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6481,7 +6481,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vanehub-ai"
-version = "0.1.0"
+version = "0.1.0-preview.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanehub-ai"
-version = "0.1.0"
+version = "0.1.0-preview.1"
 description = "Unified AI coding agent management"
 authors = ["vanehub-ai"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VaneHub AI",
-  "version": "0.1.0",
+  "version": "0.1.0-preview.1",
   "identifier": "ai.vanehub.app",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -28,7 +28,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["nsis", "app", "dmg", "deb", "appimage"],
     "icon": [
       "icons/generated/32x32.png",
       "icons/generated/128x128.png",


### PR DESCRIPTION
## Why

`.github/workflows/package.yml` has never executed once — `gh run list --workflow=package.yml` and `gh release list` were both empty. Its only untagged rehearsal path was broken, so the first real execution would have been a tag push publishing straight to a public repository with no way to rehearse.

The project also needs repeated public preview builds (`preview.1`, `preview.2`, `rc.1`) before `0.1.0`, which the pipeline could not express: every tag published as a full latest release, and the Windows MSI bundler rejects a semantic-versioning pre-release identifier outright.

OpenSpec change: `openspec/changes/publish-github-preview-release/`

## What changed

**Rehearsal path (`ab3ad49`)** — `check-version-sync.mjs` resolved the tag as `process.argv[2] ?? process.env.GITHUB_REF_NAME`. GitHub sets `GITHUB_REF_NAME` for every ref, so a `workflow_dispatch` run on a branch compared `main` against `v<version>` and failed. The fallback now applies only when `GITHUB_REF_TYPE` is `tag`. Fixed in the script rather than only at the call site, so the invariant holds for any caller. Extracted into testable functions with a new suite wired into CI.

**Preview releases (`6649797`)** — version becomes `0.1.0-preview.1`, declared identically in `package.json`, `Cargo.toml`, and `tauri.conf.json`. `bundle.targets` becomes an explicit list, dropping two formats that cannot represent that version:

- `tauri-bundler` aborts an MSI build when the pre-release identifier is not numeric (`ProductVersion` accepts only `major.minor.patch[.build]`).
- The RPM `Version` field cannot contain a hyphen, and the bundler passes the version through unsanitized.

Windows ships the NSIS installer (per-user, no admin rights); Linux ships `.deb` and AppImage. A pre-release tag publishes with `--prerelease --latest=false`, derived from the tag alone so no maintainer input can be forgotten, and `.github/PREVIEW_RELEASE_NOTES.md` is prepended with the unsigned-package disclosure and per-platform Gatekeeper/SmartScreen steps.

**Intel macOS (`3f05554`)** — `package:macos:x64` existed but no matrix entry used it, so Intel Mac users would have had no download at all. Added on the `macos-15-intel` runner (`macos-13` is retired).

## Verification

Full AGENTS.md validation suite passes: `lint:ci`, `test` (151 files / 670 tests), `build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (1706 passed), `cargo check`, `docs:check`, `coverage:policy:test`, `version:unit:test`, `openspec validate --strict` (change + 91 specs).

`npm run package:windows:x64` was run locally against the pre-release version. It produced exactly one bundle — `bundle/nsis/VaneHub AI_0.1.0-preview.1_x64-setup.exe` — and never attempted MSI.

## Not yet done

Real-machine installation of each artifact, and confirming on macOS that clearing the quarantine attribute actually resolves the Gatekeeper prompt. No tag is pushed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
