### PR TITLE
fix(release): publish a checksum manifest downloaders can verify

### DIFF
--- a/.github/PREVIEW_RELEASE_NOTES.md
+++ b/.github/PREVIEW_RELEASE_NOTES.md
@@ -49,11 +49,13 @@ Binaries are built on the current Ubuntu runner image and link against its glibc
 
 ## Verifying your download
 
-Every asset is listed in `SHA256SUMS`, published alongside them. Download it and check the file you retrieved:
+Every asset is listed in `SHA256SUMS` under the name GitHub serves it as. Download it into the same directory as the file you retrieved, then:
 
 ```bash
 sha256sum --check --ignore-missing SHA256SUMS
 ```
+
+A mismatch on a large asset is far more often a truncated download than a tampered file — check the size against the release page and re-download before drawing conclusions.
 
 An SPDX SBOM and GitHub build-provenance attestations are also attached. You can verify provenance with:
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -194,10 +194,27 @@ jobs:
       - name: Generate SHA-256 checksums
         shell: bash
         run: |
-          find release-assets -type f ! -name SHA256SUMS -print0 \
-            | sort -z \
-            | xargs -0 sha256sum \
-            > release-assets/SHA256SUMS
+          # Name each entry the way GitHub will serve it, not the way it sits on this runner.
+          # `sha256sum` writes the path it was given, so the workspace-relative paths this used
+          # to emit matched nothing a downloader had on disk, and the documented
+          # `sha256sum --check --ignore-missing SHA256SUMS` verified zero files while exiting
+          # non-zero. Release assets are served under their basename with spaces replaced by
+          # dots, which is what the release notes tell people to check.
+          : > release-assets/SHA256SUMS
+          while IFS= read -r -d '' file; do
+            digest="$(sha256sum "${file}" | cut -d' ' -f1)"
+            asset="$(basename "${file}" | tr ' ' '.')"
+            printf '%s  %s\n' "${digest}" "${asset}" >> release-assets/SHA256SUMS
+          done < <(find release-assets -type f ! -name SHA256SUMS -print0 | sort -z)
+
+          echo "Published checksum manifest:"
+          cat release-assets/SHA256SUMS
+
+          # A duplicate basename would make one entry unverifiable and silently shadow another.
+          if [ "$(cut -c 67- release-assets/SHA256SUMS | sort | uniq -d | wc -l)" -ne 0 ]; then
+            echo "::error::two release assets share a name after GitHub's substitution" >&2
+            exit 1
+          fi
 
       - name: Attest package provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1

--- a/openspec/changes/publish-verifiable-checksums/.openspec.yaml
+++ b/openspec/changes/publish-verifiable-checksums/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/publish-verifiable-checksums/design.md
+++ b/openspec/changes/publish-verifiable-checksums/design.md
@@ -1,0 +1,52 @@
+## Context
+
+The publish job downloads every platform artifact into `release-assets/`, generates an SPDX SBOM, then pipes `find` output into `xargs -0 sha256sum`. `sha256sum` echoes back the path it was handed, so the manifest recorded runner paths: `release-assets/packages/nsis/VaneHub AI_0.1.0-preview.1_x64-setup.exe`.
+
+GitHub serves release assets under the basename with spaces replaced by dots. Confirmed against the published release: every asset carrying a space in its Tauri-generated name is served with a dot, and no other character was substituted.
+
+The manifest and the served names therefore had nothing in common, which was only visible by downloading the published release and running the command the notes prescribe.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The documented command verifies a downloaded asset with no renaming or path reconstruction.
+- A future regression is caught in the run, not by a downloader.
+
+**Non-Goals:**
+
+- Recomputing digests from downloaded assets. Checksums must attest to what the build produced, not to what the host served back; recomputing after download would certify the wrong thing.
+- Renaming the assets. The names come from Tauri's `productName`, and changing them would churn every download link for a cosmetic gain.
+- Re-tagging `v0.1.0-preview.1`. No package changed.
+
+## Decisions
+
+### Record the served name, not the build path
+
+The loop emits `basename` with spaces mapped to dots. That is the transformation GitHub applies, verified against the published assets rather than assumed from documentation.
+
+The alternative — telling downloaders to reconstruct the build path, or to pass `--ignore-missing` and accept a silent no-op — pushes a workflow defect onto every user, which is the situation being fixed.
+
+### Fail on a name collision instead of publishing an ambiguous manifest
+
+Two assets whose names differ only by a space and a dot collapse to one name. The manifest would then carry two entries with the same name: a checksum tool verifies the file against the first matching line and the other package silently goes unverified.
+
+The job now fails before creating the release. A release that cannot be verified unambiguously is worse than a release that did not happen, because the failure is invisible from the download page. This is currently unreachable — Tauri names each bundle by architecture and format — which is exactly why it needs a guard rather than an assumption.
+
+### Echo the manifest into the job log
+
+The original defect was invisible from the run: every step reported success. Printing the manifest makes the names reviewable at the moment they are produced, which is where a maintainer can still act.
+
+### Say that a mismatch usually means a truncated download
+
+Two `gh release download` attempts against this release returned 9.6 MB and 9.4 MB for a 12.0 MB asset — two different truncations, no error. A downloader who hits that and follows the verification step sees a checksum mismatch, whose obvious reading is tampering. The notes now name the likelier cause and tell them to check the size and retry.
+
+## Risks / Trade-offs
+
+- **The transformation is inferred from observed behaviour, not a published contract.** → It matched every asset in this release, and the collision guard fails loudly if a future name maps unexpectedly. Directly querying the release for its asset names would be exact, but the manifest is generated before the release exists.
+- **The manifest no longer distinguishes assets by directory.** → It never usefully did; the directories are runner-local and absent from the download page.
+- **The already-published manifest was replaced rather than re-tagged.** → The digests are unchanged, so the replacement asserts nothing new about the packages. The alternative — a `preview.2` whose only difference is a text file — would cost every downloader a re-download for nothing.
+
+## Open Questions
+
+None.

--- a/openspec/changes/publish-verifiable-checksums/proposal.md
+++ b/openspec/changes/publish-verifiable-checksums/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+`v0.1.0-preview.1` published a `SHA256SUMS` that verifies nothing.
+
+`sha256sum` writes back whatever path it was given, and the publish job gave it runner-workspace paths. The manifest therefore reads:
+
+```
+b754c812…  release-assets/packages/nsis/VaneHub AI_0.1.0-preview.1_x64-setup.exe
+```
+
+while GitHub serves that asset as `VaneHub.AI_0.1.0-preview.1_x64-setup.exe` — basename only, spaces replaced by dots. The command the release notes tell downloaders to run matches no file, prints `no file was verified`, and exits non-zero:
+
+```bash
+sha256sum --check --ignore-missing SHA256SUMS
+```
+
+The packages themselves are intact; the recorded digests are correct. What is broken is the only integrity check most downloaders will attempt, on an unsigned build where checksums and attestations are the entire integrity story.
+
+## What Changes
+
+- The published checksum manifest names each entry as GitHub serves it, so the documented verification command works against a downloaded asset.
+- The publish job fails when two assets would collapse to the same name, rather than emitting a manifest where one entry silently shadows another.
+- The generated manifest is echoed into the job log, so a future regression is visible in the run rather than only to a downloader.
+- The release notes state that a mismatch on a large asset is more often a truncated download than a tampered file.
+
+The already-published `v0.1.0-preview.1` manifest was corrected in place by re-uploading the asset with the same digests under the served names. No package changed, so no re-tag was required.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `desktop-release-delivery`: publishing checksums gains the requirement that the manifest is usable — entries must name assets as published, and the job must fail rather than emit an ambiguous manifest.
+
+## Impact
+
+**Runtime scope: neither.** Release automation and release documentation only. No application code, no runtime adapter, no Tauri command.
+
+Affected files:
+
+- `.github/workflows/package.yml` — the checksum generation step
+- `.github/PREVIEW_RELEASE_NOTES.md` — verification guidance
+
+Downstream: anyone who tried to verify `v0.1.0-preview.1` before the manifest was re-uploaded saw a failed check. The corrected manifest carries the same digests, so a re-download is unnecessary — only the manifest needs fetching again.

--- a/openspec/changes/publish-verifiable-checksums/specs/desktop-release-delivery/spec.md
+++ b/openspec/changes/publish-verifiable-checksums/specs/desktop-release-delivery/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Checksum manifest verifies published assets
+A published checksum manifest SHALL identify each asset by the name under which it is served, so that a downloader who places the manifest beside a downloaded asset can verify it with a standard checksum tool and no renaming. The publishing job SHALL fail rather than publish a manifest in which two entries share a name.
+
+#### Scenario: Downloader verifies an asset
+- **WHEN** a downloader places the published manifest in the same directory as a downloaded asset and runs a standard checksum check
+- **THEN** that asset SHALL be verified against its recorded digest
+
+#### Scenario: Asset name differs from its build-time path
+- **WHEN** the release host serves an asset under a name that differs from its path on the build machine
+- **THEN** the manifest SHALL record the served name
+
+#### Scenario: Two assets would share a published name
+- **WHEN** two assets would be served under the same name
+- **THEN** the publishing job SHALL fail before creating the release
+
+#### Scenario: Maintainer reviews a release run
+- **WHEN** the publishing job generates the manifest
+- **THEN** its contents SHALL appear in the job log

--- a/openspec/changes/publish-verifiable-checksums/tasks.md
+++ b/openspec/changes/publish-verifiable-checksums/tasks.md
@@ -1,0 +1,27 @@
+## 1. Repair the published release
+
+- [x] 1.1 Rewrite the `v0.1.0-preview.1` manifest to name each asset as GitHub serves it, keeping the digests the build produced
+- [x] 1.2 Prove the corrected manifest verifies a fully downloaded asset and that the original does not, in the same directory
+- [x] 1.3 Re-upload it over the existing `SHA256SUMS` asset and confirm the served copy
+
+## 2. Fix the publishing job
+
+- [x] 2.1 Generate the manifest by basename with spaces mapped to dots, rather than piping runner paths through `xargs sha256sum`
+- [x] 2.2 Fail the job when two entries would share a published name
+- [x] 2.3 Echo the manifest into the job log so a regression is visible in the run
+- [x] 2.4 Exercise the loop and the collision guard locally against fixture files with spaces in their names, confirming the guard fires rather than assuming it
+
+## 3. Fix the guidance
+
+- [x] 3.1 State in the release notes that the manifest names assets as served and belongs in the same directory as the download
+- [x] 3.2 Note that a mismatch on a large asset is more often a truncated download than tampering, after two `gh release download` attempts returned different truncated sizes for one asset
+
+## 4. Verification
+
+- [ ] 4.1 `npm run lint:ci`, `npm run test`, `npm run build`, `npm run docs:check`
+- [ ] 4.2 `openspec validate publish-verifiable-checksums --strict` and `openspec validate --specs --strict`
+- [ ] 4.3 Confirm the workflow YAML still parses and the publish job's step order is unchanged
+
+## 5. Next release
+
+- [ ] 5.1 On the next tag, download an asset and its manifest and run the documented command before announcing the release


### PR DESCRIPTION
`v0.1.0-preview.1` published a `SHA256SUMS` that verifies nothing.

`sha256sum` echoes back the path it was handed, and the publish job handed it runner-workspace paths:

```
b754c812…  release-assets/packages/nsis/VaneHub AI_0.1.0-preview.1_x64-setup.exe
```

GitHub serves that asset as `VaneHub.AI_0.1.0-preview.1_x64-setup.exe` — basename, spaces replaced by dots. So the command the release notes prescribe matched no file:

```console
$ sha256sum --check --ignore-missing SHA256SUMS
sha256sum: SHA256SUMS: no file was verified
$ echo $?
1
```

The packages are intact and the digests were correct. What was broken is the only integrity check most downloaders will attempt, on an unsigned build where checksums and attestations are the entire integrity story.

OpenSpec change: `openspec/changes/publish-verifiable-checksums/`

## Changes

Entries are now recorded by basename with spaces mapped to dots — the substitution GitHub applies, verified against the published assets rather than taken from documentation.

The job fails if two assets would collapse to one name. A duplicate entry is worse than a missing one: a checksum tool verifies the file against the first matching line and the second package goes unverified with no signal. This is currently unreachable since Tauri names each bundle by architecture and format, which is why it is a guard rather than an assumption.

The manifest is echoed into the job log. The original defect was invisible from a run in which every step reported success.

## Already-published release

`v0.1.0-preview.1`'s manifest was corrected in place by re-uploading it with the same digests under the served names. No package changed, so no re-tag — a `preview.2` differing only in a text file would cost every downloader a re-download for nothing.

Verified in one directory before and after:

```console
$ sha256sum --check --ignore-missing SHA256SUMS        # corrected
VaneHub.AI_0.1.0-preview.1_x64-setup.exe: OK
$ sha256sum --check --ignore-missing SHA256SUMS.orig   # as published
sha256sum: SHA256SUMS.orig: no file was verified
```

## Truncated downloads

Two `gh release download` attempts against this release returned 9,637,865 and 9,363,445 bytes for a 12,541,199-byte asset — two different truncations, no error either time. `curl --retry 5` fetched it whole, and its digest then matched the manifest exactly.

A downloader who hits that and follows the verification step sees a mismatch whose obvious reading is tampering. The notes now name the likelier cause and say to check the size and retry. This is also worth remembering when reading any future report of a checksum mismatch.

## Verification

The generation loop and the collision guard were exercised locally against fixture files with spaces in their names; the guard fires rather than being assumed to. `openspec validate --strict` (change + 91 specs), `npm run docs:check`, and `npm run lint:ci` pass, and the publish job's step order is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
