### PR TITLE
Gate panic shortcuts in production Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,13 @@ jobs:
       - name: Rust clippy
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 
+      # Scoped to non-test targets on purpose. unwrap/expect are permitted in tests, and
+      # `[lints.clippy]` in Cargo.toml has no target selectivity — setting these lints there
+      # would make the --all-targets step above fail on ~9,560 test sites. Reuses this job's
+      # build cache, so the marginal cost is analysing two targets rather than a rebuild.
+      - name: Rust production panic shortcuts
+        run: npm run native:panic:check
+
       - name: Rust tests
         run: cargo test --manifest-path src-tauri/Cargo.toml
 

--- a/openspec/changes/freeze-panic-shortcuts-in-production-code/.openspec.yaml
+++ b/openspec/changes/freeze-panic-shortcuts-in-production-code/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/freeze-panic-shortcuts-in-production-code/design.md
+++ b/openspec/changes/freeze-panic-shortcuts-in-production-code/design.md
@@ -1,0 +1,52 @@
+## Context
+
+See proposal.md — Why for the measurement that rules out the ticket's approach.
+
+The constraint that decides the whole design: CI already runs `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`. Any lint set above `allow` in `Cargo.toml` therefore applies to test targets too, and these two lints have 9,560 test-code hits.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make AGENTS.md's rule about panic shortcuts mechanically true for production code.
+- Require no exemption in test code, now or for any test written later.
+- Leave the 35 existing violations visible and individually attributable rather than absorbed into a blanket allowance.
+
+**Non-Goals:**
+
+- Fixing the 35 violations. That is error-handling work across five bounded contexts and belongs in its own change, which the whitelist entries name.
+- Enforcing anything in test code. The project's position is that panic shortcuts are correct there, and `eslint.config.js` takes the same line about test-file size.
+- Adding `[lints]` to `Cargo.toml`. See below.
+
+## Decisions
+
+### Enforce with a target-scoped clippy invocation, not a `Cargo.toml` lint level
+
+`[lints.clippy]` has no target selectivity. Setting `unwrap_used` to `warn` or `deny` makes it apply everywhere, and `--all-targets -- -D warnings` promotes it to an error in tests.
+
+A separate invocation scoped to `--lib --bins` with `-D clippy::unwrap_used -D clippy::expect_used` expresses exactly the intended rule and nothing more. It costs one CI step.
+
+*Alternative rejected — `Cargo.toml` lints plus per-test-module `#![allow(...)]`*: the ticket's plan. It requires exemptions in several hundred test modules, and, worse, in every test module written afterwards. A rule whose cost falls on people who are not violating it will be worked around.
+
+*Alternative rejected — `cfg_attr(test, allow(...))` at crate root*: `#![cfg_attr(test, allow(clippy::unwrap_used))]` only exempts the `test` cfg for the crate's own unit-test build. It does not cover integration test targets under `src-tauri/tests/`, which `--all-targets` also builds, and it re-introduces the crate-wide blanket this change is trying to avoid.
+
+### The whitelist is file-level, and each entry names its retirement
+
+Each of the 11 files gets `#![allow(clippy::unwrap_used, clippy::expect_used)]` with a comment recording the count and the change expected to remove it. File-level rather than line-level because 12 of the 35 are in one file and line-level noise would obscure the code; file-level rather than crate-level because the point is that the list is short, enumerable, and shrinking.
+
+The entries are debt markers with the same contract as the line budgets from `freeze-large-file-line-budgets`: removing one needs no ceremony, adding one requires justification.
+
+### Two of the eleven files are `domain` layer, and that is worth saying out loud
+
+`retrieval/domain/code_redaction.rs` and `task_orchestration/domain/graph.rs` hold nine of the 35. A panic shortcut in a domain layer is the least defensible placement in this codebase's own architecture, since domain code is meant to be pure and independently testable. The whitelist comments say so, so the follow-up change has an obvious starting order.
+
+## Risks / Trade-offs
+
+- **A contributor adds a panic shortcut inside an existing whitelisted file and the gate stays green** → True, and accepted for now. The alternative — line-level allows — makes 35 sites into 35 scattered annotations. The follow-up change removes the files from the list one at a time, and the list is short enough to finish.
+- **The gate runs clippy a second time and lengthens CI** → It reuses the same build cache as the existing clippy step in the same job, so the marginal cost is analysis of two targets, not a rebuild.
+- **Someone later adds `[lints.clippy]` to `Cargo.toml` and breaks the test build** → The proposal and the whitelist comments both record why it is deliberately absent.
+- **`--lib --bins` misses a production target added later** — for example a new binary or a build script → Build scripts are not covered by either selector. This is recorded as a known gap rather than papered over; adding a target means revisiting the gate's selector.
+
+## Migration Plan
+
+No deployment step. The gate is additive: it fails only on new production panic shortcuts. Reverting is removing the CI step, the npm script, and eleven attribute lines.

--- a/openspec/changes/freeze-panic-shortcuts-in-production-code/proposal.md
+++ b/openspec/changes/freeze-panic-shortcuts-in-production-code/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+AGENTS.md says `unwrap()` and `expect()` are permitted only in test code. Nothing enforces it. Clippy's `unwrap_used` and `expect_used` lints are `allow` by default, so `cargo clippy --all-targets -- -D warnings` — which CI runs and which does catch a great deal — is silent on both.
+
+The optimization ticket proposed closing this by adding the lints to `src-tauri/Cargo.toml` and whitelisting existing violations with module-level `#![allow(...)]`, estimating roughly 3,700 non-test sites.
+
+**Measurement says that plan cannot work, and the estimate is off by two orders of magnitude in the direction that matters.**
+
+| Clippy target selection | `unwrap_used` + `expect_used` violations |
+|---|---:|
+| `--lib` (production only) | **35** |
+| `--bins` | **35** |
+| `--all-targets` (adds test targets) | **9,595** |
+
+Production code holds 35 violations across 11 files. The other ~9,560 are in test code, where the project deliberately allows them.
+
+That gap is what breaks the ticket's plan. A `[lints.clippy]` entry in `Cargo.toml` applies to every target, and CI already runs `--all-targets -- -D warnings`, so setting these lints to anything above `allow` turns 9,560 test-code sites into hard errors. The whitelist would have to cover several hundred test modules — and every new test module forever after.
+
+## What Changes
+
+- Add a CI gate that runs clippy against **non-test targets only**, denying both lints there:
+
+  ```
+  cargo clippy --manifest-path src-tauri/Cargo.toml --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used
+  ```
+
+- **Do not touch `src-tauri/Cargo.toml`.** No `[lints]` section is added, so `--all-targets -- -D warnings` keeps its current meaning and no test module needs an exemption — now or when the next one is written.
+- Whitelist the 35 existing production violations with a file-level `#![allow(...)]` in each of the 11 files, each carrying the reason and the change that will retire it.
+- Expose the gate as an npm script so it is reachable the same way as the other quality commands.
+
+## The whitelist is now a finishable list
+
+The ticket's follow-up item — retire the whitelist — was scoped against ~3,700 sites, which is why it reads as a permanent background chore. The real list is 35 sites in 11 files:
+
+| File | Sites |
+|---|---:|
+| `contexts/tooling/skills/application/service.rs` | 12 |
+| `contexts/retrieval/domain/code_redaction.rs` | 6 |
+| `contexts/permissions/application/approval_broker.rs` | 6 |
+| `contexts/task_orchestration/domain/graph.rs` | 3 |
+| `contexts/permissions/infrastructure/hook_bridge_wait_registry.rs` | 2 |
+| six files with one each | 6 |
+
+Two of those files are `domain` layer, where a panic shortcut is least defensible.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `repository-governance`: the existing "Existing source constraints remain enforced" requirement names "production Rust uses a prohibited panic shortcut" among the things the configured checks reject, which today they do not. This change makes that requirement true and records that the enforcement covers non-test targets only.
+
+## Impact
+
+- `.github/workflows/ci.yml` — one new step in the `Rust` job.
+- `package.json` — one new script.
+- Eleven Rust source files — a file-level `#![allow(...)]` with a reason comment. No logic changes.
+- `src-tauri/Cargo.toml` — deliberately unchanged, which also keeps this change free of conflicts with the in-flight dependency cleanup.
+- No runtime behavior changes in either the desktop or Web runtime.

--- a/openspec/changes/freeze-panic-shortcuts-in-production-code/specs/repository-governance/spec.md
+++ b/openspec/changes/freeze-panic-shortcuts-in-production-code/specs/repository-governance/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Existing source constraints remain enforced
+The architecture gate SHALL preserve the repository's existing TypeScript, React, Rust, and file-size constraints and MUST NOT introduce a new blanket or permanent exemption. An existing oversized source path SHALL be governed by a recorded line budget rather than by disabling the file-size rule for that path. The prohibition on Rust panic shortcuts SHALL be enforced mechanically against non-test targets, and SHALL NOT be enforced against test targets, where the shortcuts are permitted.
+
+#### Scenario: Production source violates an existing constraint
+- **WHEN** production TypeScript uses explicit `any` or `@ts-ignore`, a new production TypeScript file exceeds 300 physical lines, or production Rust uses a prohibited panic shortcut
+- **THEN** the configured repository checks SHALL reject the source
+
+#### Scenario: Historical oversized path is exempted from the default limit
+- **WHEN** a production source path is exempted from the default file-size limit because it predates the limit
+- **THEN** the exemption SHALL take the form of a recorded line budget that bounds the path, and SHALL NOT take the form of disabling the file-size rule for that path
+
+#### Scenario: Test code uses a panic shortcut
+- **WHEN** Rust test code uses `unwrap()` or `expect()`
+- **THEN** the panic-shortcut check SHALL NOT reject it, and no per-module exemption SHALL be required to keep it passing
+
+#### Scenario: A production panic shortcut predates the check
+- **WHEN** a production Rust file carried a panic shortcut before the check existed
+- **THEN** its exemption SHALL be recorded at that file with the reason and the work expected to retire it, rather than by weakening the check for all files

--- a/openspec/changes/freeze-panic-shortcuts-in-production-code/tasks.md
+++ b/openspec/changes/freeze-panic-shortcuts-in-production-code/tasks.md
@@ -1,30 +1,30 @@
 ## 1. Record the baseline
 
-- [ ] 1.1 Capture the violation counts for `--lib`, `--bins`, and `--all-targets` so the production/test split stays checkable, and record the per-file list of the 35 production sites
+- [x] 1.1 Capture the violation counts for `--lib`, `--bins`, and `--all-targets` so the production/test split stays checkable, and record the per-file list of the 35 production sites
 
 ## 2. Add the gate
 
-- [ ] 2.1 Add an npm script running `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used`
-- [ ] 2.2 Add it as a step in the `Rust` CI job, placed after the existing clippy step so it reuses the same build cache
-- [ ] 2.3 Confirm `src-tauri/Cargo.toml` is untouched — no `[lints]` section — and record in the change why, so a later contributor does not add one and break the test build
+- [x] 2.1 Add an npm script running `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used`
+- [x] 2.2 Add it as a step in the `Rust` CI job, placed after the existing clippy step so it reuses the same build cache
+- [x] 2.3 Confirm `src-tauri/Cargo.toml` is untouched — no `[lints]` section — and record in the change why, so a later contributor does not add one and break the test build
 
 ## 3. Whitelist the existing production violations
 
-- [ ] 3.1 Add `#![allow(clippy::unwrap_used, clippy::expect_used)]` at the top of each of the 11 files, with a comment giving the site count and naming the change expected to retire it
-- [ ] 3.2 Mark the two `domain`-layer files explicitly — `retrieval/domain/code_redaction.rs` and `task_orchestration/domain/graph.rs`, nine sites between them — as the first candidates for removal, since a panic shortcut in a pure domain layer is the least defensible placement
-- [ ] 3.3 Confirm no file received a line-level allow and no crate-level allow was added
+- [x] 3.1 Add `#![allow(clippy::unwrap_used, clippy::expect_used)]` at the top of each of the 11 files, with a comment giving the site count and naming the change expected to retire it
+- [x] 3.2 Mark the two `domain`-layer files explicitly — `retrieval/domain/code_redaction.rs` and `task_orchestration/domain/graph.rs`, nine sites between them — as the first candidates for removal, since a panic shortcut in a pure domain layer is the least defensible placement
+- [x] 3.3 Confirm no file received a line-level allow and no crate-level allow was added
 
 ## 4. Prove the gate bites and the exemption holds
 
-- [ ] 4.1 The new command passes on the unmodified tree
-- [ ] 4.2 Temporarily add an `unwrap()` to a production file **not** on the whitelist, confirm the command fails naming that file, then revert
-- [ ] 4.3 Temporarily add an `unwrap()` to a test module, confirm the command still passes — this is the property the ticket's design could not have provided
-- [ ] 4.4 Confirm `cargo clippy --all-targets -- -D warnings` still passes, unchanged in meaning
+- [x] 4.1 The new command passes on the unmodified tree
+- [x] 4.2 Temporarily add an `unwrap()` to a production file **not** on the whitelist, confirm the command fails naming that file, then revert
+- [x] 4.3 Temporarily add an `unwrap()` to a test module, confirm the command still passes — this is the property the ticket's design could not have provided
+- [x] 4.4 Confirm `cargo clippy --all-targets -- -D warnings` still passes, unchanged in meaning
 
 ## 5. Verification
 
-- [ ] 5.1 `cargo test --manifest-path src-tauri/Cargo.toml` passes with an unchanged test count
-- [ ] 5.2 `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` and `cargo check --manifest-path src-tauri/Cargo.toml` pass
-- [ ] 5.3 `npm run architecture:check` passes
-- [ ] 5.4 `openspec validate freeze-panic-shortcuts-in-production-code --strict` and `openspec validate --specs --strict` pass
-- [ ] 5.5 Record the remaining whitelist as the scope of the follow-up change, replacing the ticket's estimate of roughly 3,700 sites with the measured 35
+- [x] 5.1 `cargo test --manifest-path src-tauri/Cargo.toml` passes with an unchanged test count
+- [x] 5.2 `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` and `cargo check --manifest-path src-tauri/Cargo.toml` pass
+- [x] 5.3 `npm run architecture:check` passes
+- [x] 5.4 `openspec validate freeze-panic-shortcuts-in-production-code --strict` and `openspec validate --specs --strict` pass
+- [x] 5.5 Record the remaining whitelist as the scope of the follow-up change, replacing the ticket's estimate of roughly 3,700 sites with the measured 35

--- a/openspec/changes/freeze-panic-shortcuts-in-production-code/tasks.md
+++ b/openspec/changes/freeze-panic-shortcuts-in-production-code/tasks.md
@@ -1,0 +1,30 @@
+## 1. Record the baseline
+
+- [ ] 1.1 Capture the violation counts for `--lib`, `--bins`, and `--all-targets` so the production/test split stays checkable, and record the per-file list of the 35 production sites
+
+## 2. Add the gate
+
+- [ ] 2.1 Add an npm script running `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used`
+- [ ] 2.2 Add it as a step in the `Rust` CI job, placed after the existing clippy step so it reuses the same build cache
+- [ ] 2.3 Confirm `src-tauri/Cargo.toml` is untouched — no `[lints]` section — and record in the change why, so a later contributor does not add one and break the test build
+
+## 3. Whitelist the existing production violations
+
+- [ ] 3.1 Add `#![allow(clippy::unwrap_used, clippy::expect_used)]` at the top of each of the 11 files, with a comment giving the site count and naming the change expected to retire it
+- [ ] 3.2 Mark the two `domain`-layer files explicitly — `retrieval/domain/code_redaction.rs` and `task_orchestration/domain/graph.rs`, nine sites between them — as the first candidates for removal, since a panic shortcut in a pure domain layer is the least defensible placement
+- [ ] 3.3 Confirm no file received a line-level allow and no crate-level allow was added
+
+## 4. Prove the gate bites and the exemption holds
+
+- [ ] 4.1 The new command passes on the unmodified tree
+- [ ] 4.2 Temporarily add an `unwrap()` to a production file **not** on the whitelist, confirm the command fails naming that file, then revert
+- [ ] 4.3 Temporarily add an `unwrap()` to a test module, confirm the command still passes — this is the property the ticket's design could not have provided
+- [ ] 4.4 Confirm `cargo clippy --all-targets -- -D warnings` still passes, unchanged in meaning
+
+## 5. Verification
+
+- [ ] 5.1 `cargo test --manifest-path src-tauri/Cargo.toml` passes with an unchanged test count
+- [ ] 5.2 `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` and `cargo check --manifest-path src-tauri/Cargo.toml` pass
+- [ ] 5.3 `npm run architecture:check` passes
+- [ ] 5.4 `openspec validate freeze-panic-shortcuts-in-production-code --strict` and `openspec validate --specs --strict` pass
+- [ ] 5.5 Record the remaining whitelist as the scope of the follow-up change, replacing the ticket's estimate of roughly 3,700 sites with the measured 35

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lint:ci": "eslint . --max-warnings=0",
     "contracts:check": "vitest run src/contracts/contract-conformance.test.ts",
     "architecture:check": "node --test scripts/architecture/*.node-test.mjs && node scripts/architecture/check.mjs && npm run lint:ci && tsc --noEmit && cargo test --manifest-path src-tauri/Cargo.toml --test architecture",
+    "native:panic:check": "cargo clippy --manifest-path src-tauri/Cargo.toml --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used",
     "performance:unit:test": "node --test scripts/performance/*.node-test.mjs",
     "performance:check": "npm run performance:unit:test && node scripts/performance/cli.mjs check",
     "performance:benchmark": "node scripts/performance/cli.mjs benchmark",

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/runner_registry.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/runner_registry.rs
@@ -1,3 +1,8 @@
+// Predates the production panic-shortcut gate; removing this attribute is the
+// definition of done for this file, and it may be removed without ceremony.
+// TODO(retire-production-panic-shortcuts): 1 pre-existing site.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use crate::contexts::agent_runtime::application::{
     AgentRunner, PreparedRunnerLaunch, RunnerCapabilities, RunnerError, RunnerErrorKind,
     RunnerEvent, RunnerHandle, RunnerInspection, RunnerKind, RunnerLaunchSpec, RunnerReference,

--- a/src-tauri/src/contexts/permissions/application/approval_broker.rs
+++ b/src-tauri/src/contexts/permissions/application/approval_broker.rs
@@ -1,3 +1,8 @@
+// Predates the production panic-shortcut gate; removing this attribute is the
+// definition of done for this file, and it may be removed without ceremony.
+// TODO(retire-production-panic-shortcuts): 6 pre-existing sites.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Owns the pending-approval queue as the Rust-side single source of truth (design.md D7).
 //! Deliberately in-memory, not SQLite-backed: a pending approval only means anything while its
 //! originating generation's process is alive, so there is nothing meaningful to recover across an

--- a/src-tauri/src/contexts/permissions/infrastructure/hook_bridge_discovery.rs
+++ b/src-tauri/src/contexts/permissions/infrastructure/hook_bridge_discovery.rs
@@ -1,3 +1,8 @@
+// Predates the production panic-shortcut gate; removing this attribute is the
+// definition of done for this file, and it may be removed without ceremony.
+// TODO(retire-production-panic-shortcuts): 1 pre-existing site.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Per-launch port/token generation and the local discovery file the hook wrapper reads
 //! (design.md D3, D6). Both are regenerated every application start — nothing here is meant to
 //! survive a restart.

--- a/src-tauri/src/contexts/permissions/infrastructure/hook_bridge_wait_registry.rs
+++ b/src-tauri/src/contexts/permissions/infrastructure/hook_bridge_wait_registry.rs
@@ -1,3 +1,8 @@
+// Predates the production panic-shortcut gate; removing this attribute is the
+// definition of done for this file, and it may be removed without ceremony.
+// TODO(retire-production-panic-shortcuts): 2 pre-existing sites.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Wakes an in-flight loopback HTTP request once a human resolves the `Ask` decision it's
 //! blocked on. Structurally analogous to `agent_runtime`'s own `pending_approvals`/
 //! `await_approval`, but not the same registry: that one is private to `RuntimeAgentApiAdapter`

--- a/src-tauri/src/contexts/retrieval/application/indexing_service.rs
+++ b/src-tauri/src/contexts/retrieval/application/indexing_service.rs
@@ -1,3 +1,8 @@
+// Predates the production panic-shortcut gate; removing this attribute is the
+// definition of done for this file, and it may be removed without ceremony.
+// TODO(retire-production-panic-shortcuts): 1 pre-existing site.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use crate::contexts::retrieval::domain::{
     content_hash, document_id, FailureCategory, IndexState, RetrievalDocument, RetrievalError,
     RetrievalScope, SourceKind,

--- a/src-tauri/src/contexts/retrieval/application/search_service.rs
+++ b/src-tauri/src/contexts/retrieval/application/search_service.rs
@@ -1,3 +1,8 @@
+// Predates the production panic-shortcut gate; removing this attribute is the
+// definition of done for this file, and it may be removed without ceremony.
+// TODO(retire-production-panic-shortcuts): 1 pre-existing site.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use crate::contexts::retrieval::domain::{
     cosine_similarity, escape_fts_query, fuse_with_rrf, Degradation, MatchedVia, RetrievalError,
     RetrievalQuery, RetrievalScope, ScoredHit, SourceKind,

--- a/src-tauri/src/contexts/retrieval/domain/code_redaction.rs
+++ b/src-tauri/src/contexts/retrieval/domain/code_redaction.rs
@@ -1,3 +1,9 @@
+// Predates the production panic-shortcut gate; removing this attribute is the
+// definition of done for this file, and it may be removed without ceremony.
+// TODO(retire-production-panic-shortcuts): 6 pre-existing sites, in a domain
+// module — the least defensible placement for a panic shortcut, so clear these first.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use regex::{Captures, Regex};
 use std::sync::OnceLock;
 

--- a/src-tauri/src/contexts/sessions/infrastructure/scheduled_tasks.rs
+++ b/src-tauri/src/contexts/sessions/infrastructure/scheduled_tasks.rs
@@ -1,3 +1,8 @@
+// Predates the production panic-shortcut gate; removing this attribute is the
+// definition of done for this file, and it may be removed without ceremony.
+// TODO(retire-production-panic-shortcuts): 1 pre-existing site.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use crate::commands::error::CommandError;
 use crate::commands::sessions::dto;
 use crate::contexts::operations::application::{DiagnosticLog, DiagnosticLogPort, LogSeverity};

--- a/src-tauri/src/contexts/task_orchestration/domain/graph.rs
+++ b/src-tauri/src/contexts/task_orchestration/domain/graph.rs
@@ -1,3 +1,9 @@
+// Predates the production panic-shortcut gate; removing this attribute is the
+// definition of done for this file, and it may be removed without ceremony.
+// TODO(retire-production-panic-shortcuts): 3 pre-existing sites, in a domain
+// module — the least defensible placement for a panic shortcut, so clear these first.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use super::{DependencyEdge, PlanDraft};
 use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;

--- a/src-tauri/src/contexts/tooling/skills/application/service.rs
+++ b/src-tauri/src/contexts/tooling/skills/application/service.rs
@@ -1,3 +1,8 @@
+// Predates the production panic-shortcut gate; removing this attribute is the
+// definition of done for this file, and it may be removed without ceremony.
+// TODO(retire-production-panic-shortcuts): 12 pre-existing sites.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use super::{
     build_resource_index, logical_base_uri, parse_logical_uri, preview_package, truncate_chars,
     AgentMountConfiguration, BuiltinCleanupStatus, BuiltinReconciliationOutcome,

--- a/src-tauri/src/contexts/tooling/skills/infrastructure/filesystem/transaction.rs
+++ b/src-tauri/src/contexts/tooling/skills/infrastructure/filesystem/transaction.rs
@@ -1,3 +1,8 @@
+// Predates the production panic-shortcut gate; removing this attribute is the
+// definition of done for this file, and it may be removed without ceremony.
+// TODO(retire-production-panic-shortcuts): 1 pre-existing site.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use crate::contexts::tooling::skills::application::{
     SkillApplicationError, SkillFilesystemTransaction,
 };

--- a/src-tauri/tests/architecture.rs
+++ b/src-tauri/tests/architecture.rs
@@ -2162,9 +2162,14 @@ const NATIVE_SUBTREE_BUDGETS: &[SubtreeBudget] = &[
     // No item body was duplicated or edited: the top-level item multiset is identical before and
     // after, 84 of the 138 moved items are byte-identical to their pre-split text, 52 differ only
     // by an added `pub(super)`, and the last 2 are the rustfmt rewraps above.
+    // Raised again by `freeze-panic-shortcuts-in-production-code`, by exactly 5: the four-line
+    // `#![allow(clippy::unwrap_used, clippy::expect_used)]` header plus its blank separator, added
+    // to `runner_registry.rs`, the one file in this subtree carrying a pre-existing panic shortcut.
+    // The header is the debt marker itself, so this rises now and falls again when the shortcut is
+    // retired and the attribute goes with it.
     SubtreeBudget {
         root: "src-tauri/src/contexts/agent_runtime/infrastructure",
-        budget: 58_357,
+        budget: 58_362,
         owner: "split-api-adapter-modules",
     },
     // Raised from 2,914 by `split-database-migrations`, which turned `migrations.rs` into a


### PR DESCRIPTION
Implements `freeze-panic-shortcuts-in-production-code` — item 1 of the optimization ticket, with the ticket's mechanism replaced. Read the measurement first; it is why.

## The ticket's plan could not have worked

AGENTS.md permits `unwrap()` and `expect()` only in test code, and nothing enforced it: both clippy lints default to `allow`, so the existing `cargo clippy --all-targets -- -D warnings` step was silent on them.

The ticket proposed adding the lints to `src-tauri/Cargo.toml` and whitelisting existing violations with module-level `#![allow(...)]`, estimating roughly 3,700 non-test sites.

| Clippy target selection | Violations |
|---|---:|
| `--lib` (production only) | **35** |
| `--bins` | **35** |
| `--all-targets` (adds test targets) | **9,595** |

Production holds **35** sites across 11 files. The other ~9,560 are in test code, where the project deliberately allows them.

`[lints.clippy]` has no target selectivity, and CI already runs `--all-targets`. Setting these lints there at any level above `allow` turns those ~9,560 test sites into hard errors, so the whitelist would have to cover several hundred test modules — and every test module written afterwards. A rule whose cost falls on people who are not violating it gets worked around.

## What this does instead

One clippy invocation scoped to non-test targets:

```
cargo clippy --manifest-path src-tauri/Cargo.toml --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used
```

Exposed as `npm run native:panic:check` and added to the `Rust` CI job after the existing clippy step, so it reuses that job's build cache — the marginal cost is analysing two targets, not a rebuild.

**`src-tauri/Cargo.toml` is deliberately untouched.** The CI step and the change artifacts both record why, so a later contributor does not add a `[lints]` section and break the test build. It also keeps this change free of conflicts with the dependency cleanup that just landed.

## Verified three ways, not one

- **Passes** on the annotated tree.
- **Exits 101** when an `unwrap()` is added to a production file that is not whitelisted, naming the file and the lint.
- **Stays green** when an `unwrap()` is added to test code.

That third property is the one the ticket's design could not have provided, and it is the reason the scoping is worth the extra CI step.

A note on the first probe attempt: `Some(1).unwrap()` produced a *warning* from a different lint (`unnecessary_literal_unwrap`) rather than an `unwrap_used` error, because clippy const-folds it. The probe was redone with a value clippy cannot fold, which is what produced the 101.

## The whitelist is a finishable list now

35 sites, 11 files, each carrying its count and the change expected to retire it:

| File | Sites |
|---|---:|
| `contexts/tooling/skills/application/service.rs` | 12 |
| `contexts/retrieval/domain/code_redaction.rs` | 6 |
| `contexts/permissions/application/approval_broker.rs` | 6 |
| `contexts/task_orchestration/domain/graph.rs` | 3 |
| `contexts/permissions/infrastructure/hook_bridge_wait_registry.rs` | 2 |
| six files with one each | 6 |

**Nine of the 35 sit in two `domain` modules** — `retrieval/domain/code_redaction.rs` and `task_orchestration/domain/graph.rs`. A panic shortcut in a pure domain layer is the least defensible placement in this codebase's own architecture, so those headers say so and name themselves as first to clear.

This also rescopes the ticket's follow-up item. It was written against ~3,700 sites, which is why it reads as a permanent background chore; against 35 it is a change someone can finish.

## Line budget

The `agent_runtime/infrastructure` subtree budget rises by **exactly 5** — the four-line header plus its blank separator, added to `runner_registry.rs`, the one file in that subtree with a pre-existing shortcut. The budget gate caught this on the first run rather than letting it through, which is the mechanism working as designed. It falls again when that shortcut is retired and the attribute goes with it.

## Known gap, recorded rather than papered over

`--lib --bins` does not cover build scripts. Adding a new production target means revisiting the selector; the design says so explicitly.

## Verification

| Command | Result |
|---|---|
| `npm run native:panic:check` | pass |
| `cargo clippy --all-targets -- -D warnings` | pass, unchanged in meaning |
| `cargo test --manifest-path src-tauri/Cargo.toml` | **3,590 passed / 0 failed** |
| `cargo fmt -- --check`, `cargo check` | pass |
| `npm run architecture:check` | pass, 41/41 |
| `openspec validate --strict` | pass, specs 138/138 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
