### PR TITLE
docs: surface project app icon in README hero

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,6 +10,10 @@
 
 # VaneHub AI
 
+<p align="center">
+  <img src="public/icon-512.png" alt="VaneHub AI アプリアイコン" width="160" />
+</p>
+
 単一の React インターフェースと明確な Web/mock・Tauri runtime 境界を通じて AI Coding Agent を管理する、デスクトップ優先のワークスペースです。
 
 <!-- docs-fact:project-version value:0.1.0-preview.1 -->

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 # VaneHub AI
 
+<p align="center">
+  <img src="public/icon-512.png" alt="VaneHub AI app icon" width="160" />
+</p>
+
 Desktop-first workspace for managing AI coding agents through one React interface and explicit Web/mock and Tauri runtime boundaries.
 
 <!-- docs-fact:project-version value:0.1.0-preview.1 -->

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,6 +10,10 @@
 
 # VaneHub AI
 
+<p align="center">
+  <img src="public/icon-512.png" alt="VaneHub AI 应用图标" width="160" />
+</p>
+
 通过统一 React 界面和明确的 Web/mock、Tauri runtime 边界管理 AI Coding Agent 的桌面优先工作台。
 
 <!-- docs-fact:project-version value:0.1.0-preview.1 -->


### PR DESCRIPTION
## What

Adds the VaneHub AI app icon to the hero section of all three README variants so the project's own icon shows up on the GitHub repo page.

- `README.md`
- `README.zh-CN.md`
- `README.ja.md`

## Why

The repo page previously had no visual identity. GitHub automatically uses the first image in the README as the repository's social card (the thumbnail shown when the repo is shared or embedded), so placing the icon at the top of the hero section makes it the project's de-facto GitHub icon without any separate social-preview upload.

## How

Reuses the existing `public/icon-512.png` raster (the rendered output of `src-tauri/icons/source/app-icon.svg`). No new assets, no rasterization step. Centered via `<p align="center">`, fixed display width of 160px so it reads as an icon rather than a full-bleed image.

## Notes

- GitHub does **not** expose repository Social Preview upload through the public REST/GraphQL API (verified via schema introspection — no `createSocialPreview` mutation exists), so the README-first-image approach is the durable, version-controlled way to set the repo's social card. An explicit 1280×640 Social Preview banner can still be uploaded manually in *Settings → Social preview* if a landscape card is later preferred.
- `npm run docs:check` passes (incl. README parity + media link validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
