### PR TITLE
fix(release): stop blank secrets from failing the macOS build

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -62,15 +62,6 @@ jobs:
             runner: ubuntu-latest
             rust_target: x86_64-unknown-linux-gnu
             npm_script: package:linux:x64
-    env:
-      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-      APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -122,6 +113,35 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Forward provisioned signing credentials
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          # An unset secret expands to an empty string rather than being absent, and the Tauri
+          # bundler treats a defined APPLE_CERTIFICATE as a request to sign. Forwarding a blank
+          # value fails the macOS build at `security import` instead of producing the unsigned
+          # bundle an unprovisioned repository should get, so only non-empty values are exported.
+          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY \
+                      APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID \
+                      TAURI_SIGNING_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+            value="${!name}"
+            if [[ -n "${value}" ]]; then
+              printf '%s<<__VANEHUB_ENV__\n%s\n__VANEHUB_ENV__\n' "${name}" "${value}" >> "${GITHUB_ENV}"
+            fi
+          done
+
+          if [[ -z "${APPLE_CERTIFICATE}" && "${RUNNER_OS}" == "macOS" ]]; then
+            echo "No Apple signing credentials configured; producing an unsigned, un-notarized bundle."
+          fi
+
       - name: Build package
         run: npm run ${{ matrix.npm_script }}
 
@@ -129,9 +149,14 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: VaneHub-AI-${{ matrix.platform }}-${{ matrix.arch }}
+          # Collect distributables by format rather than the whole bundle tree. `bundle/**` also
+          # matches the AppImage's unpacked `.AppDir` and the deb build directory (268 extra
+          # files in one Linux run), and every one of them would be attached to the release.
           path: |
-            src-tauri/target/${{ matrix.rust_target }}/release/bundle/**
-            src-tauri/target/release/bundle/**
+            src-tauri/target/${{ matrix.rust_target }}/release/bundle/*/*.exe
+            src-tauri/target/${{ matrix.rust_target }}/release/bundle/*/*.dmg
+            src-tauri/target/${{ matrix.rust_target }}/release/bundle/*/*.deb
+            src-tauri/target/${{ matrix.rust_target }}/release/bundle/*/*.AppImage
           if-no-files-found: error
           retention-days: 7
 

--- a/openspec/changes/publish-github-preview-release/design.md
+++ b/openspec/changes/publish-github-preview-release/design.md
@@ -83,13 +83,17 @@ This must land in the same commit as the README edits. `npm run docs:check` runs
 
 Preview-specific guidance lives in `.github/PREVIEW_RELEASE_NOTES.md` so it is reviewable, diffable, and cannot drift from the workflow that consumes it. The publish job prepends it to the auto-generated pull-request summary.
 
-`gh release create --help` documents the prepend behavior for `--notes` specifically and does not name `--notes-file`. The implementation uses `--notes-file` and the rehearsal must confirm that generated notes are appended rather than replaced. If they are replaced, the fallback is to fetch generated notes explicitly and concatenate before publishing:
+`gh release create --help` documents the prepend behavior for `--notes` specifically and does not name `--notes-file`, but both populate the same field. In `pkg/cmd/release/create/create.go`, `--notes-file` is read into `opts.Body`, and generated notes are appended to whatever body is already present:
 
-```bash
-gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-  -f tag_name="${GITHUB_REF_NAME}" --jq .body > generated-notes.md
-cat .github/PREVIEW_RELEASE_NOTES.md generated-notes.md > release-notes.md
+```go
+if opts.Body == "" {
+  params["body"] = generatedNotes.Body
+} else {
+  params["body"] = fmt.Sprintf("%s\n%s", opts.Body, generatedNotes.Body)
+}
 ```
+
+The preview guidance therefore lands above the generated pull-request summary, which is the intended order. No concatenation step is needed.
 
 The notes file stays version-independent so it does not need editing per preview: it refers to assets by format rather than by filename, and the `xattr` path is the installed application path, not a download path.
 

--- a/openspec/changes/publish-github-preview-release/specs/desktop-release-delivery/spec.md
+++ b/openspec/changes/publish-github-preview-release/specs/desktop-release-delivery/spec.md
@@ -22,7 +22,34 @@ Successful tagged builds SHALL create a GitHub Release with generated notes, dow
 - **WHEN** a version tag matches all project version declarations and all builds succeed
 - **THEN** the workflow SHALL publish exactly one GitHub Release for that tag
 
+### Requirement: Protected release credentials
+Signing and notarization credentials MUST be read only from GitHub encrypted secrets scoped to a protected release environment and MUST NOT be committed to the repository or exposed to pull-request workflows. A credential that has not been provisioned MUST NOT reach the build as an empty value.
+
+#### Scenario: Release credentials are absent
+- **WHEN** the repository has not been provisioned with real signing credentials
+- **THEN** configuration SHALL identify the missing deployment prerequisite without fabricating or persisting a secret
+
+#### Scenario: Release job accesses credentials
+- **WHEN** an authorized release deployment runs
+- **THEN** only the release job SHALL receive the environment-scoped credentials required by its target platform
+
+#### Scenario: Build runs without provisioned credentials
+- **WHEN** a platform build runs and no signing credential is provisioned for it
+- **THEN** the build SHALL receive no credential variable at all rather than a blank one
+- **AND** it SHALL produce an unsigned distributable rather than failing
+
 ## ADDED Requirements
+
+### Requirement: Published release assets
+A published release SHALL attach only distributable package files. Intermediate build output produced while assembling a package MUST NOT be attached.
+
+#### Scenario: Packaging leaves intermediate output beside a distributable
+- **WHEN** a bundler writes staging directories or unpacked trees into the bundle output directory
+- **THEN** those files SHALL NOT be collected as release assets
+
+#### Scenario: Release assets are collected
+- **WHEN** platform artifacts are gathered for publication
+- **THEN** each collected file SHALL be an installable package in one of the declared distributable formats
 
 ### Requirement: Pre-release publication marking
 The release workflow SHALL determine a release's pre-release status from the published tag alone and SHALL mark a release carrying a pre-release identifier as a GitHub pre-release that is not promoted to the repository's latest release.

--- a/openspec/changes/publish-github-preview-release/tasks.md
+++ b/openspec/changes/publish-github-preview-release/tasks.md
@@ -50,7 +50,7 @@ Every edit in this group must be applied to `README.md`, `README.zh-CN.md`, and 
 - [x] 6.2 Pass `--prerelease` and `--latest=false` when the tag carries a pre-release identifier, and neither when it does not
 - [x] 6.3 Pass `.github/PREVIEW_RELEASE_NOTES.md` via `--notes-file` alongside `--generate-notes`
 - [x] 6.5 Add a `macos-x64` matrix entry on the `macos-15-intel` runner so Intel Macs have a download, and list it in the release notes download table
-- [ ] 6.4 Confirm during rehearsal that generated notes are appended rather than replaced; if replaced, switch to fetching notes via `gh api .../releases/generate-notes` and concatenating before publishing, as recorded in `design.md`
+- [x] 6.4 Confirm generated notes are appended rather than replaced. `gh` reads `--notes-file` into `opts.Body` and formats `"%s\n%s"` with the generated notes second, so the preview guidance lands above the generated summary and no concatenation fallback is needed
 
 ## 7. Update release documentation
 
@@ -76,7 +76,7 @@ Every edit in this group must be applied to `README.md`, `README.zh-CN.md`, and 
 
 - [x] 9.0a Forward Apple and Tauri signing credentials to the build only when non-empty. An unset secret expands to a blank string, and the bundler read that as a request to sign, failing both macOS jobs at `security import` in the first rehearsal
 - [x] 9.0b Collect artifacts by distributable format instead of `bundle/**`, which swept in the AppImage `.AppDir` tree and deb staging directory — 270 files in the Linux artifact where 2 are distributables
-- [ ] 9.1 Run `workflow_dispatch` against the change branch before merging, and confirm every matrix job uploads artifacts
+- [x] 9.1 Run `workflow_dispatch` against the change branch before merging, and confirm every matrix job uploads artifacts
 - [ ] 9.2 Download the Windows, macOS, and Linux artifacts and install each on a real machine, following the published guidance verbatim
 - [ ] 9.3 Confirm the macOS `xattr` step actually resolves the quarantine prompt on a clean machine
 - [ ] 9.4 Create and push the annotated tag `v0.1.0-preview.1`

--- a/openspec/changes/publish-github-preview-release/tasks.md
+++ b/openspec/changes/publish-github-preview-release/tasks.md
@@ -74,6 +74,8 @@ Every edit in this group must be applied to `README.md`, `README.zh-CN.md`, and 
 
 ## 9. Rehearse and release
 
+- [x] 9.0a Forward Apple and Tauri signing credentials to the build only when non-empty. An unset secret expands to a blank string, and the bundler read that as a request to sign, failing both macOS jobs at `security import` in the first rehearsal
+- [x] 9.0b Collect artifacts by distributable format instead of `bundle/**`, which swept in the AppImage `.AppDir` tree and deb staging directory — 270 files in the Linux artifact where 2 are distributables
 - [ ] 9.1 Run `workflow_dispatch` against the change branch before merging, and confirm every matrix job uploads artifacts
 - [ ] 9.2 Download the Windows, macOS, and Linux artifacts and install each on a real machine, following the published guidance verbatim
 - [ ] 9.3 Confirm the macOS `xattr` step actually resolves the quarantine prompt on a clean machine


### PR DESCRIPTION
Follow-up to #98, which merged while the first rehearsal was still running. Two blockers the rehearsal found are not on `main`, and both only surface when the workflow actually runs.

`main` currently declares `0.1.0-preview.1` and carries the `macos-x64` matrix entry, so it looks ready to tag. **It is not.** Tagging `main` as it stands produces a release with no macOS packages and hundreds of spurious assets.

## 1. macOS builds fail before producing anything

Rehearsal [31198004811](https://github.com/cdavid817/vanehub-ai/actions/runs/31198004811) failed both macOS jobs at bundling:

```
failed to bundle project: failed codesign application:
  failed to run command security import: failed to import keychain certificate
```

An unset GitHub secret expands to an empty string rather than being absent, so the job-level `APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}` always defined the variable. The Tauri bundler reads a defined `APPLE_CERTIFICATE` as a request to sign, tried to import a blank certificate, and aborted.

This is not new to the preview work — macOS packages could never have been produced on this repository, by tag or by manual run, before Apple credentials were provisioned.

Each credential is now forwarded to the build only when non-empty, so an unprovisioned repository builds unsigned and a provisioned one signs.

## 2. Releases would attach build intermediates

The Linux artifact was 245 MB holding 270 files, of which 2 were distributables. `bundle/**` also matches the AppImage's unpacked `.AppDir` (251 files) and the deb staging directory, and the publish job attaches every file `find` returns.

Artifacts are now collected by distributable format.

## Verification

Rehearsal [31201213407](https://github.com/cdavid817/vanehub-ai/actions/runs/31201213407) passes on all four targets. macOS logs `No Apple signing credentials configured; producing an unsigned, un-notarized bundle.` and proceeds. The artifacts total exactly five files:

| Asset | Size |
| --- | --- |
| `VaneHub AI_0.1.0-preview.1_amd64.AppImage` | 87.6 MB |
| `VaneHub AI_0.1.0-preview.1_amd64.deb` | 17.7 MB |
| `VaneHub AI_0.1.0-preview.1_aarch64.dmg` | 15.0 MB |
| `VaneHub AI_0.1.0-preview.1_x64.dmg` | 15.9 MB |
| `VaneHub AI_0.1.0-preview.1_x64-setup.exe` | 12.0 MB |

Also adds the two requirements these gaps correspond to — credentials must reach the build absent rather than blank, and a release attaches only distributables — plus the resolved note-composition question in `design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
