### PR TITLE
fix(permissions): refuse to install a hook naming a missing binary

### DIFF
--- a/.github/PREVIEW_RELEASE_NOTES.md
+++ b/.github/PREVIEW_RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 - **Delivered:** CLI management, single-Agent sessions, interactive Agent terminals, session organization, project/worktree and SSH workspace tools, settings, MCP/SDK/Skills/Prompt Hooks/extensions, IM connectors, scheduled tasks, notifications, usage reporting, and unified redacted logs.
 - **Preview:** Multi-Agent coordination has native and Web/mock service contracts, but the create-session UI still disables Multi Agent mode.
 - **Not available yet:** the Multi-Agent coordination UI, and Japanese application UI resources — Japanese currently covers the README only.
+- **Not available in this build:** Claude Code permission-hook management. The hook is a separate binary that these packages do not yet ship, so enabling it in settings reports an error rather than writing a hook Claude Code could not run. Every other permission surface is unaffected, and your global Claude Code settings are left untouched.
 
 ## Downloads
 

--- a/openspec/changes/refuse-missing-permission-hook-binary/.openspec.yaml
+++ b/openspec/changes/refuse-missing-permission-hook-binary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/refuse-missing-permission-hook-binary/design.md
+++ b/openspec/changes/refuse-missing-permission-hook-binary/design.md
@@ -1,0 +1,49 @@
+## Context
+
+`ClaudeCodeHookAdapter` writes `PreToolUse` entries into Claude Code's global `settings.json` through `cli_config`'s hook-projection port. Each entry's `command` is `wrapper_binary_path(app)`, resolved in `bootstrap/permissions.rs` as the Tauri resource directory joined with the binary name, falling back to the running executable's directory.
+
+`tauri.conf.json` declares neither `bundle.resources` nor `bundle.externalBin`, so no packaged build contains the wrapper. In development the fallback happens to land on `target/<profile>/`, where `cargo` has just built it, which is why this never surfaced before a package was installed.
+
+Installation is not automatic: `PermissionsApi::assign_template` calls `install()` only for the `claude-code` agent, and `permissions-approval` requires a distinct first-use confirmation. The damage is therefore opt-in — but when taken, it persists in a file VaneHub does not own.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Never name a non-existent command in another tool's global configuration.
+- Say why, at the moment the user asks for it.
+- Keep the escape hatch open for anyone already affected.
+
+**Non-Goals:**
+
+- Shipping the wrapper binary. That is the real fix and is deliberately separate; see Open Questions.
+- Changing how the path is resolved. The current resolution is also wrong for a sidecar, but correcting it without shipping the binary would change one wrong path for another.
+- Any Web-runtime behaviour. That runtime has no permission-hook surface.
+
+## Decisions
+
+### Check in the adapter, not at the call site
+
+`install()` verifies `wrapper_path.is_file()` before delegating to the projection. The adapter is the only place that knows what the entries contain and which binary they name, so it is the only place that can check the two are consistent. A caller-side check would have to duplicate the path and stay in sync with it.
+
+`is_file()` rather than `exists()`: a directory at that path would satisfy `exists()` and still be unexecutable.
+
+### Guard `install` only, never `remove`
+
+`remove()` writes an empty entry list and names no binary, so it has no precondition to violate. Guarding it would strand exactly the users this change exists for — anyone who enabled the hook against a build that wrote it — with entries they can no longer clear from inside the app.
+
+### Report through the existing infrastructure error
+
+The failure is returned as `PermissionsApplicationError::Infrastructure { category: "cli_config" }`, which `assign_template` already propagates to the command layer. No new error variant, no new command, and the existing frontend path surfaces it.
+
+The message names the resolved path. A user who reports "hook management won't turn on" then arrives with the location that was checked, which is what distinguishes "this build doesn't ship it" from "it was there and moved".
+
+## Risks / Trade-offs
+
+- **A previously working setup now reports an error.** → Only where the binary is genuinely gone. If it was working, the file is present and nothing changes.
+- **The check races a delete between the test and the write.** → Accepted. The window is microseconds, the consequence is the pre-existing behaviour, and closing it would mean holding a lock over another tool's configuration file.
+- **Reporting an error is not the same as making the feature work.** → It is not meant to be. The feature is unavailable in packaged builds either way; this change makes that visible instead of leaving a broken hook behind. The preview release notes state it plainly.
+
+## Open Questions
+
+- Shipping the wrapper as a Tauri sidecar needs `bundle.externalBin`, a step that builds it per target and renames it to `vanehub-permission-hook-<triple>`, and a corrected resolution order — a sidecar lands beside the main executable, so preferring the resource directory would still miss it. All four packaging targets need to be validated. Worth doing before `0.1.0`; too large to fold in here.

--- a/openspec/changes/refuse-missing-permission-hook-binary/proposal.md
+++ b/openspec/changes/refuse-missing-permission-hook-binary/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The permission-hook wrapper is a second binary (`src-tauri/src/bin/vanehub-permission-hook.rs`). `tauri.conf.json` declares no `bundle.resources` and no `bundle.externalBin`, so no packaged build ships it — `bootstrap/permissions.rs` records this as "deliberately out of scope for this pass".
+
+Nothing checks for it before use. Enabling Claude Code permission management writes `PreToolUse` entries into Claude Code's **global** `settings.json` naming that path. In a packaged build the path does not exist, so Claude Code invokes a command that cannot start on every matching tool call — in a file VaneHub does not own, which keeps that state after VaneHub exits.
+
+Confirmed on a packaged Windows build: `vanehub-permission-hook.exe` is absent, and `wrapper_binary_path` resolves through the Tauri resource directory to a path with nothing at it.
+
+## What Changes
+
+- Installing the Claude Code hook fails with an actionable error when the wrapper binary is not on disk, instead of writing entries that point at it.
+- The user's global Claude Code settings are left untouched in that case.
+- Removing the hook keeps working without the binary, so anyone who enabled it against an earlier build can still clean up.
+
+This does not ship the binary. Bundling it as a Tauri sidecar needs a per-target build-and-rename step, `bundle.externalBin`, a corrected resolution order (a sidecar lands beside the main executable, not in the resource directory), and validation on all four packaging targets. That is a separate change; this one stops the damage in the meantime and is recorded as a preview limitation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `claude-code-permission-hook`: hook installation gains a precondition — the wrapper binary must exist before any entry naming it is written to Claude Code's global settings.
+
+## Impact
+
+**Runtime scope: desktop only.** The Web runtime has no permission-hook surface. No React component, frontend service interface, or Tauri command signature changes; the new failure travels the existing `PermissionsApplicationError::Infrastructure` path that `assign_template` already surfaces.
+
+Affected files:
+
+- `src-tauri/src/contexts/permissions/infrastructure/claude_code_hook_adapter.rs`
+- `.github/PREVIEW_RELEASE_NOTES.md` — records the limitation for preview downloaders
+
+Behaviour change for users: enabling Claude Code hook management on a packaged build now reports an error where it previously appeared to succeed. That is the point — it appeared to succeed while leaving Claude Code unable to run the hook.

--- a/openspec/changes/refuse-missing-permission-hook-binary/specs/claude-code-permission-hook/spec.md
+++ b/openspec/changes/refuse-missing-permission-hook-binary/specs/claude-code-permission-hook/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Hook installation requires the wrapper binary to exist
+VaneHub SHALL NOT write a permission-hook entry into Claude Code's global settings unless the wrapper binary named by that entry is present on disk. When it is absent, enabling hook management SHALL fail with an error identifying the expected location, and SHALL leave the user's Claude Code settings unmodified.
+
+#### Scenario: Wrapper binary is absent
+- **WHEN** hook management is enabled and the wrapper binary is not present at its resolved path
+- **THEN** the operation SHALL fail with an error naming that path
+- **AND** Claude Code's global settings SHALL NOT be modified
+
+#### Scenario: Wrapper binary is present
+- **WHEN** hook management is enabled and the wrapper binary exists at its resolved path
+- **THEN** the hook entries SHALL be written as before
+
+#### Scenario: Removing a hook installed by an earlier build
+- **WHEN** hook management is disabled while the wrapper binary is absent
+- **THEN** the removal SHALL still clear VaneHub's entries from Claude Code's settings
+
+#### Scenario: Distribution does not carry the wrapper binary
+- **WHEN** a packaged build does not ship the wrapper binary
+- **THEN** the limitation SHALL be stated to users rather than surfacing as a hook Claude Code cannot execute

--- a/openspec/changes/refuse-missing-permission-hook-binary/tasks.md
+++ b/openspec/changes/refuse-missing-permission-hook-binary/tasks.md
@@ -1,0 +1,28 @@
+## 1. Refuse to name a binary that is not there
+
+- [x] 1.1 Guard `ClaudeCodeHookAdapter::install` on `wrapper_path.is_file()`, returning a `cli_config` infrastructure error that names the resolved path
+- [x] 1.2 Leave `remove` unguarded so a hook installed by an earlier build stays clearable
+- [x] 1.3 Record in a comment why this matters: the entries live in Claude Code's global settings and outlive the process
+
+## 2. Tests
+
+- [x] 2.1 Point the existing install test at a real file so it asserts the success path rather than passing by accident
+- [x] 2.2 Add a test that an absent binary fails and the projection is never called
+- [x] 2.3 Add a test that `remove` still works with the binary absent
+- [x] 2.4 Update the projection-failure test to use a present binary, so it still exercises the projection error rather than the new guard
+
+## 3. Tell users
+
+- [x] 3.1 State the limitation in `.github/PREVIEW_RELEASE_NOTES.md`, including that global Claude Code settings are left untouched
+
+## 4. Verification
+
+- [ ] 4.1 `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
+- [ ] 4.2 `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
+- [ ] 4.3 `cargo test --manifest-path src-tauri/Cargo.toml`
+- [ ] 4.4 `npm run lint:ci`, `npm run test`, `npm run build`, `npm run docs:check`
+- [ ] 4.5 `openspec validate refuse-missing-permission-hook-binary --strict` and `openspec validate --specs --strict`
+
+## 5. Follow-up
+
+- [ ] 5.1 Ship the wrapper as a Tauri sidecar: `bundle.externalBin`, a per-target build-and-rename step, a resolution order that looks beside the main executable rather than in the resource directory, and validation on all four packaging targets. Needed before `0.1.0`

--- a/src-tauri/src/contexts/permissions/infrastructure/claude_code_hook_adapter.rs
+++ b/src-tauri/src/contexts/permissions/infrastructure/claude_code_hook_adapter.rs
@@ -53,6 +53,20 @@ impl ClaudeCodeHookAdapter {
 
 impl ClaudeCodeHookPort for ClaudeCodeHookAdapter {
     fn install(&self) -> Result<(), PermissionsApplicationError> {
+        // These entries land in Claude Code's *global* settings, where they outlive this process
+        // and run on every tool call. Pointing one at a binary that is not on disk would make each
+        // of those calls invoke a command that cannot start, in a file VaneHub does not own.
+        // Refusing leaves that file untouched and reports why.
+        if !self.wrapper_path.is_file() {
+            return Err(PermissionsApplicationError::infrastructure(
+                "cli_config",
+                format!(
+                    "the permission hook binary is missing at {}, so Claude Code hook management \
+                     cannot be enabled",
+                    self.wrapper_path.display()
+                ),
+            ));
+        }
         self.projection
             .set_permission_hook_entries(&self.entries())
             .map_err(|error| {
@@ -89,6 +103,7 @@ fn hook_entries(command: &str) -> Vec<Value> {
 mod tests {
     use super::*;
     use crate::contexts::tooling::cli_config::api::CliConfigError;
+    use crate::test_support::TempDirectory;
     use std::sync::Mutex;
 
     #[derive(Default)]
@@ -109,11 +124,10 @@ mod tests {
 
     #[test]
     fn install_sends_one_entry_per_matcher_pointing_at_the_wrapper_path() {
+        let directory = TempDirectory::new("claude-code-hook-install");
+        let wrapper = directory.write("vanehub-permission-hook", "");
         let projection = Arc::new(FakeProjection::default());
-        let adapter = ClaudeCodeHookAdapter::new(
-            projection.clone(),
-            PathBuf::from("/opt/vanehub/bin/vanehub-permission-hook"),
-        );
+        let adapter = ClaudeCodeHookAdapter::new(projection.clone(), wrapper.clone());
 
         adapter.install().expect("install should succeed");
 
@@ -124,13 +138,50 @@ mod tests {
         assert_eq!(entries[0]["matcher"], "Bash|Edit|Write|Read|Glob|Grep");
         assert_eq!(entries[1]["matcher"], "mcp__.*");
         for entry in entries {
-            assert_eq!(
-                entry["hooks"][0]["command"],
-                "/opt/vanehub/bin/vanehub-permission-hook"
-            );
+            assert_eq!(entry["hooks"][0]["command"], wrapper.display().to_string());
             assert_eq!(entry["hooks"][0]["type"], "command");
             assert_eq!(entry["hooks"][0]["timeout"], 330);
         }
+    }
+
+    #[test]
+    fn install_refuses_when_the_wrapper_binary_is_absent_and_writes_nothing() {
+        let directory = TempDirectory::new("claude-code-hook-absent");
+        let projection = Arc::new(FakeProjection::default());
+        let adapter = ClaudeCodeHookAdapter::new(
+            projection.clone(),
+            directory.path().join("vanehub-permission-hook"),
+        );
+
+        let result = adapter.install();
+
+        assert!(matches!(
+            result,
+            Err(PermissionsApplicationError::Infrastructure {
+                category: "cli_config",
+                ..
+            })
+        ));
+        assert!(
+            projection.calls.lock().unwrap().is_empty(),
+            "the user's global Claude Code settings must be left untouched"
+        );
+    }
+
+    #[test]
+    fn remove_still_works_when_the_wrapper_binary_is_absent() {
+        let directory = TempDirectory::new("claude-code-hook-cleanup");
+        let projection = Arc::new(FakeProjection::default());
+        let adapter = ClaudeCodeHookAdapter::new(
+            projection.clone(),
+            directory.path().join("vanehub-permission-hook"),
+        );
+
+        adapter
+            .remove()
+            .expect("a previously installed hook must stay removable");
+
+        assert_eq!(projection.calls.lock().unwrap().len(), 1);
     }
 
     #[test]
@@ -148,9 +199,11 @@ mod tests {
 
     #[test]
     fn projection_failure_surfaces_as_an_infrastructure_error() {
+        let directory = TempDirectory::new("claude-code-hook-projection-failure");
+        let wrapper = directory.write("vanehub-permission-hook", "");
         let projection = Arc::new(FakeProjection::default());
         *projection.fail_next.lock().unwrap() = true;
-        let adapter = ClaudeCodeHookAdapter::new(projection, PathBuf::from("/opt/vanehub-hook"));
+        let adapter = ClaudeCodeHookAdapter::new(projection, wrapper);
 
         let result = adapter.install();
 


### PR DESCRIPTION
Found while auditing the preview build. The permission-hook wrapper is a second binary (`src-tauri/src/bin/vanehub-permission-hook.rs`), and `tauri.conf.json` declares neither `bundle.resources` nor `bundle.externalBin`, so **no packaged build ships it** — `bootstrap/permissions.rs` records that as "deliberately out of scope for this pass".

Nothing checked for it. Enabling Claude Code permission management writes `PreToolUse` entries into Claude Code's **global** `settings.json` naming that path, so in a packaged build Claude Code invokes a command that cannot start on every matching tool call — in a file VaneHub does not own, which keeps that state after VaneHub exits.

Confirmed on a packaged Windows build: `vanehub-permission-hook.exe` is absent, and `wrapper_binary_path` resolves through the Tauri resource directory to a path with nothing at it.

OpenSpec change: `openspec/changes/refuse-missing-permission-hook-binary/`

## What this does

`install()` verifies `wrapper_path.is_file()` before delegating to the projection, and reports the resolved path when it fails. The adapter is the only place that knows both what the entries contain and which binary they name, so it is the only place that can check the two agree.

`remove()` is deliberately left unguarded — it names no binary, and guarding it would strand exactly the users this exists for: anyone who enabled the hook against a build that wrote it, with entries they could no longer clear from inside the app.

`is_file()` rather than `exists()`, since a directory at that path would satisfy `exists()` and still be unexecutable.

## What this does not do

It does not ship the binary. That needs `bundle.externalBin`, a step that builds it per target and renames it to `vanehub-permission-hook-<triple>`, and a corrected resolution order — a sidecar lands beside the main executable, so preferring the resource directory would still miss it — validated across all four packaging targets. Tracked as follow-up in `design.md`, wanted before `0.1.0`.

The preview release notes now state the limitation, including that global Claude Code settings are left untouched.

## Scope

Installation was already opt-in: `assign_template` calls `install()` only for the `claude-code` agent, and `permissions-approval` requires a distinct first-use confirmation. So this was never a silent startup side effect — but when a user did opt in, it persisted in someone else's config file.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `openspec validate --strict` (change + 91 specs) all pass. The four adapter tests cover the success path against a real file, refusal with the projection never called, removal with the binary absent, and the pre-existing projection-failure path.

`relay::tests` is flaky on the machine used here — 2 of 3 runs fail on `main` as well as on this branch, with the same tests. Not a regression; CI is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
