### PR TITLE
Decompose the API tool-use loop, 978 lines to 621

### DIFF
--- a/openspec/changes/decompose-api-tool-use-loop/.openspec.yaml
+++ b/openspec/changes/decompose-api-tool-use-loop/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-18
+skip_specs: true

--- a/openspec/changes/decompose-api-tool-use-loop/design.md
+++ b/openspec/changes/decompose-api-tool-use-loop/design.md
@@ -1,0 +1,193 @@
+## Context
+
+`execute_with_code_intelligence` is `execution.rs:68-1045` — 978 physical lines in one function,
+with 28 parameters and roughly forty `return` statements. It is the entire generation path for
+`launch_kind = "api"` agents. `split-api-adapter-modules` moved it without touching it and recorded
+that as a residual, both in its own `design.md` and in a comment on the `[ARCH-NATIVE-006]` path
+budget in `src-tauri/tests/architecture.rs`.
+
+Three facts about the surrounding code shape this change:
+
+- The whole test surface for this function is `api_process_adapter/tests.rs`, whose `execute()`
+  wrapper (`tests.rs:33-83`) calls it with a `RuntimeAgentCodeIntelligenceAdapter` over an
+  unavailable responder. Seventeen tests go through that wrapper against a real local
+  `TcpListener` fixture, so they exercise the actual HTTP send, the actual SSE parse, and the actual
+  tool loop — not a mock of them. There is no integration test in `src-tauri/tests/` that reaches
+  this function.
+- `tests.rs` opens with `use super::*;`, so anything a test names must be reachable from `mod.rs`.
+- The module already has seven sibling modules from `split-api-adapter-modules`, each owning one
+  concern. Four of the seams below have an existing owner; only one needs a new module.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reduce the function to a size where the tool-use loop is readable as a loop, by extracting
+  fragments whose control flow can be shown equivalent rather than argued to be.
+- Make the *declined* seams as legible as the extracted ones: the reason a cut is unsafe is the
+  most useful thing this change can leave behind.
+- Land every seam in the module that already owns its concern rather than inventing a bucket.
+
+**Non-Goals:**
+
+- Reaching a line target. A fragment that would need loop-carried state threaded through a
+  signature is left in place regardless of how many lines it is.
+- Changing any signature, event, wire format, or error text. `execute_with_code_intelligence`'s own
+  28-parameter signature is untouched.
+- Editing any existing test. New tests are added; none is modified, renamed, or removed.
+
+## Decisions
+
+### The safety argument, and how each seam is checked against it
+
+The moves that preceded this change proved themselves with an identity: same item multiset, same
+bodies, same test names. Extracting from inside a function body cannot produce that identity,
+because a `return` inside the extracted fragment must become a value. So each seam is admitted only
+if it satisfies **all four** of these, and the table in the next section records the check:
+
+1. **Every exit is a `return <expr>;` that leaves the whole function.** A fragment containing a
+   `continue`, a `break` of the parent's loop, or a `?` that propagates into the parent is not
+   admitted. The one permitted transformation is `return X` → `return Err(X)` with a caller-side
+   `Err(failure) => return failure`, which produces the same `GenerationProcessEvent` from the same
+   logical point. `failed_retryable`, `failed_non_retryable` and `failed_configuration`
+   (`mod.rs:560-576`) are pure constructors with no side effects, so moving *where* they are called
+   from cannot be observed.
+2. **No loop-carried state crosses the boundary implicitly.** Anything the fragment reads or writes
+   that outlives one iteration is an explicit parameter (`&mut emitted_visible_content`), or the
+   seam is declined.
+3. **The fragment's text is unchanged apart from the exit rewrite and the receiver rename.** Every
+   `?`, every error string, every side-effecting call and their relative order survive verbatim, so
+   the diff reviews as "this block, behind a signature".
+4. **The behaviour has a named test before the cut.** Where none existed, a characterization test is
+   written against the un-split function and confirmed green first (see "Coverage established
+   before the cut").
+
+An exception, admitted deliberately: **`authorize_tool_call` violates rule 1** — three of its arms
+end in `continue`. It is admitted anyway because those three `continue`s are the *last* statement of
+their arm and the parent's replacement arm is also `continue`, so nothing is skipped or reordered;
+the enum's three variants are exactly the three things the block can do. This is the only seam where
+the argument is "the shapes correspond" rather than "the text is identical", and it is called out
+here so a reviewer knows to read that one closely.
+
+### The six seams, their homes, and their coverage
+
+| # | Seam | Lines out | New home | Exits | Tests that cover it |
+|---|---|---:|---|---|---|
+| 1 | `resolve_endpoint` — provider config, endpoint metadata, context capacity, auth mode, credential, wire format | 99-181 | new `endpoint.rs` | 7 × `return <event>` | `execute_fails_non_retryably_when_no_model_is_configured`, `..._when_no_credential_is_stored`, `..._when_openai_compatible_agent_has_no_base_url`, `..._when_openai_compatible_base_url_is_blank`, `onepiece_missing_model_...`, `onepiece_missing_credential_...`, `onepiece_missing_endpoint_...`, **new** `an_endpoint_profile_context_window_smaller_than_the_request_fails_the_generation` |
+| 2 | `resolve_generation_tool_catalog` — availability probes plus catalog, delegation, native tools, capability clear | 232-287 | `prompt.rs` | none | `execute_wires_plan_mode_and_retrieval_available_to_the_correct_resolve_tool_catalog_argument` (asserts on the wire body's `tools` array), plus every test that reaches a request |
+| 3 | `resolve_generation_skill_tools` — skill-tool catalog context and resolution | 292-335 | `prompt.rs` | none | `execute_persists_a_completed_skill_tool_result_and_continues_the_plan_mode_loop` |
+| 4 | `resolve_image_support` — image-input capability from profile, metadata, or catalog | 384-400 | `endpoint.rs` | none | every `execute()` test (the catalog fallback branch); the profile and metadata branches by the new endpoint-profile test |
+| 5 | `analyze_round_context` — request projection into a `ContextSnapshot` | 430-455 | `invocation.rs` | none | the new endpoint-profile test, which reaches the overflow guard only through this snapshot |
+| 6 | `stream_round` — the SSE read loop | 525-613 | stays in `execution.rs` | 5 × `return <event>` | `execute_skips_the_approval_prompt_for_an_allowed_shell_call`, `execute_returns_mcp_failure_...`, `execute_stops_tool_loop_immediately_when_mcp_call_cancels_generation`, **new** `a_rejected_token_event_fails_the_generation_retryably` |
+| 7 | `record_tool_outcome` — the status/output/emit/push tail, duplicated at five call sites | 5 sites | stays in `execution.rs` | 1 × `return <event>` | `execute_skips_the_approval_prompt_for_an_allowed_shell_call`, `execute_returns_mcp_failure_and_continues_generation`, `remember_tool_call_is_rejected_without_persisting_when_memory_is_disabled`, **new** `a_rejected_completed_tool_use_event_fails_the_generation_retryably` |
+| 8 | `authorize_tool_call` — the permission gate and approval wait | 871-953 | `interactive.rs` | 3 × `continue`, 3 × `return <event>` | `execute_skips_the_approval_prompt_for_an_allowed_shell_call` (Allow), `execute_returns_mcp_failure_...` (Ask→Approved), `execute_denied_mcp_call_...` (Ask→Denied), `execute_stops_tool_loop_immediately_...` (Cancelled), **new** `a_policy_denied_tool_call_returns_denial_data_without_executing` (Deny), **new** `an_answer_delivered_to_an_approval_wait_is_treated_as_a_denial` (Answered) |
+
+Seams 6 and 7 stay in `execution.rs` because the tool-use loop is the only thing that has them; the
+module's own doc comment is "the tool-use loop and the skill-tool dispatch it drives". Moving them
+to a new module would create a file whose only reason to exist is that `execution.rs` is long.
+
+### Why each seam lands where it does
+
+`endpoint.rs` is new because no existing module owns "which endpoint are we calling, with what
+credential, and what does it support". `invocation.rs` is accounting — it owns the *record* of an
+invocation, not the decision of where to send it. Seam 1 and Seam 4 read the same three sources
+(`request.endpoint_profile`, the stored metadata, the model catalog) with the same precedence, so
+they belong together.
+
+Seams 2 and 3 go to `prompt.rs`, which already owns `resolve_tool_catalog_with_code_intelligence`.
+Seam 5 goes to `invocation.rs`, which already owns `record_context_snapshot`,
+`estimated_input_characters` and `WireFormat` — the snapshot analysis is the thing
+`record_context_snapshot` records. Seam 8 goes to `interactive.rs`, which already owns
+`await_approval`, `permission_action_and_resource` and `ApprovalOutcome`; the gate is what calls all
+three.
+
+### Preserving the skill-tool catalog lease's drop order
+
+`ResolvedSkillToolCatalog::lease` is an `Arc<dyn Any + Send + Sync>` held for the rest of the
+generation in `_skill_tool_catalog_lease`. Seam 3 therefore extracts only the *body* of the
+`if let Some(catalog)` block, returning `Option<ResolvedSkillToolCatalog>`; the three `let mut`
+bindings stay in the parent, in their original order, so their drop order at the end of the
+function is byte-for-byte what it was. Returning a struct that owned all three, or destructuring a
+tuple, would reorder the drops — the lease currently drops after the generation counter and before
+the key map, and nothing documents that this is irrelevant.
+
+### Coverage established before the cut
+
+Four behaviours a seam touches have no test today. Each gets a characterization test written and
+confirmed green **against the un-split function**, in a commit that precedes the extraction:
+
+- **No test constructs `endpoint_profile: Some(..)`.** `sample_request` sets it to `None`, and
+  `FakeConfig` inherits the trait's default `active_endpoint_profile_metadata` → `Ok(None)`. So
+  `endpoint_capacity` is `None` in every existing test, and Seams 1, 4 and 5 are exercised only
+  along their fallback branches. The new test freezes a profile with a one-token context window and
+  asserts the distinctive overflow failure, which is reachable only if profile → `ContextCapacity` →
+  `ContextAnalysisService::analyze` → the guard all hold.
+- **`Effect::Deny` and `ApprovalOutcome::Answered(_)` are untested.** Existing approval tests cover
+  Allow, Ask→Approved, Ask→Denied and Ask→Cancelled. The policy-deny arm ("Denied by policy.") and
+  the fail-closed answer arm are both inside Seam 8.
+- **The `failed_retryable("Agent generation event handling failed.")` exit is untested**, at all
+  eight of its occurrences: `CapturingSink` is the only `AgentProcessEventSink` in the suite and it
+  never fails. Seams 6, 7 and 8 each contain one. A `RejectingSink` that refuses exactly the events
+  matching a predicate makes each reachable.
+
+These tests are additions. No existing test is edited, renamed, or removed — if one had needed
+editing to accommodate a seam, that would have been evidence of a behaviour change and the seam
+would have been abandoned instead.
+
+### Seams deliberately not taken
+
+- **The non-success HTTP response handler (476-523).** Its recovery path is
+  `turns.remove(0); continue;` — it mutates the turn list and re-enters the loop *without*
+  decrementing `round_trip`, so a context-recovery retry silently consumes one of the 25 permitted
+  round trips. That coupling between `turns`, the loop-scoped `context_recovery_attempted` flag and
+  the round-trip budget is load-bearing and invisible from inside a helper. Declined under rule 2.
+- **The per-tool-call dispatch chain (648-1006) as one `execute_one_tool_call`.** Every one of its
+  seven branches ends in `continue`, two of them mutate the request-scoped `images_in_request`
+  counter, and the branch order is itself the dispatch precedence. A helper would need `&mut
+  images_in_request`, `&mut executed`, and an enum with a variant per branch — which is the loop
+  body with a signature bolted on, not a seam. Declined under rules 1 and 2.
+- **The remaining setup bindings (182-230):** personalization, memory selection, system prompt,
+  history, `tool_assisted_session`, timeout, HTTP client. Five sequentially dependent bindings, each
+  with its own early return, sharing no concept beyond "more setup". Extracting them would produce a
+  bag named after its position in the file. Declined under rule 3 — there is no boundary to preserve.
+- **The two `maybe_compact_accounted` calls (355-381, 1015-1041), 27 near-identical lines each.**
+  Tempting, but they differ in the value of `tool_assisted_session`, which changes between them, and
+  both take `&mut turns`, `&mut request_sequence` and `&mut automatic_compaction_state`. A closure
+  capturing those mutably would conflict with the loop's other uses of `turns`; a function would need
+  all 23 arguments again. No reduction, only indirection. Declined.
+
+### Verification is measured, not asserted
+
+- The pre-change test-name list from `cargo test --lib -- --list` must be a **subset** of the
+  post-change list, with the difference being exactly the new characterization tests and nothing
+  else. Existing names cannot move, because moving one means a test was edited.
+- `git diff` on `tests.rs` must contain only additions.
+- Every extracted fragment is diffed against its pre-extraction text to confirm rules 1 and 3.
+- The `[ARCH-NATIVE-006]` budget for `execution.rs` is lowered to its measured value; the residual
+  comment is rewritten with the new function size.
+
+## Risks / Trade-offs
+
+- **A seam changes behaviour in a path no test reaches** → the reason four behaviours get
+  characterization tests first. Where a path still has no test after that (for example, a
+  `finish_api_invocation` call on the SSE read-error branch), the fragment's text is unchanged, so
+  the risk is confined to the exit rewrite, which the compiler checks the type of and the diff shows
+  in full.
+- **`authorize_tool_call`'s enum drops a case** → the `match` in the parent is exhaustive over three
+  variants, and the helper's own `match effect` is exhaustive over `Effect`. A missed case fails to
+  compile. Two new tests cover the two arms that had none.
+- **Seam 3 reorders the catalog lease's drop** → prevented structurally by keeping the three
+  bindings in the parent, as above.
+- **The subtree budget rises** → it will: new tests, one new module, eight signatures and eight call
+  sites. Each component is counted and stated when the budget is raised, so a number that does not
+  add up is visible rather than absorbed.
+- **The function is still large afterwards** → yes. It goes from 978 lines to roughly 580. Four
+  further seams were available on a line count and refused on the reasons above. A 580-line function
+  that behaves identically is the better outcome.
+
+## Migration Plan
+
+No deployment or data migration; this is a compile-time reorganization and a revert is a plain
+`git revert`. The work commits in three stages, each leaving `cargo test` green: the characterization
+tests first (against the un-split function), then the no-early-exit seams (2, 3, 4, 5), then the
+seams with exits (1, 6, 7, 8). Stopping after any stage leaves a coherent, smaller function.

--- a/openspec/changes/decompose-api-tool-use-loop/design.md
+++ b/openspec/changes/decompose-api-tool-use-loop/design.md
@@ -79,8 +79,8 @@ here so a reviewer knows to read that one closely.
 | 4 | `resolve_image_support` — image-input capability from profile, metadata, or catalog | 384-400 | `endpoint.rs` | none | every `execute()` test (the catalog fallback branch); the profile and metadata branches by the new endpoint-profile test |
 | 5 | `analyze_round_context` — request projection into a `ContextSnapshot` | 430-455 | `invocation.rs` | none | the new endpoint-profile test, which reaches the overflow guard only through this snapshot |
 | 6 | `stream_round` — the SSE read loop | 525-613 | stays in `execution.rs` | 5 × `return <event>` | `execute_skips_the_approval_prompt_for_an_allowed_shell_call`, `execute_returns_mcp_failure_...`, `execute_stops_tool_loop_immediately_when_mcp_call_cancels_generation`, **new** `a_rejected_token_event_fails_the_generation_retryably` |
-| 7 | `record_tool_outcome` — the status/output/emit/push tail, duplicated at five call sites | 5 sites | stays in `execution.rs` | 1 × `return <event>` | `execute_skips_the_approval_prompt_for_an_allowed_shell_call`, `execute_returns_mcp_failure_and_continues_generation`, `remember_tool_call_is_rejected_without_persisting_when_memory_is_disabled`, **new** `a_rejected_completed_tool_use_event_fails_the_generation_retryably` |
-| 8 | `authorize_tool_call` — the permission gate and approval wait | 871-953 | `interactive.rs` | 3 × `continue`, 3 × `return <event>` | `execute_skips_the_approval_prompt_for_an_allowed_shell_call` (Allow), `execute_returns_mcp_failure_...` (Ask→Approved), `execute_denied_mcp_call_...` (Ask→Denied), `execute_stops_tool_loop_immediately_...` (Cancelled), **new** `a_policy_denied_tool_call_returns_denial_data_without_executing` (Deny), **new** `an_answer_delivered_to_an_approval_wait_is_treated_as_a_denial` (Answered) |
+| 7 | `record_tool_outcome` — the status/output/emit/push tail, duplicated at five call sites | 5 sites | stays in `execution.rs` | 1 × `return <event>` | `execute_skips_the_approval_prompt_for_an_allowed_shell_call`, `execute_returns_mcp_failure_as_tool_data_and_continues_generation`, `remember_tool_call_is_rejected_without_persisting_when_memory_is_disabled`, **new** `a_rejected_completed_tool_use_event_fails_the_generation_retryably` |
+| 8 | `authorize_tool_call` — the permission gate and approval wait | 871-953 | `interactive.rs` | 3 × `continue`, 3 × `return <event>` | `execute_skips_the_approval_prompt_for_an_allowed_shell_call` (Allow), `execute_returns_mcp_failure_...` (Ask→Approved), `execute_denied_mcp_call_...` (Ask→Denied), `execute_stops_tool_loop_immediately_...` (Cancelled), **new** `a_policy_denied_tool_call_returns_denial_data_without_executing` (Deny), **new** `an_answer_delivered_to_an_approval_wait_is_treated_as_a_denial` (Answered), **new** `a_rejected_awaiting_approval_event_fails_the_generation_retryably` (the prompt's own sink exit) |
 
 Seams 6 and 7 stay in `execution.rs` because the tool-use loop is the only thing that has them; the
 module's own doc comment is "the tool-use loop and the skill-tool dispatch it drives". Moving them
@@ -113,7 +113,7 @@ the key map, and nothing documents that this is irrelevant.
 
 ### Coverage established before the cut
 
-Four behaviours a seam touches have no test today. Each gets a characterization test written and
+Four behaviours a seam touches have no test today. They get six characterization tests, written and
 confirmed green **against the un-split function**, in a commit that precedes the extraction:
 
 - **No test constructs `endpoint_profile: Some(..)`.** `sample_request` sets it to `None`, and
@@ -181,9 +181,32 @@ would have been abandoned instead.
 - **The subtree budget rises** → it will: new tests, one new module, eight signatures and eight call
   sites. Each component is counted and stated when the budget is raised, so a number that does not
   add up is visible rather than absorbed.
-- **The function is still large afterwards** → yes. It goes from 978 lines to roughly 580. Four
-  further seams were available on a line count and refused on the reasons above. A 580-line function
-  that behaves identically is the better outcome.
+- **The function is still large afterwards** → yes. It goes from 978 lines to 621. Four further
+  seams were available on a line count and refused on the reasons above. A 621-line function that
+  behaves identically is the better outcome.
+
+## Residual after implementation
+
+`execute_with_code_intelligence` is 621 lines, down from 978. `execution.rs` is 955, down from
+1,166. Six seams landed; the four declined above stayed declined, and nothing needed to be
+abandoned mid-implementation.
+
+Two text changes fall outside "the exit rewrite, the receiver rename, and indentation" and are
+recorded here rather than left for a reader to find:
+
+- `resolve_generation_tool_catalog`'s inline comment said the retrieval probe matched "how
+  `plan_mode` itself is derived just above". `plan_mode` is now a parameter, so the sentence would
+  have been false; it reads "derived at the call site".
+- The five copies of the tool-outcome tail were not quite identical: four spelled the status
+  `"failed".to_owned()` and the fifth `"failed".to_string()`. `record_tool_outcome` uses
+  `to_owned()`. Both produce the same `String` from the same `&'static str`.
+
+Four `#[allow]` attributes were needed, all for `GenerationProcessEvent`'s 440-byte size:
+`clippy::result_large_err` on the three seams returning `Result<_, GenerationProcessEvent>` — the
+same allowance `ask_user_question`, `request_plan_exit` and `execute_registered_native_tool`
+already carry in this module — and `clippy::large_enum_variant` on `ToolAuthorization`. Boxing was
+rejected: it would have been the only heap allocation this change introduced, on paths whose whole
+job is to hand an event back unchanged.
 
 ## Migration Plan
 

--- a/openspec/changes/decompose-api-tool-use-loop/proposal.md
+++ b/openspec/changes/decompose-api-tool-use-loop/proposal.md
@@ -1,0 +1,87 @@
+## Why
+
+`split-api-adapter-modules` turned `api_process_adapter.rs` into a directory module and recorded one
+residual in writing: `execute_with_code_intelligence`, 978 lines in a single function, was **moved
+intact and not decomposed**. Its proposal said why:
+
+> Decomposing it is the real work, and it is not a move: it means finding seams in live control flow
+> that handles tool dispatch, code-intelligence fallback, and error propagation. That belongs in its
+> own change, with its own review and its own risk budget, not smuggled into a relocation whose
+> entire safety argument rests on "nothing changed but the file it lives in".
+
+This is that change. `src-tauri/tests/architecture.rs` carries the marker:
+
+```
+// 978 of these lines are `execute_with_code_intelligence` ... This entry retires when that
+// function does.
+```
+
+The function is the whole generation path for `launch_kind = "api"` agents: endpoint and credential
+resolution, tool-catalog assembly, the SSE streaming round, the permission gate, seven distinct
+tool-dispatch branches, compaction, and about forty early returns. Every one of those is reachable
+in production on the first message a user sends to an API agent.
+
+## What Changes
+
+- Extract six seams out of `execute_with_code_intelligence` into the modules that already own each
+  concern, plus one new `endpoint.rs` for the concern that has no existing home.
+- Decline four further candidate seams and record, in `design.md`, the specific loop-carried state
+  or exit shape that makes each unsafe to cut.
+- Add characterization tests for the three behaviours a seam touches that no existing test covers,
+  **before** extracting them, and confirm each passes against the un-split function first.
+- Lower the `[ARCH-NATIVE-006]` path budget for `execution.rs` to its measured post-change value and
+  rewrite the residual comment to state the new function size.
+
+## The safety argument is different from the ones before it
+
+Every prior change in this work stream — `extract-api-adapter-inline-tests`,
+`relocate-heavyweight-inline-tests`, `split-database-migrations`, `split-web-agent-client`,
+`split-api-adapter-modules` — proved itself the same way: byte-identical item bodies, an identical
+top-level item multiset, an identical test-name list. Nothing changed but the file an item lived in.
+
+**That claim is unavailable here.** Extracting a fragment of a function's body changes control flow:
+a `return` inside the fragment becomes a value the fragment produces and the caller returns. So this
+change replaces the "nothing changed" argument with three narrower ones, stated and checked
+individually in `design.md`:
+
+1. **Every extracted fragment's exits are pure `return <expr>;` with no code after them in the
+   parent's iteration.** Each maps to `Err(<the same expr>)` and a caller-side
+   `Err(failure) => return failure`, which is observably the same event returned from the same
+   logical point. Fragments whose exits are `continue`, or that mutate loop-carried state a caller
+   cannot see, are **not** extracted.
+2. **Every `?`, every error construction, and every side-effecting call keeps its exact text and its
+   exact relative order** inside the moved fragment. The diff is reviewable as "this block, verbatim,
+   behind a signature".
+3. **Coverage is established per seam before the cut, not asserted after it.** Each seam names the
+   tests that exercise it. Where a seam had none, a test for the *pre-split* behaviour is written
+   first and confirmed green against the un-split function.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None. No Tauri command, SQLite schema, adapter contract, wire format, event shape, or user-visible
+runtime behaviour changes in either the desktop or Web runtime. No frontend file is touched. The
+change sets `skip_specs: true`.
+
+## Impact
+
+- `src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/execution.rs` — the
+  function shrinks; two helpers stay in this module because the tool-use loop is their only concern.
+- `.../api_process_adapter/endpoint.rs` — new. Provider config, endpoint metadata, context capacity,
+  credential, wire format, image-input capability.
+- `.../api_process_adapter/prompt.rs` — gains the tool-catalog assembly, next to the
+  `resolve_tool_catalog_with_code_intelligence` it already owns.
+- `.../api_process_adapter/invocation.rs` — gains the per-round context analysis, next to the
+  `record_context_snapshot` and `estimated_input_characters` it already owns.
+- `.../api_process_adapter/interactive.rs` — gains the permission gate, next to the `await_approval`
+  and `permission_action_and_resource` it already owns.
+- `.../api_process_adapter/mod.rs` — one `mod` declaration and the re-exports `tests.rs` needs.
+- `.../api_process_adapter/tests.rs` — **existing tests are not edited.** New characterization tests
+  are appended for the three uncovered behaviours.
+- `src-tauri/tests/architecture.rs` — the `execution.rs` path budget is lowered; the
+  `agent_runtime/infrastructure` subtree budget is re-measured.

--- a/openspec/changes/decompose-api-tool-use-loop/tasks.md
+++ b/openspec/changes/decompose-api-tool-use-loop/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Capture the baseline
 
-- [ ] 1.1 Record `execute_with_code_intelligence`'s physical line span, `execution.rs`'s line count,
+- [x] 1.1 Record `execute_with_code_intelligence`'s physical line span, `execution.rs`'s line count,
       and the `agent_runtime/infrastructure` subtree aggregate
-- [ ] 1.2 Capture the unsorted test-name list via
+- [x] 1.2 Capture the unsorted test-name list via
       `cargo test --manifest-path src-tauri/Cargo.toml --lib -- --list`, for the post-change subset
       comparison
-- [ ] 1.3 Save the pre-extraction text of each of the eight candidate fragments, for the
+- [x] 1.3 Save the pre-extraction text of each of the eight candidate fragments, for the
       text-identity check in 5.2
 
 ## 2. Establish coverage before cutting anything
@@ -13,65 +13,67 @@
 Each of these is written against the **un-split** function and must pass before any extraction
 begins. No existing test may be edited.
 
-- [ ] 2.1 Add a `RejectingSink` event-sink double that refuses events matching a predicate — the
+- [x] 2.1 Add a `RejectingSink` event-sink double that refuses events matching a predicate — the
       only way to reach the eight `failed_retryable("Agent generation event handling failed.")`
       exits, since `CapturingSink` never fails
-- [ ] 2.2 `a_rejected_token_event_fails_the_generation_retryably` — covers the SSE loop's sink exit
+- [x] 2.2 `a_rejected_token_event_fails_the_generation_retryably` — covers the SSE loop's sink exit
       (Seam 6)
-- [ ] 2.3 `a_rejected_completed_tool_use_event_fails_the_generation_retryably` — covers the tool
+- [x] 2.3 `a_rejected_completed_tool_use_event_fails_the_generation_retryably` — covers the tool
       outcome tail's sink exit (Seam 7)
-- [ ] 2.4 `an_answer_delivered_to_an_approval_wait_is_treated_as_a_denial` — covers
+- [x] 2.4 `a_rejected_awaiting_approval_event_fails_the_generation_retryably` — covers the
+      permission gate's sink exit, which fires before `create_pending_approval` (Seam 8)
+- [x] 2.5 `an_answer_delivered_to_an_approval_wait_is_treated_as_a_denial` — covers
       `ApprovalOutcome::Answered(_)`'s fail-closed arm (Seam 8)
-- [ ] 2.5 `a_policy_denied_tool_call_returns_denial_data_without_executing` — covers `Effect::Deny`
+- [x] 2.6 `a_policy_denied_tool_call_returns_denial_data_without_executing` — covers `Effect::Deny`
       (Seam 8)
-- [ ] 2.6 `an_endpoint_profile_context_window_smaller_than_the_request_fails_the_generation` — the
+- [x] 2.7 `an_endpoint_profile_context_window_smaller_than_the_request_fails_the_generation` — the
       first test in the suite to set `endpoint_profile: Some(..)`; covers profile → `ContextCapacity`
       → snapshot → overflow guard (Seams 1, 4, 5)
-- [ ] 2.7 Confirm all five pass against the unmodified function, and that the only change to
+- [x] 2.8 Confirm all six pass against the unmodified function, and that the only change to
       `tests.rs` is additions
 
 ## 3. Extract the seams with no early exits
 
 Each leaves `cargo test` green before the next begins.
 
-- [ ] 3.1 `prompt.rs` — `resolve_generation_tool_catalog` (execution.rs 232-287)
-- [ ] 3.2 `prompt.rs` — `resolve_generation_skill_tools` (292-335), keeping the three `let mut`
+- [x] 3.1 `prompt.rs` — `resolve_generation_tool_catalog` (execution.rs 232-287)
+- [x] 3.2 `prompt.rs` — `resolve_generation_skill_tools` (292-335), keeping the three `let mut`
       bindings in the parent so the catalog lease's drop order is unchanged
-- [ ] 3.3 new `endpoint.rs` — `resolve_image_support` (384-400)
-- [ ] 3.4 `invocation.rs` — `analyze_round_context` (430-455)
+- [x] 3.3 new `endpoint.rs` — `resolve_image_support` (384-400)
+- [x] 3.4 `invocation.rs` — `analyze_round_context` (430-455)
 
 ## 4. Extract the seams whose exits become `Err`
 
-- [ ] 4.1 `endpoint.rs` — `resolve_endpoint` returning `Result<ResolvedEndpoint, _>` (99-181); the
+- [x] 4.1 `endpoint.rs` — `resolve_endpoint` returning `Result<ResolvedEndpoint, _>` (99-181); the
       caller destructures into the same five names so the body below is untouched
-- [ ] 4.2 `execution.rs` — `stream_round` returning `Result<StreamedRound, _>` (525-613), preserving
+- [x] 4.2 `execution.rs` — `stream_round` returning `Result<StreamedRound, _>` (525-613), preserving
       the asymmetry that the two sink-failure exits do **not** call `finish_api_invocation`
-- [ ] 4.3 `execution.rs` — `record_tool_outcome` returning `Result<ExecutedToolCall, _>`, replacing
+- [x] 4.3 `execution.rs` — `record_tool_outcome` returning `Result<ExecutedToolCall, _>`, replacing
       all five duplicated tails
-- [ ] 4.4 `interactive.rs` — `authorize_tool_call` returning a three-variant `ToolAuthorization`
+- [x] 4.4 `interactive.rs` — `authorize_tool_call` returning a three-variant `ToolAuthorization`
       (871-953); the `continue`s stay in the parent
-- [ ] 4.5 `mod.rs` — declare `endpoint` and re-export whatever `tests.rs`'s `use super::*;` needs
+- [x] 4.5 `mod.rs` — declare `endpoint` and re-export whatever `tests.rs`'s `use super::*;` needs
 
 ## 5. Prove the extraction was faithful
 
-- [ ] 5.1 The 1.2 test-name list is a subset of the post-change list, and the difference is exactly
-      the five tests added in section 2
-- [ ] 5.2 Each extracted fragment diffs against its 1.3 text with no change other than the exit
+- [x] 5.1 The 1.2 test-name list is a subset of the post-change list, and the difference is exactly
+      the six tests added in section 2
+- [x] 5.2 Each extracted fragment diffs against its 1.3 text with no change other than the exit
       rewrite, the receiver rename, and indentation
-- [ ] 5.3 `git diff` on `tests.rs` contains only added lines
-- [ ] 5.4 `cargo test --manifest-path src-tauri/Cargo.toml` passes; the total test count rose by
-      exactly five
+- [x] 5.3 `git diff` on `tests.rs` contains only added lines
+- [x] 5.4 `cargo test --manifest-path src-tauri/Cargo.toml` passes; the total test count rose by
+      exactly six
 
 ## 6. Budgets and verification
 
-- [ ] 6.1 Lower the `[ARCH-NATIVE-006]` budget for `execution.rs` to its measured value and rewrite
+- [x] 6.1 Lower the `[ARCH-NATIVE-006]` budget for `execution.rs` to its measured value and rewrite
       the residual comment with the new function size
-- [ ] 6.2 Re-measure the `agent_runtime/infrastructure` subtree; raise `[ARCH-NATIVE-007]` only by
+- [x] 6.2 Re-measure the `agent_runtime/infrastructure` subtree; raise `[ARCH-NATIVE-007]` only by
       an itemized amount (new module scaffolding, helper signatures, call sites, new tests) —
       investigate anything the itemisation does not explain
-- [ ] 6.3 `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
-- [ ] 6.4 `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
-- [ ] 6.5 `npm run architecture:check`
-- [ ] 6.6 `npx openspec validate decompose-api-tool-use-loop --strict` and
+- [x] 6.3 `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
+- [x] 6.4 `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
+- [x] 6.5 `npm run architecture:check`
+- [x] 6.6 `npx openspec validate decompose-api-tool-use-loop --strict` and
       `npx openspec validate --specs --strict`
-- [ ] 6.7 Record the residual: the function's final size, and each declined seam with its reason
+- [x] 6.7 Record the residual: the function's final size, and each declined seam with its reason

--- a/openspec/changes/decompose-api-tool-use-loop/tasks.md
+++ b/openspec/changes/decompose-api-tool-use-loop/tasks.md
@@ -1,0 +1,77 @@
+## 1. Capture the baseline
+
+- [ ] 1.1 Record `execute_with_code_intelligence`'s physical line span, `execution.rs`'s line count,
+      and the `agent_runtime/infrastructure` subtree aggregate
+- [ ] 1.2 Capture the unsorted test-name list via
+      `cargo test --manifest-path src-tauri/Cargo.toml --lib -- --list`, for the post-change subset
+      comparison
+- [ ] 1.3 Save the pre-extraction text of each of the eight candidate fragments, for the
+      text-identity check in 5.2
+
+## 2. Establish coverage before cutting anything
+
+Each of these is written against the **un-split** function and must pass before any extraction
+begins. No existing test may be edited.
+
+- [ ] 2.1 Add a `RejectingSink` event-sink double that refuses events matching a predicate — the
+      only way to reach the eight `failed_retryable("Agent generation event handling failed.")`
+      exits, since `CapturingSink` never fails
+- [ ] 2.2 `a_rejected_token_event_fails_the_generation_retryably` — covers the SSE loop's sink exit
+      (Seam 6)
+- [ ] 2.3 `a_rejected_completed_tool_use_event_fails_the_generation_retryably` — covers the tool
+      outcome tail's sink exit (Seam 7)
+- [ ] 2.4 `an_answer_delivered_to_an_approval_wait_is_treated_as_a_denial` — covers
+      `ApprovalOutcome::Answered(_)`'s fail-closed arm (Seam 8)
+- [ ] 2.5 `a_policy_denied_tool_call_returns_denial_data_without_executing` — covers `Effect::Deny`
+      (Seam 8)
+- [ ] 2.6 `an_endpoint_profile_context_window_smaller_than_the_request_fails_the_generation` — the
+      first test in the suite to set `endpoint_profile: Some(..)`; covers profile → `ContextCapacity`
+      → snapshot → overflow guard (Seams 1, 4, 5)
+- [ ] 2.7 Confirm all five pass against the unmodified function, and that the only change to
+      `tests.rs` is additions
+
+## 3. Extract the seams with no early exits
+
+Each leaves `cargo test` green before the next begins.
+
+- [ ] 3.1 `prompt.rs` — `resolve_generation_tool_catalog` (execution.rs 232-287)
+- [ ] 3.2 `prompt.rs` — `resolve_generation_skill_tools` (292-335), keeping the three `let mut`
+      bindings in the parent so the catalog lease's drop order is unchanged
+- [ ] 3.3 new `endpoint.rs` — `resolve_image_support` (384-400)
+- [ ] 3.4 `invocation.rs` — `analyze_round_context` (430-455)
+
+## 4. Extract the seams whose exits become `Err`
+
+- [ ] 4.1 `endpoint.rs` — `resolve_endpoint` returning `Result<ResolvedEndpoint, _>` (99-181); the
+      caller destructures into the same five names so the body below is untouched
+- [ ] 4.2 `execution.rs` — `stream_round` returning `Result<StreamedRound, _>` (525-613), preserving
+      the asymmetry that the two sink-failure exits do **not** call `finish_api_invocation`
+- [ ] 4.3 `execution.rs` — `record_tool_outcome` returning `Result<ExecutedToolCall, _>`, replacing
+      all five duplicated tails
+- [ ] 4.4 `interactive.rs` — `authorize_tool_call` returning a three-variant `ToolAuthorization`
+      (871-953); the `continue`s stay in the parent
+- [ ] 4.5 `mod.rs` — declare `endpoint` and re-export whatever `tests.rs`'s `use super::*;` needs
+
+## 5. Prove the extraction was faithful
+
+- [ ] 5.1 The 1.2 test-name list is a subset of the post-change list, and the difference is exactly
+      the five tests added in section 2
+- [ ] 5.2 Each extracted fragment diffs against its 1.3 text with no change other than the exit
+      rewrite, the receiver rename, and indentation
+- [ ] 5.3 `git diff` on `tests.rs` contains only added lines
+- [ ] 5.4 `cargo test --manifest-path src-tauri/Cargo.toml` passes; the total test count rose by
+      exactly five
+
+## 6. Budgets and verification
+
+- [ ] 6.1 Lower the `[ARCH-NATIVE-006]` budget for `execution.rs` to its measured value and rewrite
+      the residual comment with the new function size
+- [ ] 6.2 Re-measure the `agent_runtime/infrastructure` subtree; raise `[ARCH-NATIVE-007]` only by
+      an itemized amount (new module scaffolding, helper signatures, call sites, new tests) —
+      investigate anything the itemisation does not explain
+- [ ] 6.3 `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
+- [ ] 6.4 `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
+- [ ] 6.5 `npm run architecture:check`
+- [ ] 6.6 `npx openspec validate decompose-api-tool-use-loop --strict` and
+      `npx openspec validate --specs --strict`
+- [ ] 6.7 Record the residual: the function's final size, and each declined seam with its reason

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/endpoint.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/endpoint.rs
@@ -5,9 +5,139 @@
 //! and capacity resolution live together rather than beside their call sites.
 
 use super::super::model_context_catalog;
+use super::invocation::{wire_format_for, WireFormat};
+use super::{failed_configuration, failed_non_retryable};
 use crate::contexts::agent_runtime::application::{
-    ApiProviderConfig, GenerationProcessRequest, StoredEndpointProfileMetadata,
+    ApiAgentGateway, ApiCredentialPort, ApiProviderConfig, GenerationProcessEvent,
+    GenerationProcessRequest, StoredEndpointProfileMetadata,
 };
+use crate::contexts::agent_runtime::domain::ContextCapacity;
+
+/// Everything a generation needs to reach its provider, resolved once before anything is sent.
+pub(super) struct ResolvedEndpoint {
+    pub(super) provider_config: ApiProviderConfig,
+    pub(super) endpoint_metadata: Option<StoredEndpointProfileMetadata>,
+    pub(super) endpoint_capacity: Option<ContextCapacity>,
+    pub(super) api_key: String,
+    pub(super) wire_format: WireFormat,
+}
+
+/// A frozen endpoint Profile on the request wins over the agent's stored configuration for every
+/// one of these, including the credential: a Profile-routed generation looks up
+/// `onepiece-profile:<id>` first and only falls back to the agent's own key.
+///
+/// Each `Err` is the `GenerationProcessEvent` the caller returns unchanged. They are the same
+/// seven events, built by the same three constructors from the same strings, in the same order as
+/// when this lived inline — the caller's `Err(failure) => return failure` puts each back where its
+/// `return` was.
+// `result_large_err`: the same allowance `ask_user_question`, `request_plan_exit` and
+// `execute_registered_native_tool` already carry. `GenerationProcessEvent` is what this module
+// returns; boxing it here would put an allocation on a path whose whole job is to hand the event
+// straight back.
+#[allow(clippy::result_large_err)]
+pub(super) fn resolve_endpoint(
+    request: &GenerationProcessRequest,
+    agent_id: &str,
+    config: &dyn ApiAgentGateway,
+    credentials: &dyn ApiCredentialPort,
+) -> Result<ResolvedEndpoint, GenerationProcessEvent> {
+    let provider_config = if let Some(profile) = request.endpoint_profile.as_ref() {
+        ApiProviderConfig {
+            source_provider_id: profile.source_provider_id.clone(),
+            model_id: profile.model_id.clone(),
+            interface_format: profile.interface_format.clone(),
+            base_url: profile.base_url.clone(),
+            auto_approve_tools: false,
+        }
+    } else {
+        match config.provider_config(agent_id) {
+            Ok(Some(config)) => config,
+            Ok(None) => {
+                return Err(failed_configuration(
+                    agent_id,
+                    "No model is configured for this agent.",
+                ));
+            }
+            Err(error) => return Err(failed_non_retryable(&error.to_string())),
+        }
+    };
+    let endpoint_metadata = if request.endpoint_profile.is_some() {
+        None
+    } else {
+        match config.active_endpoint_profile_metadata(agent_id) {
+            Ok(metadata) => metadata,
+            Err(error) => return Err(failed_non_retryable(&error.to_string())),
+        }
+    };
+    let endpoint_capacity = request
+        .endpoint_profile
+        .as_ref()
+        .and_then(|profile| {
+            let window = profile.context_window_tokens?;
+            (profile.context_capacity_provenance != "unknown").then(|| ContextCapacity {
+                context_window_tokens: window,
+                maximum_output_tokens: Some(profile.reserved_output_tokens),
+                metadata_revision: profile.context_capacity_provenance.clone(),
+                source_identity: format!("endpoint-profile:{}", profile.profile_id),
+            })
+        })
+        .or_else(|| {
+            endpoint_metadata.as_ref().and_then(|metadata| {
+                let window = metadata
+                    .context_window_tokens
+                    .and_then(|value| u64::try_from(value).ok())?;
+                (metadata.context_capacity_provenance != "unknown").then(|| ContextCapacity {
+                    context_window_tokens: window,
+                    maximum_output_tokens: u64::try_from(metadata.reserved_output_tokens).ok(),
+                    metadata_revision: metadata.context_capacity_provenance.clone(),
+                    source_identity: format!("endpoint-profile:{}", metadata.profile_id),
+                })
+            })
+        });
+    let authentication_mode = if let Some(profile) = request.endpoint_profile.as_ref() {
+        profile.authentication_mode.clone()
+    } else {
+        match config.api_endpoint_authentication_mode(agent_id) {
+            Ok(mode) => mode,
+            Err(error) => return Err(failed_non_retryable(&error.to_string())),
+        }
+    };
+    let credential_id = request.endpoint_profile.as_ref().map_or_else(
+        || agent_id.to_string(),
+        |profile| format!("onepiece-profile:{}", profile.profile_id),
+    );
+    let fetched_credential = if authentication_mode == "required" {
+        match credentials.fetch(&credential_id) {
+            Ok(Some(key)) => Ok(Some(key)),
+            Ok(None) if request.endpoint_profile.is_some() => credentials.fetch(agent_id),
+            other => other,
+        }
+    } else {
+        Ok(None)
+    };
+    let api_key = match fetched_credential {
+        Ok(Some(key)) => key,
+        Ok(None) if authentication_mode != "required" => String::new(),
+        Ok(None) => {
+            return Err(failed_configuration(
+                agent_id,
+                "No API key is stored for this agent.",
+            ));
+        }
+        Err(error) => return Err(failed_non_retryable(&error.to_string())),
+    };
+    let wire_format = match wire_format_for(&provider_config) {
+        Ok(wire_format) => wire_format,
+        Err(message) => return Err(failed_configuration(agent_id, message)),
+    };
+    Ok(ResolvedEndpoint {
+        provider_config,
+        endpoint_metadata,
+        endpoint_capacity,
+        api_key,
+        wire_format,
+    })
+}
 
 /// Capability comes from reviewed catalog metadata, never from trying and seeing: a provider
 /// that rejects an image-bearing request fails the whole generation after the user has already

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/endpoint.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/endpoint.rs
@@ -1,0 +1,34 @@
+//! Which endpoint a generation calls, with what credential, and what it is declared to support.
+//!
+//! All of it reads the same three sources in the same precedence — the request's frozen endpoint
+//! Profile, the agent's stored Profile metadata, then the model catalog — which is why capability
+//! and capacity resolution live together rather than beside their call sites.
+
+use super::super::model_context_catalog;
+use crate::contexts::agent_runtime::application::{
+    ApiProviderConfig, GenerationProcessRequest, StoredEndpointProfileMetadata,
+};
+
+/// Capability comes from reviewed catalog metadata, never from trying and seeing: a provider
+/// that rejects an image-bearing request fails the whole generation after the user has already
+/// waited, and the failure text varies by vendor (`add-agent-image-input` D3).
+pub(super) fn resolve_image_support(
+    request: &GenerationProcessRequest,
+    endpoint_metadata: Option<&StoredEndpointProfileMetadata>,
+    provider_config: &ApiProviderConfig,
+) -> bool {
+    request.endpoint_profile.as_ref().map_or_else(
+        || {
+            endpoint_metadata.map_or_else(
+                || {
+                    model_context_catalog::accepts_image_input(
+                        provider_config.source_provider_id.as_deref(),
+                        &provider_config.model_id,
+                    )
+                },
+                |metadata| metadata.image_input_capability == "supported",
+            )
+        },
+        |profile| profile.image_input_capability == "supported",
+    )
+}

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/execution.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/execution.rs
@@ -2,12 +2,11 @@
 
 use super::super::agent_image::MAX_IMAGES_PER_REQUEST;
 use super::super::memory_selection_gateway::RuntimeAgentMemorySelectionAdapter;
-use super::super::model_context_catalog;
-use super::super::skill_tool_catalog_adapter::resolve_skill_tool_catalog;
 use super::super::tool_call_accumulator::ToolCallAccumulator;
 use super::super::tools::{execute_file_image_read, ToolExecutionOutcome};
 use super::super::SqliteNativeToolRepository;
-use super::compaction::{maybe_compact_accounted, should_compact, turns_character_count};
+use super::compaction::maybe_compact_accounted;
+use super::endpoint::resolve_image_support;
 use super::generation::{
     generation_options_from_configuration, is_plan_mode, reviewed_stream_usage_strategy,
 };
@@ -16,7 +15,7 @@ use super::interactive::{
     ApprovalOutcome,
 };
 use super::invocation::{
-    begin_api_invocation, estimated_input_characters, finish_api_invocation,
+    analyze_round_context, begin_api_invocation, estimated_input_characters, finish_api_invocation,
     record_context_snapshot, wire_format_for,
 };
 use super::native_tools::{
@@ -24,25 +23,23 @@ use super::native_tools::{
     log_image_attachment, resolve_tool_image,
 };
 use super::prompt::{
+    resolve_generation_skill_tools, resolve_generation_tool_catalog,
     resolve_personalization_settings, resolve_system_prompt_with_settings,
-    resolve_tool_catalog_with_code_intelligence,
 };
 use super::{
     failed_configuration, failed_non_retryable, failed_retryable, ExecutedToolCall,
     PendingApprovals, HISTORY_LIMIT, MAX_TOOL_ROUND_TRIPS,
 };
 use crate::contexts::agent_runtime::application::{
-    delegate_utility_skill_tool_definition, AgentClockPort, AgentCodeIntelligenceContext,
-    AgentCodeIntelligencePort, AgentCoreInstructionsPort, AgentLog, AgentLogLevel,
-    AgentLoggingPort, AgentMcpToolPort, AgentMemoryPort, AgentPermissionPort,
-    AgentPersonalizationPort, AgentProcessEventSink, AgentRetrievalPort,
-    AgentRuntimeApplicationError, AgentSkillPort, AgentWorkspaceMutationPort, ApiAgentGateway,
-    ApiCredentialPort, ApiProviderConfig, ContextAnalysisInput, ContextAnalysisService,
-    ContextQualityRecorder, ConversationHistoryPort, GenerationProcessEvent,
-    GenerationProcessFailure, GenerationProcessRequest, NativeToolExecutionMode,
-    NativeToolRegistry, SkillToolUseProvenance, ToolEligibilityContext, ToolLifecycleEvent,
-    ToolLifecyclePhase, ToolUseBlock, UtilityDelegationApplicationService,
-    ASK_USER_QUESTION_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME, REMEMBER_TOOL_NAME,
+    AgentClockPort, AgentCodeIntelligencePort, AgentCoreInstructionsPort, AgentLoggingPort,
+    AgentMcpToolPort, AgentMemoryPort, AgentPermissionPort, AgentPersonalizationPort,
+    AgentProcessEventSink, AgentRetrievalPort, AgentRuntimeApplicationError, AgentSkillPort,
+    AgentWorkspaceMutationPort, ApiAgentGateway, ApiCredentialPort, ApiProviderConfig,
+    ContextAnalysisService, ContextQualityRecorder, ConversationHistoryPort,
+    GenerationProcessEvent, GenerationProcessFailure, GenerationProcessRequest, NativeToolRegistry,
+    SkillToolUseProvenance, ToolLifecycleEvent, ToolLifecyclePhase, ToolUseBlock,
+    UtilityDelegationApplicationService, ASK_USER_QUESTION_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME,
+    REMEMBER_TOOL_NAME,
 };
 use crate::contexts::agent_runtime::domain::{
     AutomaticCompactionState, ContextCapacity, UsageAnchor,
@@ -52,9 +49,9 @@ use crate::contexts::permissions::domain::Effect;
 use crate::contexts::sessions::api::{SessionsApi, UsagePurpose, UsageStatus};
 use crate::contexts::skill_evolution_evidence::domain::ObservedSkillRevision;
 use crate::contexts::tooling::skill_tools::application::{
-    SkillToolBinding, SkillToolCatalogContext, SkillToolCatalogMode, SkillToolCatalogPort,
-    SkillToolDispatchOutcome, SkillToolExecutionLifecyclePhase, SkillToolExecutionLifecyclePort,
-    SkillToolExecutionPort, SkillToolExecutionRequest,
+    SkillToolCatalogMode, SkillToolCatalogPort, SkillToolDispatchOutcome,
+    SkillToolExecutionLifecyclePhase, SkillToolExecutionLifecyclePort, SkillToolExecutionPort,
+    SkillToolExecutionRequest,
 };
 use crate::platform::network::blocking_http_client;
 use serde_json::Value;
@@ -229,109 +226,37 @@ pub(super) fn execute_with_code_intelligence(
         }
     };
     let plan_mode = is_plan_mode(&request.configuration);
-    // Never blocks, never errors (`AgentRetrievalPort::is_configured`'s own contract) — safe to
-    // call unconditionally on every generation's catalog resolution, matching how `plan_mode`
-    // itself is derived just above.
-    let retrieval_available = retrieval.is_configured();
-    let code_search_available = request
-        .session
-        .folder
-        .as_deref()
-        .and_then(|folder| {
-            retrieval
-                .code_retrieval()
-                .map(|code| code.is_available(folder))
-        })
-        .unwrap_or(false);
-    let code_intelligence_context = request
-        .session
-        .folder
-        .as_deref()
-        .map(AgentCodeIntelligenceContext::from_session_workspace);
-    let code_intelligence_available = code_intelligence_context
-        .as_ref()
-        .is_some_and(|context| code_intelligence.is_available(context));
-    let mut tools = resolve_tool_catalog_with_code_intelligence(
+    let mut tools = resolve_generation_tool_catalog(
         request,
         mcp,
         logging,
         clock,
+        retrieval,
+        code_intelligence,
+        native_tools,
+        utility_delegation,
         plan_mode,
-        retrieval_available,
-        code_search_available,
-        code_intelligence_available,
     );
-    if utility_delegation.is_some() && !plan_mode {
-        tools.push(delegate_utility_skill_tool_definition());
-    }
-    tools.extend(
-        native_tools.eligible_tool_definitions(&ToolEligibilityContext {
-            agent_id: request.agent.id.clone(),
-            session_id: request.session.id.clone(),
-            generation_id: request.operation_id.clone(),
-            canonical_workspace: request.session.folder.as_deref().map(Into::into),
-            execution_mode: if plan_mode {
-                NativeToolExecutionMode::Plan
-            } else {
-                NativeToolExecutionMode::Execute
-            },
-            readiness: native_tools.readiness_snapshot(),
-        }),
-    );
-    if request
-        .endpoint_profile
-        .as_ref()
-        .is_some_and(|profile| profile.tool_calling_capability != "supported")
-    {
-        tools.clear();
-    }
+    // Declared here, not returned as one value: `_skill_tool_catalog_lease` is an `Arc` held for
+    // the rest of the generation, and these three drop in this order at the end of it.
     let mut skill_tool_keys = HashMap::new();
     let mut _skill_tool_catalog_lease = None;
     let mut _skill_tool_catalog_generation = None;
     if let Some(catalog) = skill_tool_catalog {
-        let loaded_roles = observed_skill_revisions
-            .iter()
-            .map(|observed| SkillToolBinding {
-                skill_id: observed.skill_id.clone(),
-                revision: observed.revision.clone(),
-            })
-            .collect::<Vec<_>>();
-        let context = SkillToolCatalogContext::RoleGeneration {
-            workspace_path: request.session.folder.clone(),
-            loaded_roles,
-            mode: if plan_mode {
-                SkillToolCatalogMode::Plan
-            } else {
-                SkillToolCatalogMode::Execute
-            },
-        };
-        let existing_names = tools.iter().map(|tool| tool.name.clone());
-        match resolve_skill_tool_catalog(
+        if let Some(resolved) = resolve_generation_skill_tools(
             catalog,
-            &context,
-            existing_names,
-            &provider_config.interface_format,
+            request,
+            &provider_config,
+            observed_skill_revisions,
+            &tools,
+            logging,
+            clock,
+            plan_mode,
         ) {
-            Ok(resolved) => {
-                tools.extend(resolved.definitions);
-                skill_tool_keys = resolved.keys_by_name;
-                _skill_tool_catalog_generation = Some(resolved.generation);
-                _skill_tool_catalog_lease = Some(resolved.lease);
-            }
-            Err(error) => {
-                let _ = logging.record(AgentLog {
-                    level: AgentLogLevel::Warn,
-                    category: "session.runtime.api.skill-tools".to_string(),
-                    message: format!("Skill tool catalog rejected: {}", error.code()),
-                    agent_id: Some(request.agent.id.clone()),
-                    session_id: Some(request.session.id.clone()),
-                    operation_id: Some(request.operation_id.clone()),
-                    run_id: None,
-                    trace_id: None,
-                    span_id: None,
-                    occurred_at: clock.now(),
-                });
-            }
+            tools.extend(resolved.definitions);
+            skill_tool_keys = resolved.keys_by_name;
+            _skill_tool_catalog_generation = Some(resolved.generation);
+            _skill_tool_catalog_lease = Some(resolved.lease);
         }
     }
     let mut generation_options = generation_options_from_configuration(
@@ -381,23 +306,8 @@ pub(super) fn execute_with_code_intelligence(
     }
 
     let mut emitted_visible_content = false;
-    // Capability comes from reviewed catalog metadata, never from trying and seeing: a provider
-    // that rejects an image-bearing request fails the whole generation after the user has already
-    // waited, and the failure text varies by vendor (`add-agent-image-input` D3).
-    let images_supported = request.endpoint_profile.as_ref().map_or_else(
-        || {
-            endpoint_metadata.as_ref().map_or_else(
-                || {
-                    model_context_catalog::accepts_image_input(
-                        provider_config.source_provider_id.as_deref(),
-                        &provider_config.model_id,
-                    )
-                },
-                |metadata| metadata.image_input_capability == "supported",
-            )
-        },
-        |profile| profile.image_input_capability == "supported",
-    );
+    let images_supported =
+        resolve_image_support(request, endpoint_metadata.as_ref(), &provider_config);
     let mut images_in_request = 0_usize;
     let mut context_recovery_attempted = false;
     for round_trip in 0..MAX_TOOL_ROUND_TRIPS {
@@ -427,30 +337,15 @@ pub(super) fn execute_with_code_intelligence(
             system.as_deref(),
             &generation_options,
         );
-        let projection = (wire_format.project_request_context)(&body);
-        let mut context_snapshot = ContextAnalysisService::analyze(
-            ContextAnalysisInput {
-                provider_id: provider_config.source_provider_id.clone(),
-                model_id: provider_config.model_id.clone(),
-                request_fingerprint: projection.request_fingerprint,
-                characters: projection.characters,
-                components: projection.components,
-                rounds: projection.rounds,
-                token_estimate_complete: projection.token_estimate_complete,
-                capacity: endpoint_capacity.clone().or_else(|| {
-                    (endpoint_metadata.is_none() && request.endpoint_profile.is_none()).then(
-                        || {
-                            model_context_catalog::resolve_capacity(
-                                provider_config.source_provider_id.as_deref(),
-                                &provider_config.model_id,
-                            )
-                        },
-                    )?
-                }),
-                active_character_compaction: should_compact(turns_character_count(&turns)),
-                invocation_sequence: sequence,
-                overflow_count: projection.overflow_count,
-            },
+        let mut context_snapshot = analyze_round_context(
+            &body,
+            &wire_format,
+            &provider_config,
+            endpoint_capacity.as_ref(),
+            endpoint_metadata.as_ref(),
+            request,
+            &turns,
+            sequence,
             context_usage_anchor.as_ref(),
         );
         record_context_snapshot(logging, clock, request, sequence, &context_snapshot);

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/execution.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/execution.rs
@@ -1,22 +1,21 @@
 //! The tool-use loop and the skill-tool dispatch it drives.
 
-use super::super::agent_image::MAX_IMAGES_PER_REQUEST;
+use super::super::agent_image::{AgentImage, MAX_IMAGES_PER_REQUEST};
 use super::super::memory_selection_gateway::RuntimeAgentMemorySelectionAdapter;
 use super::super::tool_call_accumulator::ToolCallAccumulator;
 use super::super::tools::{execute_file_image_read, ToolExecutionOutcome};
 use super::super::SqliteNativeToolRepository;
 use super::compaction::maybe_compact_accounted;
-use super::endpoint::resolve_image_support;
+use super::endpoint::{resolve_endpoint, resolve_image_support, ResolvedEndpoint};
 use super::generation::{
     generation_options_from_configuration, is_plan_mode, reviewed_stream_usage_strategy,
 };
 use super::interactive::{
-    ask_user_question, await_approval, permission_action_and_resource, request_plan_exit,
-    ApprovalOutcome,
+    ask_user_question, authorize_tool_call, request_plan_exit, ToolAuthorization,
 };
 use super::invocation::{
     analyze_round_context, begin_api_invocation, estimated_input_characters, finish_api_invocation,
-    record_context_snapshot, wire_format_for,
+    record_context_snapshot, WireFormat,
 };
 use super::native_tools::{
     execute_registered_native_tool, execute_tool_call_with_runtime_ports, is_image_read_request,
@@ -27,26 +26,23 @@ use super::prompt::{
     resolve_personalization_settings, resolve_system_prompt_with_settings,
 };
 use super::{
-    failed_configuration, failed_non_retryable, failed_retryable, ExecutedToolCall,
-    PendingApprovals, HISTORY_LIMIT, MAX_TOOL_ROUND_TRIPS,
+    failed_non_retryable, failed_retryable, ExecutedToolCall, PendingApprovals, HISTORY_LIMIT,
+    MAX_TOOL_ROUND_TRIPS,
 };
 use crate::contexts::agent_runtime::application::{
     AgentClockPort, AgentCodeIntelligencePort, AgentCoreInstructionsPort, AgentLoggingPort,
     AgentMcpToolPort, AgentMemoryPort, AgentPermissionPort, AgentPersonalizationPort,
     AgentProcessEventSink, AgentRetrievalPort, AgentRuntimeApplicationError, AgentSkillPort,
-    AgentWorkspaceMutationPort, ApiAgentGateway, ApiCredentialPort, ApiProviderConfig,
-    ContextAnalysisService, ContextQualityRecorder, ConversationHistoryPort,
-    GenerationProcessEvent, GenerationProcessFailure, GenerationProcessRequest, NativeToolRegistry,
+    AgentWorkspaceMutationPort, ApiAgentGateway, ApiCredentialPort, ContextAnalysisService,
+    ContextQualityRecorder, ConversationHistoryPort, GenerationProcessEvent,
+    GenerationProcessFailure, GenerationProcessRequest, NativeToolRegistry, ReportedUsageTotals,
     SkillToolUseProvenance, ToolLifecycleEvent, ToolLifecyclePhase, ToolUseBlock,
     UtilityDelegationApplicationService, ASK_USER_QUESTION_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME,
     REMEMBER_TOOL_NAME,
 };
-use crate::contexts::agent_runtime::domain::{
-    AutomaticCompactionState, ContextCapacity, UsageAnchor,
-};
+use crate::contexts::agent_runtime::domain::{AutomaticCompactionState, UsageAnchor};
 use crate::contexts::artifacts::application::ArtifactService;
-use crate::contexts::permissions::domain::Effect;
-use crate::contexts::sessions::api::{SessionsApi, UsagePurpose, UsageStatus};
+use crate::contexts::sessions::api::{NewModelInvocation, SessionsApi, UsagePurpose, UsageStatus};
 use crate::contexts::skill_evolution_evidence::domain::ObservedSkillRevision;
 use crate::contexts::tooling::skill_tools::application::{
     SkillToolCatalogMode, SkillToolCatalogPort, SkillToolDispatchOutcome,
@@ -93,88 +89,15 @@ pub(super) fn execute_with_code_intelligence(
     native_tool_events: Option<&tauri::AppHandle>,
 ) -> GenerationProcessEvent {
     let agent_id = request.agent.id.as_str();
-    let provider_config = if let Some(profile) = request.endpoint_profile.as_ref() {
-        ApiProviderConfig {
-            source_provider_id: profile.source_provider_id.clone(),
-            model_id: profile.model_id.clone(),
-            interface_format: profile.interface_format.clone(),
-            base_url: profile.base_url.clone(),
-            auto_approve_tools: false,
-        }
-    } else {
-        match config.provider_config(agent_id) {
-            Ok(Some(config)) => config,
-            Ok(None) => {
-                return failed_configuration(agent_id, "No model is configured for this agent.");
-            }
-            Err(error) => return failed_non_retryable(&error.to_string()),
-        }
-    };
-    let endpoint_metadata = if request.endpoint_profile.is_some() {
-        None
-    } else {
-        match config.active_endpoint_profile_metadata(agent_id) {
-            Ok(metadata) => metadata,
-            Err(error) => return failed_non_retryable(&error.to_string()),
-        }
-    };
-    let endpoint_capacity = request
-        .endpoint_profile
-        .as_ref()
-        .and_then(|profile| {
-            let window = profile.context_window_tokens?;
-            (profile.context_capacity_provenance != "unknown").then(|| ContextCapacity {
-                context_window_tokens: window,
-                maximum_output_tokens: Some(profile.reserved_output_tokens),
-                metadata_revision: profile.context_capacity_provenance.clone(),
-                source_identity: format!("endpoint-profile:{}", profile.profile_id),
-            })
-        })
-        .or_else(|| {
-            endpoint_metadata.as_ref().and_then(|metadata| {
-                let window = metadata
-                    .context_window_tokens
-                    .and_then(|value| u64::try_from(value).ok())?;
-                (metadata.context_capacity_provenance != "unknown").then(|| ContextCapacity {
-                    context_window_tokens: window,
-                    maximum_output_tokens: u64::try_from(metadata.reserved_output_tokens).ok(),
-                    metadata_revision: metadata.context_capacity_provenance.clone(),
-                    source_identity: format!("endpoint-profile:{}", metadata.profile_id),
-                })
-            })
-        });
-    let authentication_mode = if let Some(profile) = request.endpoint_profile.as_ref() {
-        profile.authentication_mode.clone()
-    } else {
-        match config.api_endpoint_authentication_mode(agent_id) {
-            Ok(mode) => mode,
-            Err(error) => return failed_non_retryable(&error.to_string()),
-        }
-    };
-    let credential_id = request.endpoint_profile.as_ref().map_or_else(
-        || agent_id.to_string(),
-        |profile| format!("onepiece-profile:{}", profile.profile_id),
-    );
-    let fetched_credential = if authentication_mode == "required" {
-        match credentials.fetch(&credential_id) {
-            Ok(Some(key)) => Ok(Some(key)),
-            Ok(None) if request.endpoint_profile.is_some() => credentials.fetch(agent_id),
-            other => other,
-        }
-    } else {
-        Ok(None)
-    };
-    let api_key = match fetched_credential {
-        Ok(Some(key)) => key,
-        Ok(None) if authentication_mode != "required" => String::new(),
-        Ok(None) => {
-            return failed_configuration(agent_id, "No API key is stored for this agent.");
-        }
-        Err(error) => return failed_non_retryable(&error.to_string()),
-    };
-    let wire_format = match wire_format_for(&provider_config) {
-        Ok(wire_format) => wire_format,
-        Err(message) => return failed_configuration(agent_id, message),
+    let ResolvedEndpoint {
+        provider_config,
+        endpoint_metadata,
+        endpoint_capacity,
+        api_key,
+        wire_format,
+    } = match resolve_endpoint(request, agent_id, config, credentials) {
+        Ok(endpoint) => endpoint,
+        Err(failure) => return failure,
     };
     let generation_personalization =
         resolve_personalization_settings(personalization, logging, clock, request);
@@ -417,95 +340,24 @@ pub(super) fn execute_with_code_intelligence(
             ));
         }
 
-        let mut reader = std::io::BufReader::new(response);
-        let mut current_data: Option<String> = None;
-        let mut accumulator = ToolCallAccumulator::default();
-        let mut assistant_text = String::new();
-        let mut round_usage = None;
-        loop {
-            if cancelled.load(Ordering::SeqCst) {
-                finish_api_invocation(
-                    accounting,
-                    invocation.as_ref(),
-                    round_usage.as_ref(),
-                    None,
-                    UsageStatus::Cancelled,
-                    clock,
-                    logging,
-                );
-                return failed_non_retryable("Generation was cancelled.");
-            }
-            let mut line = String::new();
-            let read = match reader.read_line(&mut line) {
-                Ok(read) => read,
-                Err(error) => {
-                    finish_api_invocation(
-                        accounting,
-                        invocation.as_ref(),
-                        round_usage.as_ref(),
-                        None,
-                        UsageStatus::Failed,
-                        clock,
-                        logging,
-                    );
-                    return GenerationProcessEvent::Failed(GenerationProcessFailure::retryable(
-                        format!("Failed to read the provider API response: {error}"),
-                    ));
-                }
-            };
-            if read == 0 {
-                break;
-            }
-            let line = line.trim_end_matches(['\r', '\n']);
-            if let Some(data) = line.strip_prefix("data:") {
-                current_data = Some(data.trim().to_string());
-                continue;
-            }
-            if line.is_empty() {
-                if let Some(data) = current_data.take() {
-                    match (wire_format.translate_sse_data)(&data, &mut accumulator) {
-                        Some(GenerationProcessEvent::Completed(usage)) => {
-                            round_usage = usage;
-                            break;
-                        }
-                        Some(GenerationProcessEvent::Failed(failure)) => {
-                            finish_api_invocation(
-                                accounting,
-                                invocation.as_ref(),
-                                round_usage.as_ref(),
-                                None,
-                                UsageStatus::Failed,
-                                clock,
-                                logging,
-                            );
-                            return GenerationProcessEvent::Failed(failure);
-                        }
-                        Some(GenerationProcessEvent::Token(text)) => {
-                            let starts_new_round = assistant_text.is_empty();
-                            assistant_text.push_str(&text);
-                            let content_delta = if emitted_visible_content && starts_new_round {
-                                format!("\n{text}")
-                            } else {
-                                text
-                            };
-                            emitted_visible_content = true;
-                            if sink
-                                .handle(GenerationProcessEvent::Token(content_delta))
-                                .is_err()
-                            {
-                                return failed_retryable("Agent generation event handling failed.");
-                            }
-                        }
-                        Some(event) => {
-                            if sink.handle(event).is_err() {
-                                return failed_retryable("Agent generation event handling failed.");
-                            }
-                        }
-                        None => {}
-                    }
-                }
-            }
-        }
+        let StreamedRound {
+            mut accumulator,
+            assistant_text,
+            round_usage,
+        } = match stream_round(
+            response,
+            &wire_format,
+            sink,
+            &cancelled,
+            &mut emitted_visible_content,
+            accounting,
+            invocation.as_ref(),
+            clock,
+            logging,
+        ) {
+            Ok(round) => round,
+            Err(failure) => return failure,
+        };
 
         finish_api_invocation(
             accounting,
@@ -575,19 +427,10 @@ pub(super) fn execute_with_code_intelligence(
                     log_image_attachment(logging, clock, request, &tool_use.id, image);
                     images_in_request += 1;
                 }
-                tool_use.status = if outcome.is_error {
-                    "failed".to_owned()
-                } else {
-                    "completed".to_owned()
-                };
-                tool_use.output = Some(Value::String(outcome.output.clone()));
-                if sink
-                    .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
-                    .is_err()
-                {
-                    return failed_retryable("Agent generation event handling failed.");
+                match record_tool_outcome(sink, tool_use, outcome, image) {
+                    Ok(entry) => executed.push(entry),
+                    Err(failure) => return failure,
                 }
-                executed.push((tool_use, outcome.output, outcome.is_error, image));
                 continue;
             }
             // Intercepted here for the same reason `ask_user_question` is: the image has to reach
@@ -631,19 +474,10 @@ pub(super) fn execute_with_code_intelligence(
                     log_image_attachment(logging, clock, request, &tool_use.id, image);
                     images_in_request += 1;
                 }
-                tool_use.status = if outcome.is_error {
-                    "failed".to_owned()
-                } else {
-                    "completed".to_owned()
-                };
-                tool_use.output = Some(Value::String(outcome.output.clone()));
-                if sink
-                    .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
-                    .is_err()
-                {
-                    return failed_retryable("Agent generation event handling failed.");
+                match record_tool_outcome(sink, tool_use, outcome, image) {
+                    Ok(entry) => executed.push(entry),
+                    Err(failure) => return failure,
                 }
-                executed.push((tool_use, outcome.output, outcome.is_error, image));
                 continue;
             }
             // Handled here rather than in `execute_tool_call_impl` because asking needs the event
@@ -661,19 +495,10 @@ pub(super) fn execute_with_code_intelligence(
                     Ok(outcome) => outcome,
                     Err(failure) => return failure,
                 };
-                tool_use.status = if outcome.is_error {
-                    "failed".to_owned()
-                } else {
-                    "completed".to_owned()
-                };
-                tool_use.output = Some(Value::String(outcome.output.clone()));
-                if sink
-                    .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
-                    .is_err()
-                {
-                    return failed_retryable("Agent generation event handling failed.");
+                match record_tool_outcome(sink, tool_use, outcome, None) {
+                    Ok(entry) => executed.push(entry),
+                    Err(failure) => return failure,
                 }
-                executed.push((tool_use, outcome.output, outcome.is_error, None));
                 continue;
             }
             // Same placement and reason as the question above: the sink and blocked-call channel
@@ -691,19 +516,10 @@ pub(super) fn execute_with_code_intelligence(
                     Ok(outcome) => outcome,
                     Err(failure) => return failure,
                 };
-                tool_use.status = if outcome.is_error {
-                    "failed".to_owned()
-                } else {
-                    "completed".to_owned()
-                };
-                tool_use.output = Some(Value::String(outcome.output.clone()));
-                if sink
-                    .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
-                    .is_err()
-                {
-                    return failed_retryable("Agent generation event handling failed.");
+                match record_tool_outcome(sink, tool_use, outcome, None) {
+                    Ok(entry) => executed.push(entry),
+                    Err(failure) => return failure,
                 }
-                executed.push((tool_use, outcome.output, outcome.is_error, None));
                 continue;
             }
             if tool_use.name.starts_with("skill__") {
@@ -763,88 +579,22 @@ pub(super) fn execute_with_code_intelligence(
                 executed.push((tool_use, outcome.output, outcome.is_error, None));
                 continue;
             }
-            let (permission_action, permission_resource) =
-                permission_action_and_resource(&tool_use.name, &input);
-            let project_key = request.session.folder.as_deref().unwrap_or("");
-            let effect = permissions.evaluate(
+            match authorize_tool_call(
+                &mut tool_use,
+                &input,
                 agent_id,
-                permission_action.clone(),
-                permission_resource.clone(),
-                &request.session.id,
-                &request.operation_id,
-                project_key,
-            );
-            match effect {
-                Effect::Allow => {}
-                Effect::Deny => {
-                    let denial = "Denied by policy.".to_string();
-                    tool_use.status = "failed".to_string();
-                    tool_use.output = Some(Value::String(denial.clone()));
-                    if sink
-                        .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
-                        .is_err()
-                    {
-                        return failed_retryable("Agent generation event handling failed.");
-                    }
+                request,
+                permissions,
+                pending_approvals,
+                sink,
+                &cancelled,
+            ) {
+                ToolAuthorization::Allowed => {}
+                ToolAuthorization::Denied(denial) => {
                     executed.push((tool_use, denial, true, None));
                     continue;
                 }
-                Effect::Ask => {
-                    tool_use.status = "awaiting_approval".to_string();
-                    if sink
-                        .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
-                        .is_err()
-                    {
-                        return failed_retryable("Agent generation event handling failed.");
-                    }
-                    if let Err(error) = permissions.create_pending_approval(
-                        agent_id,
-                        permission_action,
-                        permission_resource,
-                        &request.session.id,
-                        &request.operation_id,
-                        &tool_use.id,
-                        project_key,
-                    ) {
-                        return failed_non_retryable(&error.to_string());
-                    }
-                    match await_approval(&tool_use.id, &cancelled, pending_approvals) {
-                        ApprovalOutcome::Approved => {}
-                        ApprovalOutcome::Denied => {
-                            let denial = "Denied by user.".to_string();
-                            tool_use.status = "failed".to_string();
-                            tool_use.output = Some(Value::String(denial.clone()));
-                            if sink
-                                .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
-                                .is_err()
-                            {
-                                return failed_retryable("Agent generation event handling failed.");
-                            }
-                            executed.push((tool_use, denial, true, None));
-                            continue;
-                        }
-                        ApprovalOutcome::Cancelled => {
-                            return failed_non_retryable(
-                                "Generation was cancelled while a tool call was awaiting approval.",
-                            );
-                        }
-                        // An answer delivered to a call that asked for permission means the two
-                        // resolutions were crossed; fail closed rather than treat it as consent.
-                        ApprovalOutcome::Answered(_) => {
-                            let denial = "Denied by user.".to_string();
-                            tool_use.status = "failed".to_string();
-                            tool_use.output = Some(Value::String(denial.clone()));
-                            if sink
-                                .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
-                                .is_err()
-                            {
-                                return failed_retryable("Agent generation event handling failed.");
-                            }
-                            executed.push((tool_use, denial, true, None));
-                            continue;
-                        }
-                    }
-                }
+                ToolAuthorization::Failed(failure) => return failure,
             }
             tool_use.status = "running".to_string();
             if sink
@@ -885,19 +635,10 @@ pub(super) fn execute_with_code_intelligence(
             if cancelled.load(Ordering::SeqCst) {
                 return failed_non_retryable("Generation was cancelled.");
             }
-            tool_use.status = if outcome.is_error {
-                "failed".to_string()
-            } else {
-                "completed".to_string()
-            };
-            tool_use.output = Some(Value::String(outcome.output.clone()));
-            if sink
-                .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
-                .is_err()
-            {
-                return failed_retryable("Agent generation event handling failed.");
+            match record_tool_outcome(sink, tool_use, outcome, None) {
+                Ok(entry) => executed.push(entry),
+                Err(failure) => return failure,
             }
-            executed.push((tool_use, outcome.output, outcome.is_error, None));
         }
 
         turns.extend((wire_format.build_reply_turns)(&assistant_text, &executed));
@@ -937,6 +678,159 @@ pub(super) fn execute_with_code_intelligence(
     }
 
     failed_non_retryable("Tool-use loop exceeded the maximum number of round trips.")
+}
+
+/// What one round trip's SSE stream produced.
+struct StreamedRound {
+    accumulator: ToolCallAccumulator,
+    assistant_text: String,
+    round_usage: Option<ReportedUsageTotals>,
+}
+
+/// Reads one round trip's `text/event-stream` response to completion.
+///
+/// Each `Err` is the `GenerationProcessEvent` the caller returns unchanged. Note the asymmetry the
+/// exits carry with them, unchanged from when this loop was inline: cancellation, a read error and
+/// a translated failure each finish the accounting invocation before returning, while a rejected
+/// event does **not** — a sink that cannot accept events cannot be trusted to have observed the
+/// round at all, so the invocation is left open rather than recorded as a completed failure.
+#[allow(clippy::too_many_arguments, clippy::result_large_err)]
+fn stream_round(
+    response: reqwest::blocking::Response,
+    wire_format: &WireFormat,
+    sink: &dyn AgentProcessEventSink,
+    cancelled: &AtomicBool,
+    emitted_visible_content: &mut bool,
+    accounting: Option<&SessionsApi>,
+    invocation: Option<&NewModelInvocation>,
+    clock: &dyn AgentClockPort,
+    logging: &dyn AgentLoggingPort,
+) -> Result<StreamedRound, GenerationProcessEvent> {
+    let mut reader = std::io::BufReader::new(response);
+    let mut current_data: Option<String> = None;
+    let mut accumulator = ToolCallAccumulator::default();
+    let mut assistant_text = String::new();
+    let mut round_usage = None;
+    loop {
+        if cancelled.load(Ordering::SeqCst) {
+            finish_api_invocation(
+                accounting,
+                invocation,
+                round_usage.as_ref(),
+                None,
+                UsageStatus::Cancelled,
+                clock,
+                logging,
+            );
+            return Err(failed_non_retryable("Generation was cancelled."));
+        }
+        let mut line = String::new();
+        let read = match reader.read_line(&mut line) {
+            Ok(read) => read,
+            Err(error) => {
+                finish_api_invocation(
+                    accounting,
+                    invocation,
+                    round_usage.as_ref(),
+                    None,
+                    UsageStatus::Failed,
+                    clock,
+                    logging,
+                );
+                return Err(GenerationProcessEvent::Failed(
+                    GenerationProcessFailure::retryable(format!(
+                        "Failed to read the provider API response: {error}"
+                    )),
+                ));
+            }
+        };
+        if read == 0 {
+            break;
+        }
+        let line = line.trim_end_matches(['\r', '\n']);
+        if let Some(data) = line.strip_prefix("data:") {
+            current_data = Some(data.trim().to_string());
+            continue;
+        }
+        if line.is_empty() {
+            if let Some(data) = current_data.take() {
+                match (wire_format.translate_sse_data)(&data, &mut accumulator) {
+                    Some(GenerationProcessEvent::Completed(usage)) => {
+                        round_usage = usage;
+                        break;
+                    }
+                    Some(GenerationProcessEvent::Failed(failure)) => {
+                        finish_api_invocation(
+                            accounting,
+                            invocation,
+                            round_usage.as_ref(),
+                            None,
+                            UsageStatus::Failed,
+                            clock,
+                            logging,
+                        );
+                        return Err(GenerationProcessEvent::Failed(failure));
+                    }
+                    Some(GenerationProcessEvent::Token(text)) => {
+                        let starts_new_round = assistant_text.is_empty();
+                        assistant_text.push_str(&text);
+                        let content_delta = if *emitted_visible_content && starts_new_round {
+                            format!("\n{text}")
+                        } else {
+                            text
+                        };
+                        *emitted_visible_content = true;
+                        if sink
+                            .handle(GenerationProcessEvent::Token(content_delta))
+                            .is_err()
+                        {
+                            return Err(failed_retryable(
+                                "Agent generation event handling failed.",
+                            ));
+                        }
+                    }
+                    Some(event) => {
+                        if sink.handle(event).is_err() {
+                            return Err(failed_retryable(
+                                "Agent generation event handling failed.",
+                            ));
+                        }
+                    }
+                    None => {}
+                }
+            }
+        }
+    }
+    Ok(StreamedRound {
+        accumulator,
+        assistant_text,
+        round_usage,
+    })
+}
+
+/// The status/output/emit/push tail every tool-dispatch branch ends with, which each of the five
+/// branches carried its own copy of. `Err` is the sink-rejection event the caller returns
+/// unchanged; `Ok` is the entry the caller pushes to `executed` before continuing.
+#[allow(clippy::result_large_err)]
+fn record_tool_outcome(
+    sink: &dyn AgentProcessEventSink,
+    mut tool_use: ToolUseBlock,
+    outcome: ToolExecutionOutcome,
+    image: Option<AgentImage>,
+) -> Result<ExecutedToolCall, GenerationProcessEvent> {
+    tool_use.status = if outcome.is_error {
+        "failed".to_owned()
+    } else {
+        "completed".to_owned()
+    };
+    tool_use.output = Some(Value::String(outcome.output.clone()));
+    if sink
+        .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
+        .is_err()
+    {
+        return Err(failed_retryable("Agent generation event handling failed."));
+    }
+    Ok((tool_use, outcome.output, outcome.is_error, image))
 }
 
 fn skill_tool_outcome(outcome: SkillToolDispatchOutcome) -> ToolExecutionOutcome {

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/interactive.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/interactive.rs
@@ -4,16 +4,17 @@ use super::super::memory_directory::is_within_memory_directory;
 use super::super::tools::ToolExecutionOutcome;
 use super::{failed_non_retryable, failed_retryable, PendingApprovals, APPROVAL_POLL_INTERVAL};
 use crate::contexts::agent_runtime::application::{
-    AgentProcessEventSink, GenerationProcessEvent, ToolApprovalDecision, ToolUseBlock,
-    ASK_USER_QUESTION_TOOL_NAME, EDIT_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME, FILE_TOOL_NAME,
-    FIND_DEFINITION_TOOL_NAME, FIND_REFERENCES_TOOL_NAME, GET_DIAGNOSTICS_TOOL_NAME,
-    GET_HOVER_TOOL_NAME, GLOB_TOOL_NAME, GREP_TOOL_NAME, LIST_SKILLS_TOOL_NAME,
-    LOAD_SKILL_TOOL_NAME, MAX_PLAN_CHARS, MAX_QUESTION_CHARS, MAX_QUESTION_OPTIONS,
-    MAX_QUESTION_OPTION_CHARS, MCP_TOOL_NAME_PREFIX, MIN_QUESTION_OPTIONS, NOTEBOOK_TOOL_NAME,
-    READ_SKILL_RESOURCE_TOOL_NAME, RECALL_TOOL_NAME, REMEMBER_TOOL_NAME, SEARCH_CODE_TOOL_NAME,
-    SHELL_KILL_TOOL_NAME, SHELL_OUTPUT_TOOL_NAME, SHELL_TOOL_NAME, TODO_WRITE_TOOL_NAME,
+    AgentPermissionPort, AgentProcessEventSink, GenerationProcessEvent, GenerationProcessRequest,
+    ToolApprovalDecision, ToolUseBlock, ASK_USER_QUESTION_TOOL_NAME, EDIT_TOOL_NAME,
+    EXIT_PLAN_MODE_TOOL_NAME, FILE_TOOL_NAME, FIND_DEFINITION_TOOL_NAME, FIND_REFERENCES_TOOL_NAME,
+    GET_DIAGNOSTICS_TOOL_NAME, GET_HOVER_TOOL_NAME, GLOB_TOOL_NAME, GREP_TOOL_NAME,
+    LIST_SKILLS_TOOL_NAME, LOAD_SKILL_TOOL_NAME, MAX_PLAN_CHARS, MAX_QUESTION_CHARS,
+    MAX_QUESTION_OPTIONS, MAX_QUESTION_OPTION_CHARS, MCP_TOOL_NAME_PREFIX, MIN_QUESTION_OPTIONS,
+    NOTEBOOK_TOOL_NAME, READ_SKILL_RESOURCE_TOOL_NAME, RECALL_TOOL_NAME, REMEMBER_TOOL_NAME,
+    SEARCH_CODE_TOOL_NAME, SHELL_KILL_TOOL_NAME, SHELL_OUTPUT_TOOL_NAME, SHELL_TOOL_NAME,
+    TODO_WRITE_TOOL_NAME,
 };
-use crate::contexts::permissions::domain::{Action, Resource};
+use crate::contexts::permissions::domain::{Action, Effect, Resource};
 use serde_json::Value;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, RecvTimeoutError};
@@ -308,6 +309,127 @@ pub(super) enum ApprovalOutcome {
     /// an answer was delivered to a call that asked for permission, so that path treats it as a
     /// denial rather than silently proceeding (`add-agent-user-question` D1).
     Answered(String),
+}
+
+/// The three things the permission gate can conclude about one tool call.
+// `large_enum_variant`: `Failed` carries the terminal `GenerationProcessEvent` unboxed, on purpose.
+// Boxing it would be the only heap allocation this decomposition introduced, on the one path that
+// exists to hand the event back to the caller unchanged.
+#[allow(clippy::large_enum_variant)]
+pub(super) enum ToolAuthorization {
+    Allowed,
+    /// The call was refused with this text as its output. The caller records it as a failed call
+    /// and moves to the next one — a refusal is data the model sees, not an error.
+    Denied(String),
+    /// The whole generation ends with this event.
+    Failed(GenerationProcessEvent),
+}
+
+/// Evaluates one tool call against policy and, when policy asks, blocks until the user decides.
+///
+/// The `tool_use` block is mutated in place on the paths that emit it — `awaiting_approval` while
+/// the prompt is open, then `failed` with the denial text — so the caller's copy carries the same
+/// state it did when this ran inline.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn authorize_tool_call(
+    tool_use: &mut ToolUseBlock,
+    input: &Value,
+    agent_id: &str,
+    request: &GenerationProcessRequest,
+    permissions: &dyn AgentPermissionPort,
+    pending_approvals: &PendingApprovals,
+    sink: &dyn AgentProcessEventSink,
+    cancelled: &AtomicBool,
+) -> ToolAuthorization {
+    let (permission_action, permission_resource) =
+        permission_action_and_resource(&tool_use.name, input);
+    let project_key = request.session.folder.as_deref().unwrap_or("");
+    let effect = permissions.evaluate(
+        agent_id,
+        permission_action.clone(),
+        permission_resource.clone(),
+        &request.session.id,
+        &request.operation_id,
+        project_key,
+    );
+    match effect {
+        Effect::Allow => {}
+        Effect::Deny => {
+            let denial = "Denied by policy.".to_string();
+            tool_use.status = "failed".to_string();
+            tool_use.output = Some(Value::String(denial.clone()));
+            if sink
+                .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
+                .is_err()
+            {
+                return ToolAuthorization::Failed(failed_retryable(
+                    "Agent generation event handling failed.",
+                ));
+            }
+            return ToolAuthorization::Denied(denial);
+        }
+        Effect::Ask => {
+            tool_use.status = "awaiting_approval".to_string();
+            if sink
+                .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
+                .is_err()
+            {
+                return ToolAuthorization::Failed(failed_retryable(
+                    "Agent generation event handling failed.",
+                ));
+            }
+            if let Err(error) = permissions.create_pending_approval(
+                agent_id,
+                permission_action,
+                permission_resource,
+                &request.session.id,
+                &request.operation_id,
+                &tool_use.id,
+                project_key,
+            ) {
+                return ToolAuthorization::Failed(failed_non_retryable(&error.to_string()));
+            }
+            match await_approval(&tool_use.id, cancelled, pending_approvals) {
+                ApprovalOutcome::Approved => {}
+                ApprovalOutcome::Denied => {
+                    let denial = "Denied by user.".to_string();
+                    tool_use.status = "failed".to_string();
+                    tool_use.output = Some(Value::String(denial.clone()));
+                    if sink
+                        .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
+                        .is_err()
+                    {
+                        return ToolAuthorization::Failed(failed_retryable(
+                            "Agent generation event handling failed.",
+                        ));
+                    }
+                    return ToolAuthorization::Denied(denial);
+                }
+                ApprovalOutcome::Cancelled => {
+                    return ToolAuthorization::Failed(failed_non_retryable(
+                        "Generation was cancelled while a tool call was awaiting approval.",
+                    ));
+                }
+                // An answer delivered to a call that asked for permission means the two
+                // resolutions were crossed; fail closed rather than treat it as consent.
+                ApprovalOutcome::Answered(_) => {
+                    let denial = "Denied by user.".to_string();
+                    tool_use.status = "failed".to_string();
+                    tool_use.output = Some(Value::String(denial.clone()));
+                    if sink
+                        .handle(GenerationProcessEvent::ToolUse(tool_use.clone()))
+                        .is_err()
+                    {
+                        return ToolAuthorization::Failed(failed_retryable(
+                            "Agent generation event handling failed.",
+                        ));
+                    }
+                    return ToolAuthorization::Denied(denial);
+                }
+            }
+        }
+    }
+    ToolAuthorization::Allowed
 }
 
 pub(super) fn await_approval(

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/invocation.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/invocation.rs
@@ -1,17 +1,21 @@
 //! Accounting lifecycle for one API invocation, and the per-provider wire format it drives.
 
 use super::super::context_projection::PreparedContextProjection;
+use super::super::model_context_catalog;
 use super::super::tool_call_accumulator::ToolCallAccumulator;
 use super::super::{anthropic_provider, openai_compatible_provider};
-use super::compaction::value_character_count;
+use super::compaction::{should_compact, turns_character_count, value_character_count};
 use super::generation::GenerationOptions;
 use super::ExecutedToolCall;
 use crate::contexts::agent_runtime::application::{
     AgentClockPort, AgentLog, AgentLogLevel, AgentLoggingPort, AgentMessage, ApiProviderConfig,
-    GenerationProcessEvent, GenerationProcessFailure, GenerationProcessRequest,
-    ReportedUsageTotals, ToolDefinition, INTERFACE_FORMAT_OPENAI_COMPATIBLE,
+    ContextAnalysisInput, ContextAnalysisService, GenerationProcessEvent, GenerationProcessFailure,
+    GenerationProcessRequest, ReportedUsageTotals, StoredEndpointProfileMetadata, ToolDefinition,
+    INTERFACE_FORMAT_OPENAI_COMPATIBLE,
 };
-use crate::contexts::agent_runtime::domain::{ContextSnapshot, SemanticClass};
+use crate::contexts::agent_runtime::domain::{
+    ContextCapacity, ContextSnapshot, SemanticClass, UsageAnchor,
+};
 use crate::contexts::sessions::api::{
     AccountingUnit, MeasurementKind, MeasurementQuality, NewModelInvocation, NewUsageObservation,
     SessionsApi, TokenDimensions, TokenOverlap, UsageInteractionKind, UsagePurpose, UsageStatus,
@@ -293,6 +297,48 @@ fn bounded_hash(value: &str) -> String {
         .iter()
         .map(|byte| format!("{byte:02x}"))
         .collect()
+}
+
+/// One round trip's measurement of its own request, analyzed before the send and handed to
+/// `record_context_snapshot` below. The model catalog supplies the capacity only when neither a
+/// frozen endpoint Profile nor stored Profile metadata did — an endpoint whose metadata says
+/// nothing about its window is left without one rather than given the catalog's guess.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn analyze_round_context(
+    body: &Value,
+    wire_format: &WireFormat,
+    provider_config: &ApiProviderConfig,
+    endpoint_capacity: Option<&ContextCapacity>,
+    endpoint_metadata: Option<&StoredEndpointProfileMetadata>,
+    request: &GenerationProcessRequest,
+    turns: &[Value],
+    request_sequence: u32,
+    usage_anchor: Option<&UsageAnchor>,
+) -> ContextSnapshot {
+    let projection = (wire_format.project_request_context)(body);
+    ContextAnalysisService::analyze(
+        ContextAnalysisInput {
+            provider_id: provider_config.source_provider_id.clone(),
+            model_id: provider_config.model_id.clone(),
+            request_fingerprint: projection.request_fingerprint,
+            characters: projection.characters,
+            components: projection.components,
+            rounds: projection.rounds,
+            token_estimate_complete: projection.token_estimate_complete,
+            capacity: endpoint_capacity.cloned().or_else(|| {
+                (endpoint_metadata.is_none() && request.endpoint_profile.is_none()).then(|| {
+                    model_context_catalog::resolve_capacity(
+                        provider_config.source_provider_id.as_deref(),
+                        &provider_config.model_id,
+                    )
+                })?
+            }),
+            active_character_compaction: should_compact(turns_character_count(turns)),
+            invocation_sequence: request_sequence,
+            overflow_count: projection.overflow_count,
+        },
+        usage_anchor,
+    )
 }
 
 pub(super) fn record_context_snapshot(

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/mod.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/mod.rs
@@ -1,4 +1,5 @@
 mod compaction;
+mod endpoint;
 mod execution;
 mod generation;
 mod interactive;

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/prompt.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/prompt.rs
@@ -1,18 +1,27 @@
 //! Tool catalog resolution, system prompt assembly, personalization, and memory sections.
 
 use super::super::memory_surfaced::{mark_surfaced, unsurfaced_candidates};
+use super::super::skill_tool_catalog_adapter::{
+    resolve_skill_tool_catalog, ResolvedSkillToolCatalog,
+};
 use super::super::tools::task_list_prompt_section;
 use super::{SKILL_AGGREGATE_CHARACTER_BUDGET, SKILL_PER_ITEM_CHARACTER_BUDGET};
 use crate::contexts::agent_runtime::application::{
-    ask_user_question_tool_definition, code_intelligence_tool_definitions, plan_mode_tool_catalog,
-    recall_tool_definition, search_code_tool_definition, tool_catalog, AgentClockPort,
-    AgentCoreInstructionsPort, AgentLog, AgentLogLevel, AgentLoggingPort, AgentMcpToolPort,
-    AgentMemory, AgentMemoryPort, AgentMemorySelectionPort, AgentPersonalizationPort,
-    AgentSkillPort, BoundSkillPrompt, GenerationProcessRequest, PersonalizationSettings,
-    ToolDefinition,
+    ask_user_question_tool_definition, code_intelligence_tool_definitions,
+    delegate_utility_skill_tool_definition, plan_mode_tool_catalog, recall_tool_definition,
+    search_code_tool_definition, tool_catalog, AgentClockPort, AgentCodeIntelligenceContext,
+    AgentCodeIntelligencePort, AgentCoreInstructionsPort, AgentLog, AgentLogLevel,
+    AgentLoggingPort, AgentMcpToolPort, AgentMemory, AgentMemoryPort, AgentMemorySelectionPort,
+    AgentPersonalizationPort, AgentRetrievalPort, AgentSkillPort, ApiProviderConfig,
+    BoundSkillPrompt, GenerationProcessRequest, NativeToolExecutionMode, NativeToolRegistry,
+    PersonalizationSettings, ToolDefinition, ToolEligibilityContext,
+    UtilityDelegationApplicationService,
 };
 use crate::contexts::skill_evolution_evidence::domain::{
     ObservedSkillRevision, SkillAssociationKind,
+};
+use crate::contexts::tooling::skill_tools::application::{
+    SkillToolBinding, SkillToolCatalogContext, SkillToolCatalogMode, SkillToolCatalogPort,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -78,6 +87,141 @@ pub(super) fn resolve_tool_catalog_with_code_intelligence(
         tools.push(ask_user_question_tool_definition());
     }
     tools
+}
+
+/// Everything the generation offers the model, assembled once before the round-trip loop: the
+/// reviewed catalog above, then the delegation tool, then the eligible native tools, then the
+/// endpoint Profile's capability veto. The three availability probes live here rather than in the
+/// caller because nothing outside this assembly reads them.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn resolve_generation_tool_catalog(
+    request: &GenerationProcessRequest,
+    mcp: &dyn AgentMcpToolPort,
+    logging: &dyn AgentLoggingPort,
+    clock: &dyn AgentClockPort,
+    retrieval: &dyn AgentRetrievalPort,
+    code_intelligence: &dyn AgentCodeIntelligencePort,
+    native_tools: &NativeToolRegistry,
+    utility_delegation: Option<&UtilityDelegationApplicationService>,
+    plan_mode: bool,
+) -> Vec<ToolDefinition> {
+    // Never blocks, never errors (`AgentRetrievalPort::is_configured`'s own contract) — safe to
+    // call unconditionally on every generation's catalog resolution, matching how `plan_mode`
+    // itself is derived at the call site.
+    let retrieval_available = retrieval.is_configured();
+    let code_search_available = request
+        .session
+        .folder
+        .as_deref()
+        .and_then(|folder| {
+            retrieval
+                .code_retrieval()
+                .map(|code| code.is_available(folder))
+        })
+        .unwrap_or(false);
+    let code_intelligence_context = request
+        .session
+        .folder
+        .as_deref()
+        .map(AgentCodeIntelligenceContext::from_session_workspace);
+    let code_intelligence_available = code_intelligence_context
+        .as_ref()
+        .is_some_and(|context| code_intelligence.is_available(context));
+    let mut tools = resolve_tool_catalog_with_code_intelligence(
+        request,
+        mcp,
+        logging,
+        clock,
+        plan_mode,
+        retrieval_available,
+        code_search_available,
+        code_intelligence_available,
+    );
+    if utility_delegation.is_some() && !plan_mode {
+        tools.push(delegate_utility_skill_tool_definition());
+    }
+    tools.extend(
+        native_tools.eligible_tool_definitions(&ToolEligibilityContext {
+            agent_id: request.agent.id.clone(),
+            session_id: request.session.id.clone(),
+            generation_id: request.operation_id.clone(),
+            canonical_workspace: request.session.folder.as_deref().map(Into::into),
+            execution_mode: if plan_mode {
+                NativeToolExecutionMode::Plan
+            } else {
+                NativeToolExecutionMode::Execute
+            },
+            readiness: native_tools.readiness_snapshot(),
+        }),
+    );
+    if request
+        .endpoint_profile
+        .as_ref()
+        .is_some_and(|profile| profile.tool_calling_capability != "supported")
+    {
+        tools.clear();
+    }
+    tools
+}
+
+/// The skill-tool half of the generation's catalog. `None` means the catalog rejected the request:
+/// that logs a warning and leaves the tools already resolved untouched, exactly as an MCP lookup
+/// failure does above, because skill tools are additive on top of an already-usable catalog.
+///
+/// The resolved lease, generation counter and key map are returned whole rather than unpacked here
+/// so the caller can keep them in the three bindings it already had. The lease is an `Arc` held for
+/// the rest of the generation, and moving the three into one value would reorder their drops.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn resolve_generation_skill_tools(
+    catalog: &dyn SkillToolCatalogPort,
+    request: &GenerationProcessRequest,
+    provider_config: &ApiProviderConfig,
+    observed_skill_revisions: &[ObservedSkillRevision],
+    existing_tools: &[ToolDefinition],
+    logging: &dyn AgentLoggingPort,
+    clock: &dyn AgentClockPort,
+    plan_mode: bool,
+) -> Option<ResolvedSkillToolCatalog> {
+    let loaded_roles = observed_skill_revisions
+        .iter()
+        .map(|observed| SkillToolBinding {
+            skill_id: observed.skill_id.clone(),
+            revision: observed.revision.clone(),
+        })
+        .collect::<Vec<_>>();
+    let context = SkillToolCatalogContext::RoleGeneration {
+        workspace_path: request.session.folder.clone(),
+        loaded_roles,
+        mode: if plan_mode {
+            SkillToolCatalogMode::Plan
+        } else {
+            SkillToolCatalogMode::Execute
+        },
+    };
+    let existing_names = existing_tools.iter().map(|tool| tool.name.clone());
+    match resolve_skill_tool_catalog(
+        catalog,
+        &context,
+        existing_names,
+        &provider_config.interface_format,
+    ) {
+        Ok(resolved) => Some(resolved),
+        Err(error) => {
+            let _ = logging.record(AgentLog {
+                level: AgentLogLevel::Warn,
+                category: "session.runtime.api.skill-tools".to_string(),
+                message: format!("Skill tool catalog rejected: {}", error.code()),
+                agent_id: Some(request.agent.id.clone()),
+                session_id: Some(request.session.id.clone()),
+                operation_id: Some(request.operation_id.clone()),
+                run_id: None,
+                trace_id: None,
+                span_id: None,
+                occurred_at: clock.now(),
+            });
+            None
+        }
+    }
 }
 
 /// Resolves the agent's bound, enabled Skills (`add-agent-skill-support`) and stored memories

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/tests.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/tests.rs
@@ -8161,3 +8161,385 @@ fn skill_tool_lifecycle_uses_existing_phases_and_redacted_terminal_summaries() {
         .and_then(|provenance| provenance.redacted_result_summary.as_deref());
     assert_eq!(summary, Some("completed"));
 }
+
+/// `CapturingSink` accepts every event, so the eight
+/// `failed_retryable("Agent generation event handling failed.")` exits inside
+/// `execute_with_code_intelligence` are unreachable from the rest of this file. This sink refuses
+/// exactly the events a test names and accepts the rest, which is what makes each of those exits
+/// individually addressable.
+struct RejectingSink {
+    reject: Box<dyn Fn(&GenerationProcessEvent) -> bool + Send + Sync>,
+}
+
+impl RejectingSink {
+    fn new(reject: impl Fn(&GenerationProcessEvent) -> bool + Send + Sync + 'static) -> Self {
+        Self {
+            reject: Box::new(reject),
+        }
+    }
+}
+
+impl AgentProcessEventSink for RejectingSink {
+    fn handle(&self, event: GenerationProcessEvent) -> Result<(), AgentRuntimeApplicationError> {
+        if (self.reject)(&event) {
+            return Err(AgentRuntimeApplicationError::Skill(
+                "sink rejected the event".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Pins the streaming loop's sink-failure exit. It is the one exit in that loop that deliberately
+/// does *not* finish the accounting invocation first, so it must stay distinguishable from the
+/// read-error and translate-failure exits beside it.
+#[test]
+fn a_rejected_token_event_fails_the_generation_retryably() {
+    let (address, _server) = http_fixture(
+        "200 OK",
+        sse_body(&[
+            r#"{"choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}"#,
+            "[DONE]",
+        ]),
+    );
+
+    let event = execute(
+        &sample_request("api"),
+        not_cancelled(),
+        &FakeCredentials {
+            value: Some("sk-test".to_string()),
+        },
+        &openai_compatible_config("test-model", Some(&address)),
+        &FakeHistory(FakeHistoryOutcome::Messages(Vec::new())),
+        &RejectingSink::new(|event| matches!(event, GenerationProcessEvent::Token(_))),
+        &no_pending_approvals(),
+        &NoopLogging,
+        &FixedClock,
+        &NoopSkills,
+        &crate::contexts::agent_runtime::infrastructure::NativeAgentCoreInstructionsAdapter,
+        &FakeMemories::default(),
+        &NoopMcp,
+        &FakePermissions::default_classification(),
+        &NoopRetrieval,
+        &NoopPersonalization,
+    );
+
+    let GenerationProcessEvent::Failed(failure) = event else {
+        panic!("a rejected token must fail the generation");
+    };
+    assert_eq!(failure.kind, GenerationProcessFailureKind::Retryable);
+    assert_eq!(
+        failure.diagnostic,
+        "Agent generation event handling failed."
+    );
+}
+
+/// Pins the sink-failure exit of the status/output/emit/push tail that every tool-dispatch branch
+/// ends with. Rejecting only the terminal `completed`/`failed` event lets the `running` event
+/// emitted before dispatch through, so the failure can only have come from the tail.
+#[test]
+fn a_rejected_completed_tool_use_event_fails_the_generation_retryably() {
+    let directory = crate::test_support::TempDirectory::new("execute-rejected-tool-outcome");
+    let (address, _server) = http_fixture(
+        "200 OK",
+        sse_body(&[
+            r#"{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"shell","arguments":"{\"command\": \"echo hi\"}"}}]},"finish_reason":null}]}"#,
+            "[DONE]",
+        ]),
+    );
+    let mut request = sample_request("api");
+    request.session.folder = Some(directory.path().to_string_lossy().to_string());
+
+    let event = execute(
+        &request,
+        not_cancelled(),
+        &FakeCredentials {
+            value: Some("sk-test".to_string()),
+        },
+        &openai_compatible_config("test-model", Some(&address)),
+        &FakeHistory(FakeHistoryOutcome::Messages(Vec::new())),
+        &RejectingSink::new(|event| {
+            matches!(
+                event,
+                GenerationProcessEvent::ToolUse(tool_use)
+                    if tool_use.status == "completed" || tool_use.status == "failed"
+            )
+        }),
+        &no_pending_approvals(),
+        &NoopLogging,
+        &FixedClock,
+        &NoopSkills,
+        &crate::contexts::agent_runtime::infrastructure::NativeAgentCoreInstructionsAdapter,
+        &FakeMemories::default(),
+        &NoopMcp,
+        &FakePermissions::with_override(Action::shell_exec(), Effect::Allow),
+        &NoopRetrieval,
+        &NoopPersonalization,
+    );
+
+    let GenerationProcessEvent::Failed(failure) = event else {
+        panic!("a rejected tool outcome must fail the generation");
+    };
+    assert_eq!(failure.kind, GenerationProcessFailureKind::Retryable);
+    assert_eq!(
+        failure.diagnostic,
+        "Agent generation event handling failed."
+    );
+}
+
+/// Pins the sink-failure exit inside the permission gate's `Ask` arm, which fires before
+/// `create_pending_approval` — so a rejected prompt must fail the generation rather than leave a
+/// pending approval nobody will ever answer.
+#[test]
+fn a_rejected_awaiting_approval_event_fails_the_generation_retryably() {
+    let (address, _server) = http_fixture(
+        "200 OK",
+        sse_body(&[
+            r#"{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"mcp__fixture-tools__search","arguments":"{}"}}]},"finish_reason":null}]}"#,
+            "[DONE]",
+        ]),
+    );
+    let mut request = sample_request("api");
+    request.session.folder = Some("fixture-project".to_string());
+    let pending_approvals = no_pending_approvals();
+
+    let event = execute(
+        &request,
+        not_cancelled(),
+        &FakeCredentials {
+            value: Some("sk-test".to_string()),
+        },
+        &openai_compatible_config("test-model", Some(&address)),
+        &FakeHistory(FakeHistoryOutcome::Messages(Vec::new())),
+        &RejectingSink::new(|event| {
+            matches!(
+                event,
+                GenerationProcessEvent::ToolUse(tool_use)
+                    if tool_use.status == "awaiting_approval"
+            )
+        }),
+        &pending_approvals,
+        &NoopLogging,
+        &FixedClock,
+        &NoopSkills,
+        &crate::contexts::agent_runtime::infrastructure::NativeAgentCoreInstructionsAdapter,
+        &FakeMemories::default(),
+        &NoopMcp,
+        &FakePermissions::default_classification(),
+        &NoopRetrieval,
+        &NoopPersonalization,
+    );
+
+    let GenerationProcessEvent::Failed(failure) = event else {
+        panic!("a rejected approval prompt must fail the generation");
+    };
+    assert_eq!(failure.kind, GenerationProcessFailureKind::Retryable);
+    assert_eq!(
+        failure.diagnostic,
+        "Agent generation event handling failed."
+    );
+    assert!(
+        pending_approvals.lock().expect("pending").is_empty(),
+        "a rejected prompt must not leave a pending approval behind"
+    );
+}
+
+/// `Effect::Deny` is the only permission outcome with no test: `default_classification` returns
+/// `Allow` or `Ask`, and every existing denial test drives `Ask` and answers it `Denied`. A policy
+/// denial takes a different arm, produces different text ("Denied by policy." rather than "Denied
+/// by user."), and must never show an approval prompt.
+#[test]
+fn a_policy_denied_tool_call_returns_denial_data_without_executing() {
+    let (address, server) = http_fixture_sequence(
+        "200 OK",
+        vec![
+            sse_body(&[
+                r#"{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"shell","arguments":"{\"command\": \"echo hi\"}"}}]},"finish_reason":null}]}"#,
+                "[DONE]",
+            ]),
+            sse_body(&["[DONE]"]),
+        ],
+    );
+    let sink = CapturingSink::default();
+
+    let event = execute(
+        &sample_request("api"),
+        not_cancelled(),
+        &FakeCredentials {
+            value: Some("sk-test".to_string()),
+        },
+        &openai_compatible_config("test-model", Some(&address)),
+        &FakeHistory(FakeHistoryOutcome::Messages(Vec::new())),
+        &sink,
+        &no_pending_approvals(),
+        &NoopLogging,
+        &FixedClock,
+        &NoopSkills,
+        &crate::contexts::agent_runtime::infrastructure::NativeAgentCoreInstructionsAdapter,
+        &FakeMemories::default(),
+        &NoopMcp,
+        &FakePermissions::with_override(Action::shell_exec(), Effect::Deny),
+        &NoopRetrieval,
+        &NoopPersonalization,
+    );
+
+    assert!(matches!(event, GenerationProcessEvent::Completed(None)));
+    let requests = server.join().expect("fixture server");
+    assert!(String::from_utf8_lossy(&requests[1]).contains("Denied by policy."));
+    let events = sink.events.lock().expect("events");
+    assert!(events.iter().any(|event| matches!(
+        event,
+        GenerationProcessEvent::ToolUse(tool_use)
+            if tool_use.status == "failed"
+                && tool_use.output == Some(Value::String("Denied by policy.".to_string()))
+    )));
+    assert!(
+        !events.iter().any(|event| matches!(
+            event,
+            GenerationProcessEvent::ToolUse(tool_use) if tool_use.status == "awaiting_approval"
+        )),
+        "a policy denial must never reach the approval prompt"
+    );
+}
+
+/// An answer delivered to a call that asked for *permission* means the two resolutions for the
+/// shared blocked-call channel were crossed. The gate fails closed and reports "Denied by user."
+/// rather than treating the answer as consent — untested until now, and the kind of thing a
+/// refactor of the approval arms could quietly turn into an approval.
+#[test]
+fn an_answer_delivered_to_an_approval_wait_is_treated_as_a_denial() {
+    let (address, server) = http_fixture_sequence(
+        "200 OK",
+        vec![
+            sse_body(&[
+                r#"{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"mcp__fixture-tools__search","arguments":"{}"}}]},"finish_reason":null}]}"#,
+                "[DONE]",
+            ]),
+            sse_body(&["[DONE]"]),
+        ],
+    );
+    let mut request = sample_request("api");
+    request.session.folder = Some("fixture-project".to_string());
+    let sink = CapturingSink::default();
+    let pending_approvals = no_pending_approvals();
+    let cancellation = not_cancelled();
+    let resolver = resolve_tool_call_once(
+        &pending_approvals,
+        "call_1",
+        ToolApprovalDecision::Answered("go ahead".to_string()),
+        cancellation.clone(),
+    );
+    let mcp = FakeMcp::new(
+        Ok(Vec::new()),
+        crate::contexts::agent_runtime::application::AgentToolCallOutcome {
+            output: "must not be called".to_string(),
+            is_error: false,
+        },
+    );
+
+    let event = execute(
+        &request,
+        cancellation,
+        &FakeCredentials {
+            value: Some("sk-test".to_string()),
+        },
+        &openai_compatible_config("test-model", Some(&address)),
+        &FakeHistory(FakeHistoryOutcome::Messages(Vec::new())),
+        &sink,
+        &pending_approvals,
+        &NoopLogging,
+        &FixedClock,
+        &NoopSkills,
+        &crate::contexts::agent_runtime::infrastructure::NativeAgentCoreInstructionsAdapter,
+        &FakeMemories::default(),
+        &mcp,
+        &FakePermissions::default_classification(),
+        &NoopRetrieval,
+        &NoopPersonalization,
+    );
+
+    resolver
+        .join()
+        .expect("approval resolver")
+        .expect("resolve tool call with an answer");
+    assert!(matches!(event, GenerationProcessEvent::Completed(None)));
+    assert!(
+        mcp.calls.lock().expect("calls").is_empty(),
+        "an answer must not be read as consent to run the call"
+    );
+    let requests = server.join().expect("fixture server");
+    assert!(String::from_utf8_lossy(&requests[1]).contains("Denied by user."));
+    let events = sink.events.lock().expect("events");
+    assert!(events.iter().any(|event| matches!(
+        event,
+        GenerationProcessEvent::ToolUse(tool_use)
+            if tool_use.status == "failed"
+                && tool_use.output == Some(Value::String("Denied by user.".to_string()))
+    )));
+}
+
+/// The suite's first `endpoint_profile: Some(..)` case. Everywhere else `sample_request` leaves it
+/// `None` and `FakeConfig` inherits `active_endpoint_profile_metadata`'s default `Ok(None)`, so
+/// the resolved context capacity is `None` in every other test and the request-context overflow
+/// guard is unreachable. Freezing a one-token window makes the guard the only possible outcome,
+/// and it is reachable only if the profile's window survives into the analyzed snapshot. The guard
+/// returns before any HTTP send, so no fixture server is needed; `FakeConfig::default()` carries
+/// no provider config, which also pins that the profile — not the stored config — supplied the
+/// model and base URL.
+#[test]
+fn an_endpoint_profile_context_window_smaller_than_the_request_fails_the_generation() {
+    let mut request = sample_request("api");
+    request.endpoint_profile = Some(
+        crate::contexts::agent_runtime::application::FrozenEndpointProfile {
+            profile_id: "profile-1".to_string(),
+            source_provider_id: None,
+            model_id: "test-model".to_string(),
+            interface_format: INTERFACE_FORMAT_OPENAI_COMPATIBLE.to_string(),
+            base_url: Some("http://127.0.0.1:1".to_string()),
+            authentication_mode: "required".to_string(),
+            timeout_ms: 1_000,
+            image_input_capability: "supported".to_string(),
+            tool_calling_capability: "supported".to_string(),
+            structured_output_capability: "supported".to_string(),
+            reasoning_field_capability: "supported".to_string(),
+            context_window_tokens: Some(1),
+            reserved_output_tokens: 0,
+            context_capacity_provenance: "test-fixture".to_string(),
+            routing_rule_id: None,
+            routing_reason: "test".to_string(),
+        },
+    );
+
+    let event = execute(
+        &request,
+        not_cancelled(),
+        &FakeCredentials {
+            value: Some("sk-test".to_string()),
+        },
+        &FakeConfig::default(),
+        &FakeHistory(FakeHistoryOutcome::Messages(Vec::new())),
+        &CapturingSink::default(),
+        &no_pending_approvals(),
+        &NoopLogging,
+        &FixedClock,
+        &NoopSkills,
+        &crate::contexts::agent_runtime::infrastructure::NativeAgentCoreInstructionsAdapter,
+        &FakeMemories::default(),
+        &NoopMcp,
+        &FakePermissions::default_classification(),
+        &NoopRetrieval,
+        &NoopPersonalization,
+    );
+
+    let GenerationProcessEvent::Failed(failure) = event else {
+        panic!("a one-token context window must fail the generation");
+    };
+    assert_eq!(failure.kind, GenerationProcessFailureKind::NonRetryable);
+    assert!(
+        failure
+            .diagnostic
+            .contains("exceeds the selected endpoint Profile context budget"),
+        "unexpected diagnostic: {}",
+        failure.diagnostic
+    );
+}

--- a/src-tauri/tests/architecture.rs
+++ b/src-tauri/tests/architecture.rs
@@ -2107,15 +2107,19 @@ struct SubtreeBudget {
 }
 
 const NATIVE_PATH_BUDGETS: &[PathBudget] = &[
-    // 978 of these lines are `execute_with_code_intelligence`, one function that
-    // `split-api-adapter-modules` moved without decomposing: finding seams in live tool-dispatch
-    // control flow is its own change with its own risk budget, not something to bury in a
-    // relocation. This entry retires when that function does.
+    // Lowered from 1,166 by `decompose-api-tool-use-loop`, which took six seams out of
+    // `execute_with_code_intelligence` and dropped it from 978 lines to 621. What is left is the
+    // tool-use loop itself plus the two helpers only it has — the SSE round and the tool-outcome
+    // tail. Four further seams were available on a line count and refused: the non-success HTTP
+    // handler (its recovery `continue` silently consumes a round trip), the per-tool-call dispatch
+    // chain (seven branches ending in `continue`, two mutating the image counter), the remaining
+    // setup bindings (no boundary, just position), and the two 27-line `maybe_compact_accounted`
+    // calls (no reduction, only indirection). See that change's design.md.
     PathBudget {
         path:
             "src-tauri/src/contexts/agent_runtime/infrastructure/api_process_adapter/execution.rs",
-        budget: 1_166,
-        owner: "split-api-adapter-modules",
+        budget: 955,
+        owner: "decompose-api-tool-use-loop",
     },
     // The other residual `split-api-adapter-modules` left above 1,000 lines: 43 native tool
     // implementations, the largest of which is `execute_tool_call_impl`'s 266-line dispatch.
@@ -2162,10 +2166,24 @@ const NATIVE_SUBTREE_BUDGETS: &[SubtreeBudget] = &[
     // No item body was duplicated or edited: the top-level item multiset is identical before and
     // after, 84 of the 138 moved items are byte-identical to their pre-split text, 52 differ only
     // by an added `pub(super)`, and the last 2 are the rustfmt rewraps above.
+    // Raised from 58,357 by `decompose-api-tool-use-loop`. Unlike the split that set the previous
+    // figure, this one is not a pure move, and the +648 says so:
+    //
+    // +382 is the six characterization tests and the `RejectingSink` they need, written against
+    // the un-split function so each seam had coverage before it was cut — `CapturingSink` never
+    // fails, `Effect::Deny` and `ApprovalOutcome::Answered(_)` had no test, and no test in the
+    // suite had ever set `endpoint_profile: Some(..)`. The diff on `tests.rs` is additions only.
+    //
+    // +266 is production, and none of it is a duplicated body: 132 lines of doc comments,
+    // `#[allow]` attributes and parameter lists across eleven new declarations; 17 lines of struct
+    // and enum bodies for the three result types the seams return; 16 for `endpoint.rs`'s module
+    // doc and import block; 7 net new `use` lines in the three existing modules that gained a
+    // helper; and 94 of caller-side `match`/destructure scaffolding at eight call sites, already
+    // net of the 40 lines saved by de-duplicating the five copies of the tool-outcome tail.
     SubtreeBudget {
         root: "src-tauri/src/contexts/agent_runtime/infrastructure",
-        budget: 58_357,
-        owner: "split-api-adapter-modules",
+        budget: 59_005,
+        owner: "decompose-api-tool-use-loop",
     },
     // Raised from 2,914 by `split-database-migrations`, which turned `migrations.rs` into a
     // directory module. The +51 is entirely per-file boilerplate: +29 module headers (the `mod`


### PR DESCRIPTION
Implements `decompose-api-tool-use-loop`, the residual #173 deliberately left alone: `execute_with_code_intelligence`, 978 lines in one function.

## Why this one needed a different safety argument

Every prior change in this stream proved itself by identity — same top-level item multiset, byte-identical bodies, byte-identical test-name lists. **That claim is unavailable here.** Cutting inside a function body changes control flow, so `design.md` states four admission rules instead, and a seam is only extracted if it satisfies all of them:

1. Every exit is a `return <expr>;` that leaves the whole function, rewritten as `Err(<the same expr>)` with a caller-side `Err(failure) => return failure`.
2. No loop-carried state crosses implicitly.
3. The fragment's text is otherwise unchanged.
4. **The behaviour has a named test before the cut**, not after.

One deliberate exception is called out in the design: `authorize_tool_call`'s three `continue` arms.

## Result

| | Before | After |
|---|---:|---:|
| `execute_with_code_intelligence` | 978 | **621** |
| `execution.rs` | 1,166 | **955** |

Six seams extracted: `resolve_endpoint` and `resolve_image_support` into a new `endpoint.rs`; `resolve_generation_tool_catalog` and `resolve_generation_skill_tools` into `prompt.rs`; `analyze_round_context` into `invocation.rs`; `authorize_tool_call` into `interactive.rs`; plus `stream_round` and `record_tool_outcome` staying in `execution.rs` — the latter replacing a tail duplicated at five call sites.

## Coverage holes found, and closed before any cut

Three, each closed with a characterization test confirmed green **against the un-split function** before extraction began:

- **`CapturingSink` is the suite's only event sink and never fails**, so all eight `failed_retryable("Agent generation event handling failed.")` exits were unreachable. Added a `RejectingSink` and three tests.
- **`Effect::Deny` and `ApprovalOutcome::Answered(_)` had no test** — every existing denial test drives `Ask` and answers `Denied`.
- **No test in the suite had ever set `endpoint_profile: Some(..)`**, so the resolved context capacity was `None` everywhere and the overflow guard was dead code as far as the suite was concerned.

That third one is worth pausing on: a seam was about to be extracted from a branch the test suite had never entered.

## Seams declined, with reasons

- **Non-success HTTP handler.** Its recovery is `turns.remove(0); continue;` *without* decrementing `round_trip`, so a context-recovery retry silently consumes one of the 25 permitted round trips. That coupling between `turns`, `context_recovery_attempted` and the round-trip budget is invisible from inside a helper.
- **The per-tool-call dispatch chain.** Seven branches all ending in `continue`, two mutating `images_in_request`, and branch order *is* the dispatch precedence. A helper would need `&mut images_in_request`, `&mut executed` and a variant per branch — the loop body with a signature bolted on.
- **Remaining setup bindings.** Five sequentially dependent bindings, each with its own early return, sharing no concept beyond "more setup". Extracting them produces a bag named after its position in the file.
- **The two 27-line `maybe_compact_accounted` calls.** They differ in `tool_assisted_session` and both take three `&mut` arguments. No reduction, only indirection.

621 with six honest seams is the reported outcome rather than a lower number with a behaviour change nobody notices until production.

## No test was edited

`git diff --numstat` on `tests.rs`: **382 additions, 0 deletions**, zero `-` lines. All 3,543 baseline test names are present in the after list **in identical order**; the difference is exactly the six new tests, 3,543 → 3,549.

If a test had needed editing to accommodate a split, that would have been a behaviour change; none did.

## Two asymmetries preserved verbatim — the thing to review

- `stream_round`'s two sink-failure exits still do **not** call `finish_api_invocation`, unlike the three beside them.
- `authorize_tool_call` leaves `executed.push` and `continue` in the caller.

Both were pre-existing and are reproduced exactly rather than tidied, because tidying them would be the behaviour change this change is built to avoid.

## Line budgets

`execution.rs` path budget lowered to **955**. The `agent_runtime/infrastructure` subtree rises 58,357 → **59,005**, itemised on the entry — most of it the 382 lines of new characterization tests.

## Four `#[allow]`s, and why not `Box`

`GenerationProcessEvent` is 440 bytes, so `clippy::result_large_err` fires on all three `Result<_, GenerationProcessEvent>` seams, and `clippy::large_enum_variant` on `ToolAuthorization`. Clippy suggests boxing; boxing would have been **the only heap allocation this change introduces**, on paths whose entire job is handing an event back unchanged. `result_large_err` is already the house convention here — `ask_user_question`, `request_plan_exit` and `execute_registered_native_tool` all carry it.

## Verification

| Command | Result |
|---|---|
| `cargo test --manifest-path src-tauri/Cargo.toml` | 3,534 passed / 0 failed / 15 ignored, across all 7 test binaries |
| `cargo clippy --all-targets -- -D warnings` | pass |
| `cargo fmt -- --check`, `cargo check` | pass |
| `npm run architecture:check` | pass, 41/41 |
| `npm run lint:ci`, `npm run build`, `npm run test` | pass, 1,301 vitest tests, no frontend file touched |
| `openspec validate --strict` | pass, specs 138/138 |
| `npm run docs:check` | pass |

Nothing from #170 flaked; no rerun was needed.

## Two disclosures from the implementer

- Two text changes fall outside "exit rewrite plus rename", both recorded in `design.md`: a comment saying `plan_mode` is "derived just above" now says "at the call site", because it became a parameter and the original sentence would be false; and the five tool-outcome tails were not quite identical — four used `"failed".to_owned()`, the fifth `"failed".to_string()`. The helper uses `to_owned()`.
- The commit message on `54dde445` says "Five characterization tests"; there are six. The artifacts were corrected, the message body was not, since rewriting history was judged riskier than the error. Flagged because this change's premise is verifiable claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
