### PR TITLE
Extract chat, memory, and lifecycle state, web-agent-client to 822 lines

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,10 +66,10 @@ export default tseslint.config(
   // 禁止新增条目;文件降到 300 行以下后删除该条目,由全局 max-lines 接管。
   // 子树聚合预算在 scripts/architecture/ 里,防止"拆分"退化成复制粘贴。
   ...[
-    ["src/services/web-agent-client.ts", 1877],
+    ["src/services/web-agent-client.ts", 1608],
     ["src/services/tauri-agent-client.ts", 1213],
     ["src/types/agent.ts", 702],
-    ["src/services/agent-service.ts", 364],
+    ["src/services/agent-service.ts", 346],
     ["src/main-layout/main-layout.tsx", 528],
     ["src/contracts/agent.ts", 504],
     ["src/settings/pages/sdk-page.tsx", 396],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,10 +66,10 @@ export default tseslint.config(
   // 禁止新增条目;文件降到 300 行以下后删除该条目,由全局 max-lines 接管。
   // 子树聚合预算在 scripts/architecture/ 里,防止"拆分"退化成复制粘贴。
   ...[
-    ["src/services/web-agent-client.ts", 1608],
+    ["src/services/web-agent-client.ts", 1514],
     ["src/services/tauri-agent-client.ts", 1213],
     ["src/types/agent.ts", 702],
-    ["src/services/agent-service.ts", 346],
+    ["src/services/agent-service.ts", 342],
     ["src/main-layout/main-layout.tsx", 528],
     ["src/contracts/agent.ts", 504],
     ["src/settings/pages/sdk-page.tsx", 396],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,10 +66,10 @@ export default tseslint.config(
   // 禁止新增条目;文件降到 300 行以下后删除该条目,由全局 max-lines 接管。
   // 子树聚合预算在 scripts/architecture/ 里,防止"拆分"退化成复制粘贴。
   ...[
-    ["src/services/web-agent-client.ts", 1105],
+    ["src/services/web-agent-client.ts", 822],
     ["src/services/tauri-agent-client.ts", 1213],
     ["src/types/agent.ts", 702],
-    ["src/services/agent-service.ts", 320],
+    ["src/services/agent-service.ts", 308],
     ["src/main-layout/main-layout.tsx", 528],
     ["src/contracts/agent.ts", 504],
     ["src/settings/pages/sdk-page.tsx", 396],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,10 +66,10 @@ export default tseslint.config(
   // 禁止新增条目;文件降到 300 行以下后删除该条目,由全局 max-lines 接管。
   // 子树聚合预算在 scripts/architecture/ 里,防止"拆分"退化成复制粘贴。
   ...[
-    ["src/services/web-agent-client.ts", 1332],
+    ["src/services/web-agent-client.ts", 1105],
     ["src/services/tauri-agent-client.ts", 1213],
     ["src/types/agent.ts", 702],
-    ["src/services/agent-service.ts", 338],
+    ["src/services/agent-service.ts", 320],
     ["src/main-layout/main-layout.tsx", 528],
     ["src/contracts/agent.ts", 504],
     ["src/settings/pages/sdk-page.tsx", 396],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,10 +66,10 @@ export default tseslint.config(
   // 禁止新增条目;文件降到 300 行以下后删除该条目,由全局 max-lines 接管。
   // 子树聚合预算在 scripts/architecture/ 里,防止"拆分"退化成复制粘贴。
   ...[
-    ["src/services/web-agent-client.ts", 1514],
+    ["src/services/web-agent-client.ts", 1332],
     ["src/services/tauri-agent-client.ts", 1213],
     ["src/types/agent.ts", 702],
-    ["src/services/agent-service.ts", 342],
+    ["src/services/agent-service.ts", 338],
     ["src/main-layout/main-layout.tsx", 528],
     ["src/contracts/agent.ts", 504],
     ["src/settings/pages/sdk-page.tsx", 396],

--- a/openspec/changes/extract-web-client-chat-state/.openspec.yaml
+++ b/openspec/changes/extract-web-client-chat-state/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-19
+skip_specs: true

--- a/openspec/changes/extract-web-client-chat-state/design.md
+++ b/openspec/changes/extract-web-client-chat-state/design.md
@@ -1,0 +1,76 @@
+## Context
+
+See proposal.md — Why for the re-measurement and for where `extract-web-client-state-modules`'s numbers needed correcting.
+
+Four properties of the post-#175 file determine how the residual can be cut:
+
+- **8 mutable module-level bindings remain**, and they are one component: `nextMessageId`, `recoveryReportsBySession`, `messagesBySession`, `subscribersBySession`, `activeStreams` (declared together at the top of the file), `memoryChatConfigs`, `webAgentMemories`, `nextAgentMemoryId`. 20 of the 39 inline methods touch at least one; the other 19 touch none and are already free.
+- **The chat core is the only fusing set.** Removing `{messagesBySession, subscribersBySession, activeStreams, nextMessageId}` splits the component into `{webAgentMemories, nextAgentMemoryId}` and `{memoryChatConfigs, recoveryReportsBySession}`. Removing any other candidate on its own leaves one component. Two methods do the fusing: `sendMessage` joins memories to chat, `deleteSession` joins chat configs and recovery to chat.
+- **Five exported helpers are inside the component**, not just object methods. `resolveWebMockToolApproval` is imported by `web-permissions-client.ts`; the four `*ForTest` seams are imported by tests. Their implementations move with their state; `web-agent-client.ts` re-exports them so no importer changes.
+- **The write path is already helper-shaped.** `getSessionMessages`, `setSessionMessages`, `upsertMessage`, `emitChatEvent`, `applyStreamEvent`, `publishChatEvent`, `cancelActiveStream`, `createMessageId` are the accessor set for the chat core; they just live in the same file as the bindings today. The same holds for `createAgentMemory` / `simulateMemoryIndexInjection` over the memory pool and `readChatConfigs` / `writeChatConfigs` over `memoryChatConfigs`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Relocate the last 8 shared bindings into state modules that own them and expose accessors, so no context is blocked by state ownership any more.
+- Extract every context the chat seam unblocks, keeping each intermediate step compiling and green so the work is resumable at a group boundary.
+- Leave the observable surface — signatures, return shapes, mock data, ordering, timing — untouched.
+
+**Non-Goals:**
+
+- Decomposing `sendMessage`. See the decision below: its body is 529 lines, and splitting it is a rewrite, not a move.
+- Touching any React component, the Tauri client, or Rust.
+- Reaching a specific line count.
+
+## Decisions
+
+### A state module owns bindings and exports behaviour; it never exports a binding
+
+Unchanged from both prior stages, and the reason this change exists rather than a one-line `export let`. An exported `let` is copied into the importing module's binding at import time under some bundler and interop configurations, so a reassignment in the owner is invisible to the importer and the mock world silently forks — one UI panel showing stale data while another shows fresh. An exported function reads the live binding on every call, so it cannot fork.
+
+### Chat state moves first, because it is the only cut that changes the graph
+
+The measured consequence, not a preference. Memories, recovery and chat configs each look independently extractable by inspection, and each is not: with only that binding relocated, union-find still returns one component, because `deleteSession` and `sendMessage` reach across. With the chat core relocated, the other three are free simultaneously. So group order is chat state, then the contexts it unblocks — the reverse of the order the deferral note lists them in.
+
+### `sendMessage` stays in the composition root
+
+`sendMessage` is 529 physical lines. `max-lines` is a hard ESLint rule at 300 for all production TypeScript, the technical-debt list in `eslint.config.js` is explicitly closed to new entries, and `web-agent-client.ts` already has an entry. So moving `sendMessage` into a new `web-chat-client.ts` would either break the build or require adding a forbidden exemption.
+
+Making it fit means splitting its body — hoisting the simulation blocks (compaction, memory extraction, memory injection, skills, approval, question, plan exit, grep, remember, MCP, rich blocks) into scheduling helpers that take a shared context. That is a rewrite of a method whose entire observable contract is the ordering and the exact `setTimeout` delays of about fifteen interleaved blocks, in a change whose stated guarantee is that method bodies move verbatim. It is a legitimate follow-up — `decompose-api-tool-use-loop` did exactly this for the API adapter's 978-line loop — but it is a different change with a different risk profile, and folding it in here would make the "moved verbatim" claim untrue for the one method where it matters most.
+
+So `sendMessage` stays where it is and reaches chat, memory, run and session state through the accessors this change creates. Its state is no longer file-local, so it stops being a blocker for anything else even though it does not move.
+
+*Alternative rejected — move `sendMessage` with an exemption-list entry*: forbidden by AGENTS.md, and it would convert a hard rule into a negotiable one for every later file.
+
+### Accessors are the narrowest set the call sites actually need
+
+Every accessor pair costs lines a direct read/write did not, and the `[ARCH-FE-004]` subtree budget is the check on that. So the accessor set is derived from the call sites: `nextMessageId` gets only `createWebMessageId()` because every use was `web-message-${nextMessageId++}`; `messagesBySession` gets `getWebSessionMessages` / `setWebSessionMessages` / `deleteWebSessionMessages` / `listWebSessionMessageBuckets` because those are the four shapes the call sites use, and no more.
+
+### The seam split across two owners collapses back to one
+
+`resetWebLoopsForTest` was left in the composition root by the previous stage, calling `clearWebLoopTimersAndSubscribers()` and `clearWebLoopStateForTest()` around a `messagesBySession.delete` loop, because the loop module could not reach chat state without a binding export. With `deleteWebSessionMessages(sessionId)` available, the whole function moves into `web-loop-state.ts` in its original single-step form and the two half-steps stop being exported. Ordering is preserved because the moved function keeps the same statement order.
+
+### `this.` call sites survive spread, but the extracted method must say so
+
+Unchanged from both prior stages: a moved method that uses `this` declares an explicit `this: AgentService` parameter. Rewriting `this.x()` into a direct import is not equivalent — it would bypass any later override in the composition root. None of the 39 remaining methods uses `this` today, which is checked rather than assumed.
+
+### Exported test seams keep their current import path
+
+`resetWebAgentMemoriesForTest`, `resetWebLoopsForTest`, `seedWebRecoverySessionForTest`, `resetWebRecoverySessionsForTest`, `seedWebImSessionForTest`, `resolveWebMockToolApproval`, `WEB_MOCK_QUESTION_TRIGGER`, `WEB_MOCK_PLAN_EXIT_TRIGGER` are imported from `web-agent-client` by tests and by other modules. When their implementation moves, `web-agent-client.ts` re-exports them, exactly as both prior stages did. No test file is edited.
+
+### Verify each step against the type checker and the contract test, not by reading
+
+`webAgentClient` is annotated `: AgentService`, and `[ARCH-FE-003]` fails the build if the annotation goes missing. Any method dropped, renamed or given a different signature is a `tsc --noEmit` error, and `contract-conformance.test.ts` covers the surface besides.
+
+## Risks / Trade-offs
+
+- **An accessor changes semantics by accident** — e.g. returning a copy where the original returned the live array, so a caller's in-place mutation stops taking effect. This is a live risk here: `saveMessageFeedback` mutates a `ChatMessage` object in place through the array it gets back from `getSessionMessages`. Control: accessors return exactly what the previous expression returned, and the feedback path keeps reading through an accessor that hands back the live array.
+- **Stream teardown ordering changes.** `cancelActiveStream` clears timeouts, deletes the stream, then publishes `cancelled`, which re-enters `applyStreamEvent` and deletes again. Moving it must preserve that re-entrancy. Control: the function moves whole, with its callers unchanged.
+- **The accessor layer inflates the aggregate.** Control: the `[ARCH-FE-004]` subtree budget. A per-module fixed cost plus a bounded accessor set is the expected shape; anything materially larger means a method was rewritten.
+- **A method is silently dropped** → `webAgentClient: AgentService` makes it a compile error.
+- **Mock behavior drifts during a move** → `web-agent-client.test.ts`, the adapter-parity suites, and `contract-conformance.test.ts` run at every group boundary, and `npx playwright test` drives the browser-mode UI this adapter backs.
+
+## Migration Plan
+
+No deployment step. Each extraction group is an independently revertable commit that leaves `tsc --noEmit`, `npm run test` and `npm run contracts:check` green, so the work can stop at any group boundary without leaving the tree half-migrated.

--- a/openspec/changes/extract-web-client-chat-state/proposal.md
+++ b/openspec/changes/extract-web-client-chat-state/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+`extract-web-client-state-modules` took `src/services/web-agent-client.ts` from 3,861 to 1,877 lines by moving 77 methods into 23 `web-*` modules, breaking the 99-method hub that `split-web-agent-client` could not cross. It stopped at a residual it recorded as "a 20-method component over 8 bindings", deferring three contexts — chat and messaging, memories, and session lifecycle plus recovery — to a follow-up, and it was explicit that the stop was for review size, not for safety: no context required exporting a mutable binding.
+
+Every stage in this chain has found the previous stage's analysis partly wrong, so this one re-derived the map from the TypeScript AST before planning a cut: union-find over module-level mutable bindings, `let` and in-place-mutated `const` containers alike, with the transitive closure taken through the file's top-level helpers.
+
+**The headline numbers hold.** 8 mutable bindings, 39 inline methods, 20 of them touching at least one binding, 19 fully disjoint. The binding names match the deferral note exactly.
+
+Two things need correcting, and both change the plan:
+
+- **The component is 25 units, not 20.** Five exported top-level helpers are in it alongside the 20 methods — `seedWebRecoverySessionForTest`, `resetWebRecoverySessionsForTest`, `resolveWebMockToolApproval`, `resetWebAgentMemoriesForTest`, `resetWebLoopsForTest`. Counting only object methods understates the cut, because those helpers also need a home and they also fuse bindings. `resetWebRecoverySessionsForTest` alone fuses recovery to chat, so recovery cannot be freed by handling `deleteSession`.
+- **Only one binding set fuses the component, and it is the chat core.** Re-running union-find with each candidate removed: relocating memories alone, recovery alone, or chat configs alone leaves one component intact every time. Relocating `messagesBySession` / `subscribersBySession` / `activeStreams` / `nextMessageId` splits it into exactly two — `{webAgentMemories, nextAgentMemoryId}` and `{memoryChatConfigs, recoveryReportsBySession}`. Chat state is not merely the largest context, it is the only load-bearing one, so it has to move first rather than last.
+
+The deferral note also frames memories as "3 methods over `webAgentMemories` / `nextAgentMemoryId`". Three methods move, but **five** call sites read the pool: `deleteApiAgent` counts memories for its delete-blocking check and `sendMessage` both writes and indexes it. Those two stay behind and need accessors, which is a state module's job, not a client module's.
+
+## What Changes
+
+- Add state modules that **own** the last 8 shared bindings and expose behaviour, never the binding: a chat-state module for `messagesBySession` / `subscribersBySession` / `activeStreams` / `nextMessageId`, a memory-state module for `webAgentMemories` / `nextAgentMemoryId`, a recovery-state module for `recoveryReportsBySession`, and a chat-config-state module for `memoryChatConfigs`.
+- Extract the contexts the chat seam unblocks into `web-*` client modules composed by spread, following the interface-plus-spread convention the two prior stages established.
+- Collapse the one seam `extract-web-client-state-modules` had to split: `resetWebLoopsForTest` clears loop state *and* `messagesBySession`, so it currently lives in the composition root calling `clearWebLoopTimersAndSubscribers()` and `clearWebLoopStateForTest()` around the message cleanup. Once chat state is behind accessors it returns to a single function in the loop state module, and the two half-steps stop being exported.
+- Continue ratcheting the `web-agent-client.ts` per-file budget in `eslint.config.js` down after each group, and remove the entry if the file reaches 300 lines.
+- **No UI change and no behavior change.** No React component is touched, no Rust is touched, `tauri-agent-client.ts` stays byte-identical. Every method keeps its signature, return shape, mock data, ordering, and timing.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None. This is a pure code-organization refactor of one adapter's internals, continuing the lane `split-web-agent-client` opened and `extract-web-client-state-modules` advanced. The `frontend-runtime-architecture` requirements "Mechanically enforced runtime adapter parity" and "Honest Web/mock behavior" describe behavior this change deliberately preserves. The change sets `skip_specs: true`.
+
+## Impact
+
+- `src/services/web-agent-client.ts` — shrinks further toward a composition root.
+- `src/services/web-*-state.ts` — new state modules owning the previously file-local mutable bindings, exporting accessors only.
+- `src/services/web-*-client.ts` — new context modules joining the 55 the two prior stages added.
+- `src/services/web-loop-state.ts` — `resetWebLoopsForTest` returns whole; `clearWebLoopTimersAndSubscribers` and `clearWebLoopStateForTest` stop being exported.
+- `src/services/*-service.ts` — narrow interfaces whose signatures **move** out of `agent-service.ts`, which `AgentService` then extends.
+- `eslint.config.js` — the `web-agent-client.ts` and `agent-service.ts` per-file budgets drop.
+- `scripts/architecture/frontend-rules.mjs` — the `src/services` subtree budget of 19,087 continues to bind. Extraction moves code within the subtree, so the aggregate is neutral apart from per-module boilerplate and the accessor pairs a state module must add where a direct read/write used to suffice; a material rise means code was duplicated rather than moved and the budget failing is the correct outcome.
+- `src/contracts/contract-conformance.test.ts` — must keep passing unchanged; it is the evidence the surface did not move.
+- No Rust file is touched. No Tauri command, SQLite schema, or native behavior is affected.

--- a/openspec/changes/extract-web-client-chat-state/tasks.md
+++ b/openspec/changes/extract-web-client-chat-state/tasks.md
@@ -1,0 +1,41 @@
+## 1. Re-measure the residual before building on it
+
+- [ ] 1.1 Rebuild the state-ownership map from the TypeScript AST — union-find over module-level mutable bindings, `let` and in-place-mutated `const` containers alike, with the transitive closure taken through the file's top-level helpers — and record where `extract-web-client-state-modules`'s numbers need correcting
+- [ ] 1.2 Confirm the binding inventory and the method partition against the deferral note
+- [ ] 1.3 Identify the minimal binding set whose relocation breaks the component, and confirm by re-running union-find with each candidate removed rather than by inspection
+- [ ] 1.4 Enumerate the remaining `this.` call sites and note whether caller and callee land in the same group
+
+## 2. Extract the chat-state module that fuses the residual
+
+- [ ] 2.1 Create the chat-state module owning `messagesBySession`, `subscribersBySession`, `activeStreams` and `nextMessageId`, exporting accessors only, and move the message/stream write path with them
+- [ ] 2.2 Confirm no state module exports a mutable binding, and that the accessor set matches what the call sites need rather than exposing the binding shape
+- [ ] 2.3 Collapse `resetWebLoopsForTest` back into `web-loop-state.ts` and stop exporting the two half-steps the previous stage needed
+- [ ] 2.4 `tsc --noEmit`, `npm run contracts:check` and `npm run test` pass before starting the next group
+
+## 3. Extract the contexts the chat seam unblocks
+
+- [ ] 3.1 Chat and messaging: the message, feedback, subscription and generation-control methods
+- [ ] 3.2 Memories: the memory-state module and the three memory methods, leaving the two foreign readers on accessors
+- [ ] 3.3 Session recovery: the recovery-state module, the recovery trio, and the two exported recovery seams
+- [ ] 3.4 Chat configs: the chat-config-state module and the two session chat-config methods
+- [ ] 3.5 Session lifecycle and queries: `createSession`, `deleteSession`, `switchSession`, `archiveSession` and the rest, plus the session query and runner surface
+- [ ] 3.6 Each group: a narrow interface whose signatures **move** out of `agent-service.ts`, methods moved verbatim, a single spread in the composition root, and `this: AgentService` on any method that uses `this`
+- [ ] 3.7 After each group: `tsc --noEmit`, `npm run contracts:check` and `npm run test` pass before the next group starts
+- [ ] 3.8 Lower the `web-agent-client.ts` budget in `eslint.config.js` after each group so the ratchet tracks the work
+- [ ] 3.9 Record any context that could not be cut without exporting a binding, with the reason, rather than exporting the binding
+
+## 4. Prove the surface did not move
+
+- [ ] 4.1 `webAgentClient` is still annotated `: AgentService` and `tsc --noEmit` passes
+- [ ] 4.2 `npm run contracts:check` passes with no edit to `contract-conformance.test.ts`
+- [ ] 4.3 `npm run test` passes with an unchanged total test count and no test file edited
+- [ ] 4.4 No React component, `.tsx` file, or Rust file appears in the diff
+- [ ] 4.5 `src/services/tauri-agent-client.ts` is byte-identical
+
+## 5. Budgets and verification
+
+- [ ] 5.1 Confirm the `src/services` subtree aggregate rose only by per-module boilerplate plus the bounded accessor set; trace any material rise rather than absorbing it into the budget
+- [ ] 5.2 Set the final `web-agent-client.ts` and `agent-service.ts` budgets to the measured values, or remove the `web-agent-client.ts` entry if the file reached 300 lines
+- [ ] 5.3 `npm run lint:ci`, `npm run build` and `npm run architecture:check` pass
+- [ ] 5.4 `npx playwright test` passes, since the Web/mock adapter backs the browser-mode UI these specs drive
+- [ ] 5.5 `openspec validate extract-web-client-chat-state --strict` and `openspec validate --specs --strict` pass

--- a/openspec/changes/extract-web-client-chat-state/tasks.md
+++ b/openspec/changes/extract-web-client-chat-state/tasks.md
@@ -1,41 +1,74 @@
 ## 1. Re-measure the residual before building on it
 
-- [ ] 1.1 Rebuild the state-ownership map from the TypeScript AST — union-find over module-level mutable bindings, `let` and in-place-mutated `const` containers alike, with the transitive closure taken through the file's top-level helpers — and record where `extract-web-client-state-modules`'s numbers need correcting
-- [ ] 1.2 Confirm the binding inventory and the method partition against the deferral note
-- [ ] 1.3 Identify the minimal binding set whose relocation breaks the component, and confirm by re-running union-find with each candidate removed rather than by inspection
-- [ ] 1.4 Enumerate the remaining `this.` call sites and note whether caller and callee land in the same group
+- [x] 1.1 Rebuild the state-ownership map from the TypeScript AST — union-find over module-level mutable bindings, `let` and in-place-mutated `const` containers alike, with the transitive closure taken through the file's top-level helpers — and record where `extract-web-client-state-modules`'s numbers need correcting
+  - The headline numbers hold: **8 bindings, 39 inline methods, 20 touching at least one binding, 19 fully disjoint**, and the binding names match the deferral note exactly.
+  - **Correction: the component is 25 units, not 20.** Five exported top-level helpers sit in it alongside the 20 methods — `seedWebRecoverySessionForTest`, `resetWebRecoverySessionsForTest`, `resolveWebMockToolApproval`, `resetWebAgentMemoriesForTest`, `resetWebLoopsForTest`. Counting only object methods understates the cut, because those helpers also need a home and they also fuse bindings; `resetWebRecoverySessionsForTest` fuses recovery to chat on its own, so recovery could not have been freed by handling `deleteSession` alone.
+  - **Correction: memories is three methods to move but five call sites.** `deleteApiAgent` counts the pool for its delete-blocking check and `sendMessage` both writes and indexes it. Both stay behind and needed accessors.
+- [x] 1.2 Confirm the binding inventory and the method partition against the deferral note
+  - `nextMessageId`, `recoveryReportsBySession`, `messagesBySession`, `subscribersBySession`, `activeStreams`, `memoryChatConfigs`, `webAgentMemories`, `nextAgentMemoryId` — 4 `let` and 4 in-place-mutated `const` containers. Confirmed by AST, not by reading.
+- [x] 1.3 Identify the minimal binding set whose relocation breaks the component, and confirm by re-running union-find with each candidate removed rather than by inspection
+  - **The chat core is the only fusing set.** Re-running union-find with memories alone removed, with recovery alone removed, and with chat configs alone removed each leaves **one** component. Removing `messagesBySession` / `subscribersBySession` / `activeStreams` / `nextMessageId` splits it into exactly two: `{webAgentMemories, nextAgentMemoryId}` and `{memoryChatConfigs, recoveryReportsBySession}`. Measured before any code moved.
+  - The two fusing methods are `sendMessage` (memories to chat) and `deleteSession` (chat configs and recovery to chat).
+- [x] 1.4 Enumerate the remaining `this.` call sites and note whether caller and callee land in the same group
+  - **None.** No inline method used `this`, so no moved method needed a `this: AgentService` parameter and no `this.x()` was rewritten into an import. Checked against the AST rather than assumed.
 
 ## 2. Extract the chat-state module that fuses the residual
 
-- [ ] 2.1 Create the chat-state module owning `messagesBySession`, `subscribersBySession`, `activeStreams` and `nextMessageId`, exporting accessors only, and move the message/stream write path with them
-- [ ] 2.2 Confirm no state module exports a mutable binding, and that the accessor set matches what the call sites need rather than exposing the binding shape
-- [ ] 2.3 Collapse `resetWebLoopsForTest` back into `web-loop-state.ts` and stop exporting the two half-steps the previous stage needed
-- [ ] 2.4 `tsc --noEmit`, `npm run contracts:check` and `npm run test` pass before starting the next group
+- [x] 2.1 Create the chat-state module owning `messagesBySession`, `subscribersBySession`, `activeStreams` and `nextMessageId`, exporting accessors only, and move the message/stream write path with them
+  - `src/services/web-chat-state.ts`, 173 lines. It also takes the write path — `upsertMessage`, `applyStreamEvent`, `finishWebGeneration` stay private; `createWebMessageId`, `getWebSessionMessages`, `setWebSessionMessages`, `deleteWebSessionMessages`, `listWebSessionMessageBuckets`, `emitWebChatEvent`, `publishWebChatEvent`, `cancelWebActiveStream`, `hasWebActiveStream`, `setWebActiveStream`, `deleteWebActiveStream`, `subscribeWebChatEvents` and `deleteWebChatSubscribers` are the exported surface.
+- [x] 2.2 Confirm no state module exports a mutable binding, and that the accessor set matches what the call sites need rather than exposing the binding shape
+  - `grep -nE "^export (let|var) "` over `src/services` is empty, and none of the four new state modules exports a container either.
+  - The accessor set was derived from the call sites: `nextMessageId` gets only `createWebMessageId()` because every use was `web-message-${nextMessageId++}`; `listWebSessionMessageBuckets()` exists because `saveMessageFeedback` addresses a message by id across every session's bucket. `getWebSessionMessages` returns the live array because the previous expression did, which `saveMessageFeedback` depends on — it mutates the `ChatMessage` in place.
+- [x] 2.3 Collapse `resetWebLoopsForTest` back into `web-loop-state.ts` and stop exporting the two half-steps the previous stage needed
+  - Back to one function with its original statement order. `clearWebLoopTimersAndSubscribers` and `clearWebLoopStateForTest` are gone, and `snapshotWebLoopRoleSessionIds` is now private since its only caller is in the same module.
+- [x] 2.4 `tsc --noEmit`, `npm run contracts:check` and `npm run test` pass before starting the next group
 
 ## 3. Extract the contexts the chat seam unblocks
 
-- [ ] 3.1 Chat and messaging: the message, feedback, subscription and generation-control methods
-- [ ] 3.2 Memories: the memory-state module and the three memory methods, leaving the two foreign readers on accessors
-- [ ] 3.3 Session recovery: the recovery-state module, the recovery trio, and the two exported recovery seams
-- [ ] 3.4 Chat configs: the chat-config-state module and the two session chat-config methods
-- [ ] 3.5 Session lifecycle and queries: `createSession`, `deleteSession`, `switchSession`, `archiveSession` and the rest, plus the session query and runner surface
-- [ ] 3.6 Each group: a narrow interface whose signatures **move** out of `agent-service.ts`, methods moved verbatim, a single spread in the composition root, and `this: AgentService` on any method that uses `this`
-- [ ] 3.7 After each group: `tsc --noEmit`, `npm run contracts:check` and `npm run test` pass before the next group starts
-- [ ] 3.8 Lower the `web-agent-client.ts` budget in `eslint.config.js` after each group so the ratchet tracks the work
-- [ ] 3.9 Record any context that could not be cut without exporting a binding, with the reason, rather than exporting the binding
+- [x] 3.1 Chat and messaging: the message, feedback, subscription and generation-control methods
+  - 6 methods into `web-chat-client.ts` (162) over `chat-messaging-service.ts` (29), with `resolveWebMockToolApproval`, `resolveSimulatedQuestion`, `resolveSimulatedPlanExit` and the two mock triggers.
+  - `sendMessage` is **not** extracted — see 3.9.
+- [x] 3.2 Memories: the memory-state module and the three memory methods, leaving the two foreign readers on accessors
+  - 3 methods into `web-agent-memory-client.ts` (20) over `agent-memory-service.ts` (9), with the pool and its derivation/disambiguation/injection helpers in `web-agent-memory-state.ts` (106).
+- [x] 3.3 Session recovery: the recovery-state module, the recovery trio, and the two exported recovery seams
+  - 3 methods into `web-session-recovery-client.ts` (53) over `session-recovery-service.ts` (14), with `web-session-recovery-state.ts` (132) taking the reports map, the report factory, the summary read and both `*ForTest` seams.
+- [x] 3.4 Chat configs: the chat-config-state module and the two session chat-config methods
+  - 2 methods into `web-session-chat-config-client.ts` (30) over `session-chat-config-service.ts` (6), with `web-chat-config-state.ts` (27). The state module exposes `deleteWebSessionChatConfig` so the delete path is a named step rather than a raw copy-delete-write at the call site.
+- [x] 3.5 Session lifecycle and queries: `createSession`, `deleteSession`, `switchSession`, `archiveSession` and the rest, plus the session query and runner surface
+  - 11 read-side methods into `web-session-query-client.ts` (172) over `session-query-service.ts` (26), with `searchText`, `sessionSearchMatches` and `serializeWebSessionExport` as private helpers.
+  - 8 lifecycle methods into `web-session-lifecycle-client.ts` (218) and 2 seat methods into `web-session-seat-client.ts` (87), both over `session-lifecycle-service.ts` (18). Split in two because one module holding all ten would have crossed the 300-line rule.
+  - The runner descriptor helpers went to `web-agent-runner.ts` (80) because `sendMessage` and `listAgentRunners` now live in different modules.
+- [x] 3.6 Each group: a narrow interface whose signatures **move** out of `agent-service.ts`, methods moved verbatim, a single spread in the composition root, and `this: AgentService` on any method that uses `this`
+  - Six new interface files carrying seven interfaces; `AgentService` extends 6 more of them and `agent-service.ts` fell 364 → 308. No signature is duplicated. 18 new modules in total, 35 of the 39 inline methods moved.
+  - Method bodies moved verbatim apart from two mechanical substitutions, each behaviour-identical: a direct binding read became the accessor call, and the file-local `tr(key)` shim became `i18n.t(key)`, which is what it forwarded to and what the other extracted modules already use. `tr` is gone with its last caller.
+- [x] 3.7 After each group: `tsc --noEmit`, `npm run contracts:check` and `npm run test` pass before the next group starts
+  - Run at all five group boundaries. `npm run test` reported 286 files / 1301 tests passing each time — the same totals as the pre-change baseline, with no test file edited.
+- [x] 3.8 Lower the `web-agent-client.ts` budget in `eslint.config.js` after each group so the ratchet tracks the work
+  - 1,877 → 1,608 → 1,514 → 1,332 → 1,105 → 822. `agent-service.ts` ratcheted alongside, 364 → 346 → 342 → 338 → 320 → 308.
+- [x] 3.9 Record any context that could not be cut without exporting a binding, with the reason, rather than exporting the binding
+  - **No context required a binding export.** Every one of the 8 bindings is now behind accessors, the composition root holds **zero** mutable module-level bindings, and all 4 methods still inline are fully disjoint.
+  - **`sendMessage` is not extracted, and the reason is the 300-line rule, not the binding rule.** Its body is 529 physical lines. `max-lines` is a hard ESLint rule at 300 for all production TypeScript and the technical-debt list in `eslint.config.js` is closed to new entries, so a `web-chat-client.ts` holding it would either break the build or need a forbidden exemption. Making it fit means hoisting its roughly fifteen interleaved `setTimeout` simulation blocks into scheduling helpers — a rewrite of the one method whose entire observable contract is that ordering and those exact delays, in a change whose stated guarantee is that bodies move verbatim. It is a legitimate follow-up of the shape `decompose-api-tool-use-loop` took for the API adapter's 978-line loop. Its state is no longer file-local, so it blocks nothing.
+  - `deleteApiAgent`, `applyCliConfigProfile` and `subscribeSessionEvents` also stay: each is a one-method context whose own module would be more boilerplate than body, and none touches shared state any more.
 
 ## 4. Prove the surface did not move
 
-- [ ] 4.1 `webAgentClient` is still annotated `: AgentService` and `tsc --noEmit` passes
-- [ ] 4.2 `npm run contracts:check` passes with no edit to `contract-conformance.test.ts`
-- [ ] 4.3 `npm run test` passes with an unchanged total test count and no test file edited
-- [ ] 4.4 No React component, `.tsx` file, or Rust file appears in the diff
-- [ ] 4.5 `src/services/tauri-agent-client.ts` is byte-identical
+- [x] 4.1 `webAgentClient` is still annotated `: AgentService` and `tsc --noEmit` passes
+  - `[ARCH-FE-003]` in `scripts/architecture/frontend-rules.mjs` also fails the build if either adapter loses the annotation; `npm run architecture:check` passes.
+- [x] 4.2 `npm run contracts:check` passes with no edit to `contract-conformance.test.ts`
+- [x] 4.3 `npm run test` passes with an unchanged total test count and no test file edited
+  - 286 files / 1301 tests, before and after. The moved seams — `resetWebLoopsForTest`, `resetWebAgentMemoriesForTest`, `seedWebRecoverySessionForTest`, `resetWebRecoverySessionsForTest`, `resolveWebMockToolApproval`, `WEB_MOCK_QUESTION_TRIGGER`, `WEB_MOCK_PLAN_EXIT_TRIGGER` — are re-exported from `web-agent-client.ts`, so no importer changed.
+- [x] 4.4 No React component, `.tsx` file, or Rust file appears in the diff
+  - The diff is `eslint.config.js`, `scripts/architecture/frontend-rules.mjs`, this change's artifacts, and `src/services/*.ts`.
+- [x] 4.5 `src/services/tauri-agent-client.ts` is byte-identical
+  - `git diff --stat` against the branch point is empty for that path.
 
 ## 5. Budgets and verification
 
-- [ ] 5.1 Confirm the `src/services` subtree aggregate rose only by per-module boilerplate plus the bounded accessor set; trace any material rise rather than absorbing it into the budget
-- [ ] 5.2 Set the final `web-agent-client.ts` and `agent-service.ts` budgets to the measured values, or remove the `web-agent-client.ts` entry if the file reached 300 lines
-- [ ] 5.3 `npm run lint:ci`, `npm run build` and `npm run architecture:check` pass
-- [ ] 5.4 `npx playwright test` passes, since the Web/mock adapter backs the browser-mode UI these specs drive
-- [ ] 5.5 `openspec validate extract-web-client-chat-state --strict` and `openspec validate --specs --strict` pass
+- [x] 5.1 Confirm the `src/services` subtree aggregate rose only by per-module boilerplate plus the bounded accessor set; trace any material rise rather than absorbing it into the budget
+  - 19,087 → 19,347, **+260 over 18 new files, about 14 lines each** — inside the 11-25 band the two prior stages measured, and below this change's own chat group because only the chat core needed a new accessor layer at all. The other three state modules mostly moved helpers that were already accessor-shaped.
+  - It is not duplication. Method bodies moved verbatim, and the narrow interfaces' signatures moved out of `AgentService` rather than being copied, which is why `agent-service.ts` fell 364 → 308.
+- [x] 5.2 Set the final `web-agent-client.ts` and `agent-service.ts` budgets to the measured values, or remove the `web-agent-client.ts` entry if the file reached 300 lines
+  - Set to 822 and 308. Both entries stay: `sendMessage` alone is 529 lines.
+- [x] 5.3 `npm run lint:ci`, `npm run build` and `npm run architecture:check` pass
+- [x] 5.4 `npx playwright test` passes, since the Web/mock adapter backs the browser-mode UI these specs drive
+- [x] 5.5 `openspec validate extract-web-client-chat-state --strict` and `openspec validate --specs --strict` pass

--- a/scripts/architecture/frontend-rules.mjs
+++ b/scripts/architecture/frontend-rules.mjs
@@ -17,7 +17,7 @@ import { architectureDiagnostic, architectureSummaryDiagnostic, RULES } from "./
 // 代价还是那两项——每个新模块的固定开销,加上一层按调用点裁剪的访问器。这一轮多出来的访问器都在
 // chat 一侧:原先直接 `activeStreams.has/set/delete`、`messagesBySession.delete`,现在各是一个函数。
 const SUBTREE_LINE_BUDGETS = Object.freeze([
-  { root: "src/services", budget: 19286, owner: "extract-web-client-chat-state" },
+  { root: "src/services", budget: 19319, owner: "extract-web-client-chat-state" },
 ]);
 
 const STATE_PACKAGES = new Set([

--- a/scripts/architecture/frontend-rules.mjs
+++ b/scripts/architecture/frontend-rules.mjs
@@ -13,8 +13,11 @@ import { architectureDiagnostic, architectureSummaryDiagnostic, RULES } from "./
 // 绑定搬进 state 模块时,除了上面那份固定开销,还多出一层访问器——原先一句直接读写(`sessions`、
 // `activeSessionId`、`webSkills`)现在是一对 `list*`/`replace*` 函数。这层是"禁止导出可变绑定"
 // 这条规则的代价,不是重复代码:访问器集合按调用点裁剪,每个都有本模块之外的调用者。
+// 上调理由(extract-web-client-chat-state):同上一条,把最后 8 个共享可变绑定搬进 state 模块的
+// 代价还是那两项——每个新模块的固定开销,加上一层按调用点裁剪的访问器。这一轮多出来的访问器都在
+// chat 一侧:原先直接 `activeStreams.has/set/delete`、`messagesBySession.delete`,现在各是一个函数。
 const SUBTREE_LINE_BUDGETS = Object.freeze([
-  { root: "src/services", budget: 19087, owner: "extract-web-client-state-modules" },
+  { root: "src/services", budget: 19164, owner: "extract-web-client-chat-state" },
 ]);
 
 const STATE_PACKAGES = new Set([

--- a/scripts/architecture/frontend-rules.mjs
+++ b/scripts/architecture/frontend-rules.mjs
@@ -17,7 +17,7 @@ import { architectureDiagnostic, architectureSummaryDiagnostic, RULES } from "./
 // 代价还是那两项——每个新模块的固定开销,加上一层按调用点裁剪的访问器。这一轮多出来的访问器都在
 // chat 一侧:原先直接 `activeStreams.has/set/delete`、`messagesBySession.delete`,现在各是一个函数。
 const SUBTREE_LINE_BUDGETS = Object.freeze([
-  { root: "src/services", budget: 19203, owner: "extract-web-client-chat-state" },
+  { root: "src/services", budget: 19286, owner: "extract-web-client-chat-state" },
 ]);
 
 const STATE_PACKAGES = new Set([

--- a/scripts/architecture/frontend-rules.mjs
+++ b/scripts/architecture/frontend-rules.mjs
@@ -17,7 +17,7 @@ import { architectureDiagnostic, architectureSummaryDiagnostic, RULES } from "./
 // 代价还是那两项——每个新模块的固定开销,加上一层按调用点裁剪的访问器。这一轮多出来的访问器都在
 // chat 一侧:原先直接 `activeStreams.has/set/delete`、`messagesBySession.delete`,现在各是一个函数。
 const SUBTREE_LINE_BUDGETS = Object.freeze([
-  { root: "src/services", budget: 19319, owner: "extract-web-client-chat-state" },
+  { root: "src/services", budget: 19347, owner: "extract-web-client-chat-state" },
 ]);
 
 const STATE_PACKAGES = new Set([

--- a/scripts/architecture/frontend-rules.mjs
+++ b/scripts/architecture/frontend-rules.mjs
@@ -17,7 +17,7 @@ import { architectureDiagnostic, architectureSummaryDiagnostic, RULES } from "./
 // 代价还是那两项——每个新模块的固定开销,加上一层按调用点裁剪的访问器。这一轮多出来的访问器都在
 // chat 一侧:原先直接 `activeStreams.has/set/delete`、`messagesBySession.delete`,现在各是一个函数。
 const SUBTREE_LINE_BUDGETS = Object.freeze([
-  { root: "src/services", budget: 19164, owner: "extract-web-client-chat-state" },
+  { root: "src/services", budget: 19203, owner: "extract-web-client-chat-state" },
 ]);
 
 const STATE_PACKAGES = new Set([

--- a/src/services/agent-memory-service.ts
+++ b/src/services/agent-memory-service.ts
@@ -1,0 +1,9 @@
+import type { AgentMemory } from "../types/agent";
+
+export interface AgentMemoryService {
+  /** `add-cli-memory-support`: memories are a single host-level pool shared by every agent — no
+   * `agentId` scoping on read or bulk-reset, `AgentMemory.agentId` remains as provenance only. */
+  listAllMemories(): Promise<AgentMemory[]>;
+  deleteAgentMemory(memoryId: string): Promise<void>;
+  resetAllMemories(): Promise<void>;
+}

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -1,5 +1,4 @@
 import type {
-  AgentMemory,
   ExportSessionInput,
   CreateSessionInput,
   InteractionMode,
@@ -152,6 +151,7 @@ import type {
 import type { BuiltinToolService } from "./builtin-tool-service";
 import type { CliConfigService, CliParameterService, CliToolService } from "./cli-service";
 import type { AgentRegistryService } from "./agent-registry-service";
+import type { AgentMemoryService } from "./agent-memory-service";
 import type { ChatMessagingService } from "./chat-messaging-service";
 import type { CodeIndexService } from "./code-index-service";
 import type { SkillEvidenceService, SkillGovernanceService } from "./skill-governance-service";
@@ -184,6 +184,7 @@ export interface AgentService extends
   AgentTerminalService,
   UsageStatisticsService,
   MissionControlService,
+  AgentMemoryService,
   ChatMessagingService,
   LoopService {
   getDesktopUpdateSnapshot(): Promise<DesktopUpdateSnapshot>;
@@ -204,11 +205,6 @@ export interface AgentService extends
   startCodeReviewAction(reviewId: string, action: ReviewAction): Promise<{ operationId: string }>;
   listAgentRunners(sessionId: string, agentId: string): Promise<AgentRunnerDescriptor[]>;
   deleteApiAgent(agentId: string): Promise<void>;
-  /** `add-cli-memory-support`: memories are a single host-level pool shared by every agent — no
-   * `agentId` scoping on read or bulk-reset, `AgentMemory.agentId` remains as provenance only. */
-  listAllMemories(): Promise<AgentMemory[]>;
-  deleteAgentMemory(memoryId: string): Promise<void>;
-  resetAllMemories(): Promise<void>;
   getLspConfiguration(): Promise<LspConfiguration>;
   saveLspConfiguration(configuration: LspConfiguration): Promise<void>;
   listLspWorkspaceTrust(): Promise<LspWorkspaceTrust[]>;

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -1,15 +1,7 @@
 import type {
-  ExportSessionInput,
   CreateSessionInput,
-  InteractionMode,
-  LaunchResult,
   UpdateSessionSeatsInput,
   Session,
-  SessionDetails,
-  SessionExportResult,
-  SessionSearchInput,
-  SessionSearchResult,
-  WorkflowState,
 } from "../types/agent";
 import type { ChatMessage, SendMessageInput } from "../types/chat";
 
@@ -99,7 +91,6 @@ export interface PurgeEvidenceOutcome {
 }
 import type { OperationTask } from "../types/operation";
 import type { DesktopUpdateSnapshot, UpdateOperationReceipt, UpdatePreferences } from "../types/desktop-update";
-import type { AgentRunnerDescriptor } from "../types/agent-runner";
 import type { EvaluationService } from "./evaluation-service";
 import type {
   ApiAgentService,
@@ -154,6 +145,7 @@ import type { AgentRegistryService } from "./agent-registry-service";
 import type { AgentMemoryService } from "./agent-memory-service";
 import type { ChatMessagingService } from "./chat-messaging-service";
 import type { SessionChatConfigService } from "./session-chat-config-service";
+import type { SessionQueryService } from "./session-query-service";
 import type { SessionRecoveryService } from "./session-recovery-service";
 import type { CodeIndexService } from "./code-index-service";
 import type { SkillEvidenceService, SkillGovernanceService } from "./skill-governance-service";
@@ -189,6 +181,7 @@ export interface AgentService extends
   AgentMemoryService,
   ChatMessagingService,
   SessionChatConfigService,
+  SessionQueryService,
   SessionRecoveryService,
   LoopService {
   getDesktopUpdateSnapshot(): Promise<DesktopUpdateSnapshot>;
@@ -207,7 +200,6 @@ export interface AgentService extends
   revertCodeReviewChange(input: RevertReviewChangeInput): Promise<ReviewRevertReceipt>;
   sendCodeReviewFeedback(reviewId: string, acknowledgeStale: boolean): Promise<{ messageId: string }>;
   startCodeReviewAction(reviewId: string, action: ReviewAction): Promise<{ operationId: string }>;
-  listAgentRunners(sessionId: string, agentId: string): Promise<AgentRunnerDescriptor[]>;
   deleteApiAgent(agentId: string): Promise<void>;
   getLspConfiguration(): Promise<LspConfiguration>;
   saveLspConfiguration(configuration: LspConfiguration): Promise<void>;
@@ -217,15 +209,6 @@ export interface AgentService extends
   testLspServer(language: LspLanguageId): Promise<LspServerTestResult>;
   getLspServerStatus(): Promise<LspServerStatus[]>;
   applyCliConfigProfile(input: ApplyCliConfigProfileInput): Promise<CliConfigApplyResult>;
-  getWorkflowState(): Promise<WorkflowState>;
-  selectAgent(agentId: string, interactionMode: InteractionMode): Promise<WorkflowState>;
-  launchActiveWorkflow(): Promise<LaunchResult>;
-  getSessionDetails(): Promise<SessionDetails>;
-  listSessions(): Promise<Session[]>;
-  listArchivedSessions(): Promise<Session[]>;
-  searchSessions(input: SessionSearchInput): Promise<SessionSearchResult[]>;
-  getSession(sessionId: string): Promise<Session>;
-  getActiveSession(): Promise<Session | null>;
   createSession(input: CreateSessionInput): Promise<OperationTask>;
   deleteSession(sessionId: string): Promise<void>;
   switchSession(sessionId: string): Promise<Session>;
@@ -236,7 +219,6 @@ export interface AgentService extends
   unpinSession(sessionId: string): Promise<Session>;
   archiveSession(sessionId: string): Promise<Session>;
   unarchiveSession(sessionId: string): Promise<Session>;
-  exportSession(input: ExportSessionInput): Promise<SessionExportResult>;
   sendMessage(input: SendMessageInput): Promise<ChatMessage>;
   listSessionDirectory(sessionId: string, path?: string): Promise<DirectoryListing>;
   readSessionFile(sessionId: string, path: string): Promise<FileContent>;

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -12,7 +12,7 @@ import type {
   SessionSearchResult,
   WorkflowState,
 } from "../types/agent";
-import type { ChatConfig, ChatMessage, ChatStreamEvent, MessageFeedback, SaveMessageFeedbackInput, SendMessageInput } from "../types/chat";
+import type { ChatConfig, ChatMessage, SendMessageInput } from "../types/chat";
 
 export interface EvidenceQueryInput {
   workspace?: string;
@@ -152,6 +152,7 @@ import type {
 import type { BuiltinToolService } from "./builtin-tool-service";
 import type { CliConfigService, CliParameterService, CliToolService } from "./cli-service";
 import type { AgentRegistryService } from "./agent-registry-service";
+import type { ChatMessagingService } from "./chat-messaging-service";
 import type { CodeIndexService } from "./code-index-service";
 import type { SkillEvidenceService, SkillGovernanceService } from "./skill-governance-service";
 import type { ContextQualityService, ScheduledTaskService } from "./scheduled-task-service";
@@ -183,6 +184,7 @@ export interface AgentService extends
   AgentTerminalService,
   UsageStatisticsService,
   MissionControlService,
+  ChatMessagingService,
   LoopService {
   getDesktopUpdateSnapshot(): Promise<DesktopUpdateSnapshot>;
   getDesktopUpdatePreferences(): Promise<UpdatePreferences>;
@@ -244,26 +246,6 @@ export interface AgentService extends
   unarchiveSession(sessionId: string): Promise<Session>;
   exportSession(input: ExportSessionInput): Promise<SessionExportResult>;
   sendMessage(input: SendMessageInput): Promise<ChatMessage>;
-  listMessages(input: { sessionId: string; limit?: number; beforeId?: string }): Promise<ChatMessage[]>;
-  saveMessageFeedback(input: SaveMessageFeedbackInput): Promise<MessageFeedback>;
-  /**
-   * Delivers the user's answer to a tool call waiting in `awaiting_input`. Resolves to whether a
-   * live waiter received it, so the caller can distinguish a delivered answer from one aimed at a
-   * question that already resolved or whose generation is gone.
-   */
-  resolveAgentQuestion(sessionId: string, callId: string, answer: string): Promise<boolean>;
-  /**
-   * Delivers the user's decision on an `exit_plan_mode` call waiting in `awaiting_input`. Resolves
-   * to whether a live waiter received it — the caller must only change the session's execution
-   * mode when it did, so an approval aimed at a dead generation cannot leave a session
-   * write-capable on the strength of a decision the model never saw.
-   */
-  resolvePlanExit(sessionId: string, callId: string, approved: boolean): Promise<boolean>;
-  stopGeneration(sessionId: string): Promise<void>;
-  subscribeMessageEvents(
-    sessionId: string,
-    handler: (event: ChatStreamEvent) => void,
-  ): Promise<() => void>;
   listSessionDirectory(sessionId: string, path?: string): Promise<DirectoryListing>;
   readSessionFile(sessionId: string, path: string): Promise<FileContent>;
   listSessionDocuments(sessionId: string): Promise<DocumentListing>;

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -1,8 +1,4 @@
-import type {
-  CreateSessionInput,
-  UpdateSessionSeatsInput,
-  Session,
-} from "../types/agent";
+import type { Session } from "../types/agent";
 import type { ChatMessage, SendMessageInput } from "../types/chat";
 
 export interface EvidenceQueryInput {
@@ -89,7 +85,6 @@ export interface PurgeEvidenceOutcome {
   deletedSeeds: number;
   deletedFeedback: number;
 }
-import type { OperationTask } from "../types/operation";
 import type { DesktopUpdateSnapshot, UpdateOperationReceipt, UpdatePreferences } from "../types/desktop-update";
 import type { EvaluationService } from "./evaluation-service";
 import type {
@@ -145,6 +140,7 @@ import type { AgentRegistryService } from "./agent-registry-service";
 import type { AgentMemoryService } from "./agent-memory-service";
 import type { ChatMessagingService } from "./chat-messaging-service";
 import type { SessionChatConfigService } from "./session-chat-config-service";
+import type { SessionLifecycleService, SessionSeatService } from "./session-lifecycle-service";
 import type { SessionQueryService } from "./session-query-service";
 import type { SessionRecoveryService } from "./session-recovery-service";
 import type { CodeIndexService } from "./code-index-service";
@@ -181,8 +177,10 @@ export interface AgentService extends
   AgentMemoryService,
   ChatMessagingService,
   SessionChatConfigService,
+  SessionLifecycleService,
   SessionQueryService,
   SessionRecoveryService,
+  SessionSeatService,
   LoopService {
   getDesktopUpdateSnapshot(): Promise<DesktopUpdateSnapshot>;
   getDesktopUpdatePreferences(): Promise<UpdatePreferences>;
@@ -209,16 +207,6 @@ export interface AgentService extends
   testLspServer(language: LspLanguageId): Promise<LspServerTestResult>;
   getLspServerStatus(): Promise<LspServerStatus[]>;
   applyCliConfigProfile(input: ApplyCliConfigProfileInput): Promise<CliConfigApplyResult>;
-  createSession(input: CreateSessionInput): Promise<OperationTask>;
-  deleteSession(sessionId: string): Promise<void>;
-  switchSession(sessionId: string): Promise<Session>;
-  renameSession(sessionId: string, title: string): Promise<Session>;
-  updateSessionSeats(input: UpdateSessionSeatsInput): Promise<Session>;
-  rebindRemoteSessionSshConnection(sessionId: string, connectionId: string): Promise<Session>;
-  pinSession(sessionId: string): Promise<Session>;
-  unpinSession(sessionId: string): Promise<Session>;
-  archiveSession(sessionId: string): Promise<Session>;
-  unarchiveSession(sessionId: string): Promise<Session>;
   sendMessage(input: SendMessageInput): Promise<ChatMessage>;
   listSessionDirectory(sessionId: string, path?: string): Promise<DirectoryListing>;
   readSessionFile(sessionId: string, path: string): Promise<FileContent>;

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -11,7 +11,7 @@ import type {
   SessionSearchResult,
   WorkflowState,
 } from "../types/agent";
-import type { ChatConfig, ChatMessage, SendMessageInput } from "../types/chat";
+import type { ChatMessage, SendMessageInput } from "../types/chat";
 
 export interface EvidenceQueryInput {
   workspace?: string;
@@ -153,6 +153,8 @@ import type { CliConfigService, CliParameterService, CliToolService } from "./cl
 import type { AgentRegistryService } from "./agent-registry-service";
 import type { AgentMemoryService } from "./agent-memory-service";
 import type { ChatMessagingService } from "./chat-messaging-service";
+import type { SessionChatConfigService } from "./session-chat-config-service";
+import type { SessionRecoveryService } from "./session-recovery-service";
 import type { CodeIndexService } from "./code-index-service";
 import type { SkillEvidenceService, SkillGovernanceService } from "./skill-governance-service";
 import type { ContextQualityService, ScheduledTaskService } from "./scheduled-task-service";
@@ -186,6 +188,8 @@ export interface AgentService extends
   MissionControlService,
   AgentMemoryService,
   ChatMessagingService,
+  SessionChatConfigService,
+  SessionRecoveryService,
   LoopService {
   getDesktopUpdateSnapshot(): Promise<DesktopUpdateSnapshot>;
   getDesktopUpdatePreferences(): Promise<UpdatePreferences>;
@@ -221,15 +225,7 @@ export interface AgentService extends
   listArchivedSessions(): Promise<Session[]>;
   searchSessions(input: SessionSearchInput): Promise<SessionSearchResult[]>;
   getSession(sessionId: string): Promise<Session>;
-  getSessionRecoverySummary(sessionId: string): Promise<SessionRecoverySummary>;
-  listSessionRecoveryReports(sessionId: string, limit?: number): Promise<SessionRecoveryReport[]>;
-  acknowledgeSessionRecovery(
-    sessionId: string,
-    expectedRecoveryRevision: number,
-  ): Promise<SessionRecoveryAcknowledgement>;
   getActiveSession(): Promise<Session | null>;
-  getSessionChatConfig(sessionId: string): Promise<ChatConfig>;
-  saveSessionChatConfig(sessionId: string, config: ChatConfig): Promise<ChatConfig>;
   createSession(input: CreateSessionInput): Promise<OperationTask>;
   deleteSession(sessionId: string): Promise<void>;
   switchSession(sessionId: string): Promise<Session>;

--- a/src/services/chat-messaging-service.ts
+++ b/src/services/chat-messaging-service.ts
@@ -1,0 +1,29 @@
+import type {
+  ChatMessage,
+  ChatStreamEvent,
+  MessageFeedback,
+  SaveMessageFeedbackInput,
+} from "../types/chat";
+
+export interface ChatMessagingService {
+  listMessages(input: { sessionId: string; limit?: number; beforeId?: string }): Promise<ChatMessage[]>;
+  saveMessageFeedback(input: SaveMessageFeedbackInput): Promise<MessageFeedback>;
+  /**
+   * Delivers the user's answer to a tool call waiting in `awaiting_input`. Resolves to whether a
+   * live waiter received it, so the caller can distinguish a delivered answer from one aimed at a
+   * question that already resolved or whose generation is gone.
+   */
+  resolveAgentQuestion(sessionId: string, callId: string, answer: string): Promise<boolean>;
+  /**
+   * Delivers the user's decision on an `exit_plan_mode` call waiting in `awaiting_input`. Resolves
+   * to whether a live waiter received it — the caller must only change the session's execution
+   * mode when it did, so an approval aimed at a dead generation cannot leave a session
+   * write-capable on the strength of a decision the model never saw.
+   */
+  resolvePlanExit(sessionId: string, callId: string, approved: boolean): Promise<boolean>;
+  stopGeneration(sessionId: string): Promise<void>;
+  subscribeMessageEvents(
+    sessionId: string,
+    handler: (event: ChatStreamEvent) => void,
+  ): Promise<() => void>;
+}

--- a/src/services/session-chat-config-service.ts
+++ b/src/services/session-chat-config-service.ts
@@ -1,0 +1,6 @@
+import type { ChatConfig } from "../types/chat";
+
+export interface SessionChatConfigService {
+  getSessionChatConfig(sessionId: string): Promise<ChatConfig>;
+  saveSessionChatConfig(sessionId: string, config: ChatConfig): Promise<ChatConfig>;
+}

--- a/src/services/session-lifecycle-service.ts
+++ b/src/services/session-lifecycle-service.ts
@@ -1,0 +1,18 @@
+import type { CreateSessionInput, Session, UpdateSessionSeatsInput } from "../types/agent";
+import type { OperationTask } from "../types/operation";
+
+export interface SessionLifecycleService {
+  createSession(input: CreateSessionInput): Promise<OperationTask>;
+  deleteSession(sessionId: string): Promise<void>;
+  switchSession(sessionId: string): Promise<Session>;
+  renameSession(sessionId: string, title: string): Promise<Session>;
+  pinSession(sessionId: string): Promise<Session>;
+  unpinSession(sessionId: string): Promise<Session>;
+  archiveSession(sessionId: string): Promise<Session>;
+  unarchiveSession(sessionId: string): Promise<Session>;
+}
+
+export interface SessionSeatService {
+  updateSessionSeats(input: UpdateSessionSeatsInput): Promise<Session>;
+  rebindRemoteSessionSshConnection(sessionId: string, connectionId: string): Promise<Session>;
+}

--- a/src/services/session-query-service.ts
+++ b/src/services/session-query-service.ts
@@ -1,0 +1,26 @@
+import type {
+  ExportSessionInput,
+  InteractionMode,
+  LaunchResult,
+  Session,
+  SessionDetails,
+  SessionExportResult,
+  SessionSearchInput,
+  SessionSearchResult,
+  WorkflowState,
+} from "../types/agent";
+import type { AgentRunnerDescriptor } from "../types/agent-runner";
+
+export interface SessionQueryService {
+  getWorkflowState(): Promise<WorkflowState>;
+  selectAgent(agentId: string, interactionMode: InteractionMode): Promise<WorkflowState>;
+  launchActiveWorkflow(): Promise<LaunchResult>;
+  getSessionDetails(): Promise<SessionDetails>;
+  listSessions(): Promise<Session[]>;
+  listArchivedSessions(): Promise<Session[]>;
+  searchSessions(input: SessionSearchInput): Promise<SessionSearchResult[]>;
+  getSession(sessionId: string): Promise<Session>;
+  getActiveSession(): Promise<Session | null>;
+  exportSession(input: ExportSessionInput): Promise<SessionExportResult>;
+  listAgentRunners(sessionId: string, agentId: string): Promise<AgentRunnerDescriptor[]>;
+}

--- a/src/services/session-recovery-service.ts
+++ b/src/services/session-recovery-service.ts
@@ -1,0 +1,14 @@
+import type {
+  SessionRecoveryAcknowledgement,
+  SessionRecoveryReport,
+  SessionRecoverySummary,
+} from "./agent-service";
+
+export interface SessionRecoveryService {
+  getSessionRecoverySummary(sessionId: string): Promise<SessionRecoverySummary>;
+  listSessionRecoveryReports(sessionId: string, limit?: number): Promise<SessionRecoveryReport[]>;
+  acknowledgeSessionRecovery(
+    sessionId: string,
+    expectedRecoveryRevision: number,
+  ): Promise<SessionRecoveryAcknowledgement>;
+}

--- a/src/services/web-agent-client.ts
+++ b/src/services/web-agent-client.ts
@@ -14,8 +14,6 @@ import {
   webPrincipalTemplates,
 } from "./web-permissions-mock-state";
 import type {
-  AgentMemory,
-  AgentMemoryType,
   UpdateSessionSeatsInput,
   ExportSessionInput,
   InteractionMode,
@@ -94,6 +92,14 @@ export {
   setWebLoopPhaseDelayForTest,
   simulateWebLoopRestartForTest,
 } from "./web-loop-state";
+import { webAgentMemoryClient } from "./web-agent-memory-client";
+
+export { resetWebAgentMemoriesForTest } from "./web-agent-memory-state";
+import {
+  createWebAgentMemory,
+  listWebAgentMemories,
+  simulateWebMemoryIndexInjection,
+} from "./web-agent-memory-state";
 import { webChatClient } from "./web-chat-client";
 
 export {
@@ -315,90 +321,6 @@ export function seedWebImSessionForTest(connector: ImSessionConnector): Session 
 }
 
 
-/** Mock cross-session memories (`add-agent-cross-session-memory`, extended to CLI-wrapped agents
- * by `add-cli-memory-support`) — a single host-level pool shared by every agent kind, matching
- * the real backend's shared-pool model. Starts empty; real memories only ever come from a
- * `remember` tool call or extraction, both simulated in `sendMessage`. */
-let webAgentMemories: AgentMemory[] = [];
-let nextAgentMemoryId = 1;
-
-/** Mirrors the native store's deterministic derivation: a writer that supplies no name gets one
- * from the content, and only ASCII survives slugging, so non-Latin content falls back to the
- * sequence number rather than producing an empty stem. */
-function deriveMemoryName(content: string, sequence: number): string {
-  const slug = content
-    .split(/[^a-zA-Z0-9]+/u)
-    .filter(Boolean)
-    .slice(0, 6)
-    .join("-")
-    .toLowerCase();
-  return slug || `memory-${sequence}`;
-}
-
-/** Mirrors the native bounds so the mock truncates where the desktop runtime would. */
-const WEB_MEMORY_INDEX_LINE_CAP = 200;
-
-/** Mirrors the native selection bound. */
-const WEB_MEMORY_SELECTION_CAP = 5;
-
-/**
- * Simulates one generation's memory injection: an index over the whole pool, plus the handful of
- * bodies a selection would have read in full.
- *
- * Deterministic rather than model-driven — the Web runtime must reproduce the desktop's observable
- * shape without issuing a provider request, so it stands in for the selector with recency, which
- * is the same ordering the index already uses.
- */
-function simulateMemoryIndexInjection(): { indexed: number; selected: AgentMemory[] } {
-  const indexed = Math.min(webAgentMemories.length, WEB_MEMORY_INDEX_LINE_CAP);
-  return {
-    indexed,
-    selected: webAgentMemories.slice(0, Math.min(indexed, WEB_MEMORY_SELECTION_CAP)),
-  };
-}
-
-function disambiguateMemoryName(base: string): string {
-  if (!webAgentMemories.some((memory) => memory.name === base)) {
-    return base;
-  }
-  let suffix = 2;
-  while (webAgentMemories.some((memory) => memory.name === `${base}-${suffix}`)) {
-    suffix += 1;
-  }
-  return `${base}-${suffix}`;
-}
-
-function createAgentMemory(
-  agentId: string,
-  folder: string | null,
-  content: string,
-  source: AgentMemory["source"],
-  metadata: { name?: string; description?: string; memoryType?: AgentMemoryType | null } = {},
-): AgentMemory {
-  // An explicit name addresses an existing memory, so it is used as-is and replaces. A derived one
-  // must not: two agents recording the same fact are two memories in the shared pool, so the
-  // native store's collision suffix is mirrored here rather than silently merging them.
-  const name = metadata.name ?? disambiguateMemoryName(deriveMemoryName(content, nextAgentMemoryId));
-  const memory: AgentMemory = {
-    // The native store's identity is the file path, so the mock mirrors that shape rather than
-    // inventing an opaque id the management view would have to special-case.
-    id: `${name}.md`,
-    agentId,
-    folder,
-    name,
-    description: metadata.description ?? content.split("\n")[0] ?? content,
-    memoryType: metadata.memoryType ?? null,
-    content,
-    source,
-    createdAt: nowIso(),
-  };
-  nextAgentMemoryId += 1;
-  // Saving under an existing name replaces that memory, matching the native store's update path.
-  webAgentMemories = [memory, ...webAgentMemories.filter((existing) => existing.name !== name)];
-  return memory;
-}
-
-
 function searchText(value: string | null | undefined, query: string) {
   return (value ?? "").toLocaleLowerCase().includes(query.toLocaleLowerCase());
 }
@@ -461,12 +383,6 @@ function serializeWebSessionExport(input: ExportSessionInput): SessionExportResu
     path: input.destinationDirectory ? `${input.destinationDirectory}\\${session.id}.${input.format === "json" ? "json" : "md"}` : null,
     content,
   };
-}
-
-/** `add-cli-memory-support`: the shared memory pool is no longer isolated per agent id, so tests
- * that seed memories can leak into later tests within the same file unless explicitly cleared. */
-export function resetWebAgentMemoriesForTest() {
-  webAgentMemories = [];
 }
 
 const webCodeReviewClient = createWebCodeReviewClient(webSessionWorkspaceClient);
@@ -582,7 +498,7 @@ export const webAgentClient: AgentService = {
     const blocking: string[] = [];
     const sessionCount = listWebSessions().filter((session) => session.agentId === agentId).length;
     if (sessionCount > 0) blocking.push(`${sessionCount} sessions`);
-    const memoryCount = webAgentMemories.filter((memory) => memory.agentId === agentId).length;
+    const memoryCount = listWebAgentMemories().filter((memory) => memory.agentId === agentId).length;
     if (memoryCount > 0) blocking.push(`${memoryCount} memories`);
     const workerCount = listWebLoopDefinitions().filter((definition) => definition.workerAgentId === agentId).length;
     if (workerCount > 0) blocking.push(`${workerCount} Loop definitions as worker`);
@@ -602,17 +518,7 @@ export const webAgentClient: AgentService = {
     replaceWebSkillMountPaths(listWebSkillMountPaths().filter((path) => path.agentId !== agentId));
   },
 
-  async listAllMemories() {
-    return webAgentMemories;
-  },
-
-  async deleteAgentMemory(memoryId: string) {
-    webAgentMemories = webAgentMemories.filter((memory) => memory.id !== memoryId);
-  },
-
-  async resetAllMemories() {
-    webAgentMemories = [];
-  },
+  ...webAgentMemoryClient,
 
   async applyCliConfigProfile(input) {
     const supportedAgentId = requireCliConfigAgentId(input.agentId);
@@ -1218,7 +1124,7 @@ export const webAgentClient: AgentService = {
         mockAgents.find((candidate) => candidate.id === session.agentId)?.launch.kind === "api"
       ) {
         const extractionTimeoutId = setTimeout(() => {
-          const memory = createAgentMemory(
+          const memory = createWebAgentMemory(
             session.agentId,
             session.folder,
             `Extracted from a long conversation: "${userMessage.content.slice(0, 60)}"`,
@@ -1248,7 +1154,7 @@ export const webAgentClient: AgentService = {
     // extraction (see `personalization.memory.toolAssistedDesc`).
     if (memoryEnabled && mockAgents.find((candidate) => candidate.id === session.agentId)?.launch.kind === "cli") {
       const cliExtractionTimeoutId = setTimeout(() => {
-        const memory = createAgentMemory(
+        const memory = createWebAgentMemory(
           session.agentId,
           session.folder,
           `Extracted from a CLI session: "${userMessage.content.slice(0, 60)}"`,
@@ -1272,12 +1178,12 @@ export const webAgentClient: AgentService = {
     }
     // Shared pool (`add-cli-memory-support`): any memory from any agent counts, not just ones
     // produced by this session's own agent/folder.
-    const hadExistingMemories = webAgentMemories.length > 0;
+    const hadExistingMemories = listWebAgentMemories().length > 0;
     if (memoryEnabled && hadExistingMemories) {
       // `add-two-tier-memory-recall`: the index is what every request carries, so the mock reports
       // how many memories it names. Neither this nor the selection below depends on an embedding
       // source being configured — memory has to work on an installation without retrieval.
-      const injected = simulateMemoryIndexInjection();
+      const injected = simulateWebMemoryIndexInjection();
       const memoryInjectionTimeoutId = setTimeout(() => {
         publishWebChatEvent({
           type: "rich_block",
@@ -1474,7 +1380,7 @@ export const webAgentClient: AgentService = {
       // saves (`add-personalization-settings`).
       if (memoryEnabled) {
         const rememberTimeoutId = setTimeout(() => {
-          const memory = createAgentMemory(
+          const memory = createWebAgentMemory(
             session.agentId,
             session.folder,
             `User said: "${userMessage.content.slice(0, 60)}"`,

--- a/src/services/web-agent-client.ts
+++ b/src/services/web-agent-client.ts
@@ -1,10 +1,4 @@
-import type {
-  AgentService,
-  RecoveryDecision,
-  SessionRecoveryAcknowledgement,
-  SessionRecoveryReport,
-  SessionRecoverySummary,
-} from "./agent-service";
+import type { AgentService } from "./agent-service";
 import { mockAgents } from "./mock-agent-data";
 import { i18n } from "../i18n";
 import {
@@ -29,7 +23,7 @@ import { findWebSshConnection } from "./web-ssh-connection-client";
 import { readWebAppSettings } from "./web-settings-client";
 import { defaultSessionTitleFromPath } from "../lib/session-path";
 import { snapshotSeat } from "./seat-presentation";
-import type { ChatConfig, ChatMessage } from "../types/chat";
+import type { ChatMessage } from "../types/chat";
 import type { AgentRun } from "../types/agent-run";
 import type { AgentRunnerDescriptor, AgentRunnerSelection } from "../types/agent-runner";
 import { webEvaluationClient } from "./web-evaluation-client";
@@ -50,7 +44,6 @@ import { webSkillGovernanceClient } from "./web-skill-governance-client";
 import { webSkillEvidenceClient } from "./web-skill-evidence-client";
 import { webAgentRegistryClient } from "./web-agent-registry-client";
 import { normalizeWebPath } from "./web-skill-location";
-import { readWebMockStorage, writeWebMockStorage } from "./web-mock-storage";
 
 export { resetWebEvidenceForTest } from "./web-skill-evidence-client";
 import {
@@ -67,11 +60,7 @@ import { nowIso } from "./web-mock-clock";
 import { createWebMockOperation } from "./web-operation-client";
 import { webSessionWorkspaceClient } from "./web-session-workspace-client";
 import { webLspClient } from "./web-lsp-client";
-import {
-  defaultChatConfigForSession,
-  normalizeChatConfigForSession,
-  withEffectiveExecutionPolicy,
-} from "./chat-configuration";
+import { normalizeChatConfigForSession, withEffectiveExecutionPolicy } from "./chat-configuration";
 import { createWebMcpToolSimulationPlan } from "./web-mcp-tool-simulation";
 import { webBuiltinToolClient } from "./web-builtin-tool-client";
 import { createWebCodeReviewClient } from "./web-code-review-client";
@@ -111,7 +100,6 @@ import { WEB_MOCK_PLAN_EXIT_TRIGGER, WEB_MOCK_QUESTION_TRIGGER } from "./web-cha
 import {
   createWebMessageId,
   cancelWebActiveStream,
-  deleteWebActiveStream,
   deleteWebChatSubscribers,
   deleteWebSessionMessages,
   emitWebChatEvent,
@@ -121,6 +109,15 @@ import {
   setWebActiveStream,
   setWebSessionMessages,
 } from "./web-chat-state";
+import { deleteWebSessionChatConfig } from "./web-chat-config-state";
+import { webSessionChatConfigClient } from "./web-session-chat-config-client";
+import { webSessionRecoveryClient } from "./web-session-recovery-client";
+import { deleteWebRecoveryReports } from "./web-session-recovery-state";
+
+export {
+  resetWebRecoverySessionsForTest,
+  seedWebRecoverySessionForTest,
+} from "./web-session-recovery-state";
 import { prependWebAgentRun, setWebAgentRunEvents } from "./web-agent-run-state";
 
 export {
@@ -169,122 +166,6 @@ function tr(key: string, values?: Record<string, string | number>) {
 
 /** Mirrors the desktop runtime's character-count compaction trigger (see `add-agent-context-compaction`), scaled down for deterministic mock sessions. */
 const mockCompactionTriggerCharacters = 2_000;
-
-const recoveryReportsBySession = new Map<string, SessionRecoveryReport[]>();
-const chatConfigStorageKey = "vanehub.session-chat-config.v1";
-let memoryChatConfigs: Record<string, ChatConfig> = {};
-
-// Chat configs carry model and policy selections, never a credential, so browser storage stays
-// inside the "Honest Web/mock behavior" prohibition on persisting plaintext secrets.
-function readChatConfigs(): Record<string, ChatConfig> {
-  return readWebMockStorage(chatConfigStorageKey, memoryChatConfigs);
-}
-
-function writeChatConfigs(configs: Record<string, ChatConfig>) {
-  memoryChatConfigs = configs;
-  writeWebMockStorage(chatConfigStorageKey, configs);
-}
-
-function mockRecoveryReport(
-  session: Session,
-  recoveryRevision: number,
-  decision: RecoveryDecision,
-): SessionRecoveryReport {
-  return {
-    reportId: `web-recovery-${session.id}-${recoveryRevision}`,
-    sessionId: session.id,
-    recoveryRevision,
-    trigger: decision === "acknowledged" ? "user_acknowledgement" : "startup",
-    observedLifecycle: session.lifecycleState,
-    observedExecutionRunId: session.activeExecutionRunId,
-    decision,
-    reasonCodes: decision === "acknowledged"
-      ? ["acknowledged_by_user"]
-      : ["unfinished_tool_activity"],
-    evidenceRefs: [{
-      kind: "session",
-      sessionId: session.id,
-      stateRevision: session.stateRevision,
-      historyRevision: session.historyRevision,
-    }],
-    createdAt: nowIso(),
-  };
-}
-
-function webRecoverySummary(sessionId: string): SessionRecoverySummary {
-  const session = findWebSession(sessionId);
-  return {
-    session,
-    latestReport: recoveryReportsBySession.get(sessionId)?.[0] ?? null,
-  };
-}
-
-export function seedWebRecoverySessionForTest(
-  status: "action_required" | "quarantined" = "action_required",
-): Session {
-  const timestamp = nowIso();
-  const session: Session = {
-    id: `web-recovery-session-${nextWebSessionSequence()}`,
-    title: "Recovered Web session",
-    agentId: "onepiece",
-    interactionMode: "api",
-    lifecycleState: "failed",
-    recoveryStatus: "clean",
-    recoveryRevision: 0,
-    stateRevision: 0,
-    historyRevision: 0,
-    activeExecutionRunId: null,
-    folder: "D:\\example\\recovery-project",
-    projectPath: "D:\\example\\recovery-project",
-    worktreePath: null,
-    worktreeName: null,
-    worktreeBranch: null,
-    remoteWorkspace: null,
-    remoteSshConnectionId: null,
-    remoteSshConnectionRevision: null,
-    runtimeSessionId: null,
-    categoryId: null,
-    pinned: false,
-    archived: false,
-    createdAt: timestamp,
-    updatedAt: timestamp,
-  };
-  prependWebSession(session);
-  setWebActiveSessionId(session.id);
-  const recoveryRevision = 1;
-  const recovered = updateWebSession(session.id, {
-    lifecycleState: "failed",
-    recoveryStatus: status,
-    recoveryRevision,
-    stateRevision: session.stateRevision + 1,
-    activeExecutionRunId: null,
-  });
-  recoveryReportsBySession.set(recovered.id, [
-    mockRecoveryReport(
-      recovered,
-      recoveryRevision,
-      status === "quarantined" ? "quarantined" : "action_required",
-    ),
-  ]);
-  emitWebSessionEvent({
-    kind: status === "quarantined" ? "recovery-quarantined" : "recovery-action-required",
-    sessionId: recovered.id,
-    recoveryRevision,
-  });
-  return recovered;
-}
-
-export function resetWebRecoverySessionsForTest() {
-  const recoverySessionIds = new Set(recoveryReportsBySession.keys());
-  replaceWebSessions(listWebSessions().filter((session) => !recoverySessionIds.has(session.id)));
-  recoverySessionIds.forEach((sessionId) => {
-    deleteWebSessionMessages(sessionId);
-    deleteWebActiveStream(sessionId);
-  });
-  recoveryReportsBySession.clear();
-  const activeId = getWebActiveSessionId();
-  if (activeId && recoverySessionIds.has(activeId)) setWebActiveSessionId(null);
-}
 
 export function seedWebImSessionForTest(connector: ImSessionConnector): Session {
   const timestamp = nowIso();
@@ -632,51 +513,7 @@ export const webAgentClient: AgentService = {
     return findWebSession(sessionId);
   },
 
-  async getSessionRecoverySummary(sessionId: string) {
-    return structuredClone(webRecoverySummary(sessionId));
-  },
-
-  async listSessionRecoveryReports(sessionId: string, limit = 20) {
-    findWebSession(sessionId);
-    const boundedLimit = Math.max(1, Math.min(100, Math.trunc(limit)));
-    return structuredClone((recoveryReportsBySession.get(sessionId) ?? []).slice(0, boundedLimit));
-  },
-
-  async acknowledgeSessionRecovery(
-    sessionId: string,
-    expectedRecoveryRevision: number,
-  ): Promise<SessionRecoveryAcknowledgement> {
-    const session = findWebSession(sessionId);
-    if (session.recoveryStatus === "quarantined") {
-      throw new Error(`Recovery acknowledgement is not allowed for quarantined session ${sessionId}.`);
-    }
-    if (session.recoveryStatus !== "action_required") {
-      throw new Error(`Recovery acknowledgement is not allowed for session ${sessionId}.`);
-    }
-    if (session.recoveryRevision !== expectedRecoveryRevision) {
-      throw new Error(
-        `Recovery revision conflict for session ${sessionId}; current revision is ${session.recoveryRevision}.`,
-      );
-    }
-    const recoveryRevision = session.recoveryRevision + 1;
-    const updated = updateWebSession(sessionId, {
-      recoveryStatus: "clean",
-      recoveryRevision,
-      stateRevision: session.stateRevision + 1,
-      activeExecutionRunId: null,
-    });
-    const report = mockRecoveryReport(updated, recoveryRevision, "acknowledged");
-    recoveryReportsBySession.set(sessionId, [
-      report,
-      ...(recoveryReportsBySession.get(sessionId) ?? []),
-    ]);
-    emitWebSessionEvent({
-      kind: "recovery-acknowledged",
-      sessionId,
-      recoveryRevision,
-    });
-    return structuredClone({ session: updated, report });
-  },
+  ...webSessionRecoveryClient,
 
   async getActiveSession() {
     const sessionId = getWebActiveSessionId();
@@ -686,24 +523,7 @@ export const webAgentClient: AgentService = {
   ...webSessionCategoryClient,
   ...webLoopClient,
 
-  async getSessionChatConfig(sessionId) {
-    const session = findWebSession(sessionId);
-    const stored = readChatConfigs()[sessionId];
-    const normalized = stored
-      ? normalizeChatConfigForSession(session, stored)
-      : defaultChatConfigForSession(session);
-    const policy = webPrincipalTemplates.get(session.agentId) ?? getWebDefaultPolicyTemplate();
-    return withEffectiveExecutionPolicy(normalized, policy);
-  },
-
-  async saveSessionChatConfig(sessionId, config) {
-    const session = findWebSession(sessionId);
-    const normalized = normalizeChatConfigForSession(session, config);
-    writeChatConfigs({ ...readChatConfigs(), [sessionId]: normalized });
-    emitWebSessionEvent({ kind: "configuration-changed", sessionId });
-    const policy = webPrincipalTemplates.get(session.agentId) ?? getWebDefaultPolicyTemplate();
-    return withEffectiveExecutionPolicy(normalized, policy);
-  },
+  ...webSessionChatConfigClient,
   ...webKnownWorkspaceClient,
 
   async createSession(input) {
@@ -825,11 +645,9 @@ export const webAgentClient: AgentService = {
     findWebSession(sessionId);
     cancelWebActiveStream(sessionId);
     deleteWebSessionMessages(sessionId);
-    recoveryReportsBySession.delete(sessionId);
+    deleteWebRecoveryReports(sessionId);
     deleteWebChatSubscribers(sessionId);
-    const configs = { ...readChatConfigs() };
-    delete configs[sessionId];
-    writeChatConfigs(configs);
+    deleteWebSessionChatConfig(sessionId);
     replaceWebSessions(listWebSessions().filter((session) => session.id !== sessionId));
     if (getWebActiveSessionId() === sessionId) {
       setWebActiveSessionId(null);

--- a/src/services/web-agent-client.ts
+++ b/src/services/web-agent-client.ts
@@ -1,22 +1,13 @@
 import type { AgentService } from "./agent-service";
 import { mockAgents } from "./mock-agent-data";
-import { i18n } from "../i18n";
 import {
   createWebPendingApproval,
   getWebDefaultPolicyTemplate,
   isAgentAutoApproved,
   webPrincipalTemplates,
 } from "./web-permissions-mock-state";
-import type {
-  UpdateSessionSeatsInput,
-  Session,
-  SessionSeat,
-  ImSessionConnector,
-} from "../types/agent";
-import { findWebSshConnection } from "./web-ssh-connection-client";
+import type { ImSessionConnector, Session } from "../types/agent";
 import { readWebAppSettings } from "./web-settings-client";
-import { defaultSessionTitleFromPath } from "../lib/session-path";
-import { snapshotSeat } from "./seat-presentation";
 import type { ChatMessage } from "../types/chat";
 import { webEvaluationClient } from "./web-evaluation-client";
 import { webPromptHookClient } from "./web-prompt-hook-client";
@@ -26,7 +17,6 @@ import { webOnePieceProfileClient } from "./web-onepiece-profile-client";
 import { webHybridRoutingClient } from "./web-hybrid-routing-client";
 import { deleteWebApiAgentProviderConfig } from "./web-api-provider-state";
 import { webCodeIndexClient } from "./web-code-index-client";
-import { discoverWebSessionCodeIndex } from "./web-code-index-state";
 import { webCliToolClient } from "./web-cli-tool-client";
 import { webCliParameterClient } from "./web-cli-parameter-client";
 import { webCliConfigClient } from "./web-cli-config-client";
@@ -49,7 +39,6 @@ import {
 // implementation lives in the extracted module.
 export { resetWebRetrievalForTest, searchWebCodeIndex } from "./web-code-index-state";
 import { nowIso } from "./web-mock-clock";
-import { createWebMockOperation } from "./web-operation-client";
 import { webSessionWorkspaceClient } from "./web-session-workspace-client";
 import { webLspClient } from "./web-lsp-client";
 import { normalizeChatConfigForSession, withEffectiveExecutionPolicy } from "./chat-configuration";
@@ -61,7 +50,7 @@ import { webSkillCatalogClient } from "./web-skill-catalog-client";
 import { webSkillBindingClient } from "./web-skill-binding-client";
 import { webSkillOverlayClient } from "./web-skill-overlay-client";
 import { webSessionCategoryClient } from "./web-session-category-client";
-import { webExpertRoleClient, listWebExpertRoles } from "./web-expert-role-client";
+import { webExpertRoleClient } from "./web-expert-role-client";
 import { webAgentTerminalClient } from "./web-agent-terminal-client";
 import { webUsageStatisticsClient } from "./web-usage-statistics-client";
 import { webMissionControlClient } from "./web-mission-control-client";
@@ -91,9 +80,6 @@ export {
 import { WEB_MOCK_PLAN_EXIT_TRIGGER, WEB_MOCK_QUESTION_TRIGGER } from "./web-chat-client";
 import {
   createWebMessageId,
-  cancelWebActiveStream,
-  deleteWebChatSubscribers,
-  deleteWebSessionMessages,
   emitWebChatEvent,
   getWebSessionMessages,
   hasWebActiveStream,
@@ -101,10 +87,8 @@ import {
   setWebActiveStream,
   setWebSessionMessages,
 } from "./web-chat-state";
-import { deleteWebSessionChatConfig } from "./web-chat-config-state";
 import { webSessionChatConfigClient } from "./web-session-chat-config-client";
 import { webSessionRecoveryClient } from "./web-session-recovery-client";
-import { deleteWebRecoveryReports } from "./web-session-recovery-state";
 
 export {
   resetWebRecoverySessionsForTest,
@@ -116,32 +100,21 @@ export {
   resetWebMissionControlRunsForTest,
   seedWebMissionControlRunsForTest,
 } from "./web-agent-run-state";
+import { webKnownWorkspaceClient } from "./web-known-workspace-client";
 import {
-  inspectMockProject,
-  joinSiblingPath,
-  normalizeRemoteWorkspace,
-  resolveProjectPath,
-  upsertKnownProject,
-  upsertKnownRemoteWorkspace,
-  validateWorktreeName,
-  webKnownWorkspaceClient,
-} from "./web-known-workspace-client";
-import {
-  createWebSeatId,
-  emitWebSessionEvent,
   findWebSession,
   getWebActiveSessionId,
   getWebWorkflowState,
   listWebSessions,
   nextWebSessionSequence,
   prependWebSession,
-  replaceWebSessions,
   setWebActiveSessionId,
-  setWebWorkflowState,
   subscribeWebSessionStateEvents,
   updateWebSession,
 } from "./web-session-state";
 import { webSessionQueryClient } from "./web-session-query-client";
+import { webSessionLifecycleClient } from "./web-session-lifecycle-client";
+import { webSessionSeatClient } from "./web-session-seat-client";
 import { selectWebRunner, webRunRunner } from "./web-agent-runner";
 import type { Skill } from "../types/skill";
 import {
@@ -152,10 +125,6 @@ import {
   replaceWebSkillMountPaths,
   replaceWebSkills,
 } from "./web-skill-state";
-
-function tr(key: string, values?: Record<string, string | number>) {
-  return i18n.t(key, values);
-}
 
 /** Mirrors the desktop runtime's character-count compaction trigger (see `add-agent-context-compaction`), scaled down for deterministic mock sessions. */
 const mockCompactionTriggerCharacters = 2_000;
@@ -307,260 +276,8 @@ export const webAgentClient: AgentService = {
   ...webSessionChatConfigClient,
   ...webKnownWorkspaceClient,
 
-  async createSession(input) {
-    const agent = mockAgents.find((candidate) => candidate.id === input.agentId);
-    if (!agent) {
-      throw new Error(`Agent not found: ${input.agentId}`);
-    }
-    if (!agent.supportedInteractionModes.includes(input.interactionMode)) {
-      throw new Error(`${agent.displayName} does not support ${input.interactionMode}.`);
-    }
-    if (agent.availabilityState !== "available" && agent.availabilityState !== "unknown") {
-      throw new Error(agent.unavailableReason ?? `${agent.displayName} is not available.`);
-    }
-    const remoteWorkspace = input.remoteWorkspace ? normalizeRemoteWorkspace(input.remoteWorkspace) : null;
-    if (agent.id === "onepiece" && remoteWorkspace) {
-      throw new Error("OnePiece supports local projects and local Git worktrees only.");
-    }
-    const sshConnection = input.remoteWorkspace?.sshConnectionId
-      ? findWebSshConnection(input.remoteWorkspace.sshConnectionId)
-      : null;
-    if (input.remoteWorkspace?.sshConnectionId && !sshConnection) {
-      throw new Error(`SSH connection not found: ${input.remoteWorkspace.sshConnectionId}`);
-    }
-    if (
-      sshConnection &&
-      remoteWorkspace &&
-      (sshConnection.host !== remoteWorkspace.host ||
-        sshConnection.port !== (remoteWorkspace.port ?? 22) ||
-        sshConnection.user !== (remoteWorkspace.user ?? ""))
-    ) {
-      throw new Error(
-        "SSH connection endpoint does not match the remote workspace snapshot.",
-      );
-    }
-    if (remoteWorkspace && input.worktree?.enabled) {
-      throw new Error("Remote workspace cannot use Git worktree");
-    }
-    const projectPath = remoteWorkspace ? null : resolveProjectPath(input);
-    const inspection = projectPath ? inspectMockProject(projectPath) : null;
-    if (inspection) {
-      upsertKnownProject(inspection);
-    }
-    if (remoteWorkspace) {
-      upsertKnownRemoteWorkspace(remoteWorkspace);
-    }
-    let effectiveFolder = remoteWorkspace?.uri ?? projectPath;
-    let worktreePath: string | null = null;
-    let worktreeName: string | null = null;
-    let worktreeBranch: string | null = null;
-    if (input.worktree?.enabled) {
-      if (!inspection?.isGit) {
-        throw new Error("Git worktree unavailable");
-      }
-      worktreeName = validateWorktreeName(input.worktree.name ?? "");
-      worktreePath = joinSiblingPath(inspection.path, worktreeName);
-      worktreeBranch = `vanehub/${worktreeName}`;
-      effectiveFolder = worktreePath;
-    }
-    const timestamp = nowIso();
-    const titleSource = remoteWorkspace?.displayName || effectiveFolder || "";
-    const normalizedSeats = (input.seats?.length ? input.seats : [{ agentId: input.agentId, roleId: null }]).map(
-      (seat) => ({
-        ...snapshotSeat(seat, mockAgents, listWebExpertRoles()),
-        seatId: createWebSeatId(),
-        joinedAt: timestamp,
-        leftAt: null,
-      }),
-    );
-    const session: Session = {
-      id: `web-session-${nextWebSessionSequence()}`,
-      title: input.title?.trim() || defaultSessionTitleFromPath(titleSource) || tr("createSession.sessionPlaceholder"),
-      agentId: normalizedSeats[0]?.agentId ?? input.agentId,
-      // Mirrors the native normalization: no seats means one seat built from the Agent.
-      seats: normalizedSeats,
-      interactionMode: input.interactionMode,
-      lifecycleState: "idle",
-      recoveryStatus: "clean",
-      recoveryRevision: 0,
-      stateRevision: 0,
-      historyRevision: 0,
-      activeExecutionRunId: null,
-      folder: effectiveFolder,
-      projectPath,
-      worktreePath,
-      worktreeName,
-      worktreeBranch,
-      remoteWorkspace,
-      remoteSshConnectionId: sshConnection?.id ?? null,
-      remoteSshConnectionRevision: sshConnection?.revision ?? null,
-      runtimeSessionId: null,
-      categoryId: null,
-      pinned: false,
-      archived: false,
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    };
-    prependWebSession(session);
-    setWebActiveSessionId(session.id);
-    discoverWebSessionCodeIndex(session);
-    emitWebSessionEvent({ kind: "active-session-changed", sessionId: session.id });
-    setWebWorkflowState({
-      ...getWebWorkflowState(),
-      activeAgentId: session.agentId,
-      activeInteractionMode: session.interactionMode,
-      lifecycleState: session.lifecycleState,
-    });
-    return createWebMockOperation({
-      id: `web-session-create-${session.id}-${Date.now()}`,
-      kind: "workspace",
-      relatedEntityId: remoteWorkspace?.uri ?? projectPath,
-      message: `Created mock session ${session.id}`,
-      terminalStatus: "succeeded",
-      error: null,
-      result: session as unknown as Record<string, unknown>,
-    });
-  },
-
-  async deleteSession(sessionId: string) {
-    findWebSession(sessionId);
-    cancelWebActiveStream(sessionId);
-    deleteWebSessionMessages(sessionId);
-    deleteWebRecoveryReports(sessionId);
-    deleteWebChatSubscribers(sessionId);
-    deleteWebSessionChatConfig(sessionId);
-    replaceWebSessions(listWebSessions().filter((session) => session.id !== sessionId));
-    if (getWebActiveSessionId() === sessionId) {
-      setWebActiveSessionId(null);
-      emitWebSessionEvent({ kind: "active-session-changed", sessionId: null });
-    }
-  },
-
-  async switchSession(sessionId: string) {
-    const session = findWebSession(sessionId);
-    if (session.archived) {
-      throw new Error(`Cannot switch to archived session: ${sessionId}`);
-    }
-    setWebActiveSessionId(session.id);
-    emitWebSessionEvent({ kind: "active-session-changed", sessionId: session.id });
-    setWebWorkflowState({
-      ...getWebWorkflowState(),
-      activeAgentId: session.agentId,
-      activeInteractionMode: session.interactionMode,
-      lifecycleState: session.lifecycleState,
-    });
-    return session;
-  },
-
-  async renameSession(sessionId: string, title: string) {
-    const trimmedTitle = title.trim();
-    if (!trimmedTitle) {
-      throw new Error(tr("web.error.sessionTitleRequired"));
-    }
-    return updateWebSession(sessionId, { title: trimmedTitle });
-  },
-
-  async updateSessionSeats(input: UpdateSessionSeatsInput) {
-    const session = findWebSession(input.sessionId);
-    if (session.updatedAt !== input.expectedUpdatedAt) {
-      throw new Error("validation error: Session participants changed since they were loaded.");
-    }
-    if (input.seats.length === 0) {
-      throw new Error("validation error: A session must keep at least one active participant.");
-    }
-    const changedAt = nowIso();
-    const historical = session.seats ?? [{
-      seatId: `${session.id}:seat:0`,
-      agentId: session.agentId,
-      roleId: null,
-      joinedAt: session.createdAt,
-      leftAt: null,
-    }];
-    const retained = new Set<string>();
-    const additions: SessionSeat[] = [];
-    for (const requested of input.seats) {
-      const existing = historical.find((seat) =>
-        seat.leftAt == null && !retained.has(seat.seatId ?? "") &&
-        ((Boolean(requested.seatId) && seat.seatId === requested.seatId &&
-          seat.agentId === requested.agentId && seat.roleId === requested.roleId) ||
-          (!requested.seatId && seat.agentId === requested.agentId && seat.roleId === requested.roleId)),
-      );
-      if (existing?.seatId) {
-        retained.add(existing.seatId);
-      } else {
-        additions.push({
-          ...requested,
-          seatId: createWebSeatId(),
-          joinedAt: changedAt,
-          leftAt: null,
-        });
-      }
-    }
-    const seats = [
-      ...historical.map((seat) =>
-        seat.leftAt == null && !retained.has(seat.seatId ?? "")
-          ? { ...seat, leftAt: changedAt }
-          : seat,
-      ),
-      ...additions,
-    ];
-    const firstActive = seats.find((seat) => seat.leftAt == null);
-    if (!firstActive) {
-      throw new Error("validation error: A session must keep at least one active participant.");
-    }
-    return updateWebSession(input.sessionId, { seats, agentId: firstActive.agentId });
-  },
-
-  async rebindRemoteSessionSshConnection(
-    sessionId: string,
-    connectionId: string,
-  ) {
-    const session = findWebSession(sessionId);
-    if (!session.remoteWorkspace) {
-      throw new Error(
-        "Only remote workspace sessions can bind an SSH connection.",
-      );
-    }
-    const connection = findWebSshConnection(connectionId);
-    if (!connection) {
-      throw new Error(`SSH connection not found: ${connectionId}`);
-    }
-    if (
-      connection.host !== session.remoteWorkspace.host ||
-      connection.port !== (session.remoteWorkspace.port ?? 22) ||
-      connection.user !== (session.remoteWorkspace.user ?? "")
-    ) {
-      throw new Error(
-        "SSH connection endpoint does not match the remote workspace snapshot.",
-      );
-    }
-    return updateWebSession(sessionId, {
-      remoteSshConnectionId: connection.id,
-      remoteSshConnectionRevision: connection.revision,
-    });
-  },
-
-  async pinSession(sessionId: string) {
-    return updateWebSession(sessionId, { pinned: true });
-  },
-
-  async unpinSession(sessionId: string) {
-    return updateWebSession(sessionId, { pinned: false });
-  },
-
-  async archiveSession(sessionId: string) {
-    const cancelled = cancelWebActiveStream(sessionId);
-    const session = updateWebSession(sessionId, { archived: true, ...(cancelled ? { lifecycleState: "stopped" } : {}) });
-    if (getWebActiveSessionId() === sessionId) {
-      setWebActiveSessionId(null);
-      emitWebSessionEvent({ kind: "active-session-changed", sessionId: null });
-    }
-    return session;
-  },
-
-  async unarchiveSession(sessionId: string) {
-    return updateWebSession(sessionId, { archived: false });
-  },
+  ...webSessionLifecycleClient,
+  ...webSessionSeatClient,
 
   async sendMessage(input) {
     const session = findWebSession(input.sessionId);

--- a/src/services/web-agent-client.ts
+++ b/src/services/web-agent-client.ts
@@ -11,10 +11,8 @@ import {
   createWebPendingApproval,
   getWebDefaultPolicyTemplate,
   isAgentAutoApproved,
-  webPendingApprovals,
   webPrincipalTemplates,
 } from "./web-permissions-mock-state";
-import { upsertToolUse } from "./tool-use";
 import type {
   AgentMemory,
   AgentMemoryType,
@@ -33,7 +31,7 @@ import { findWebSshConnection } from "./web-ssh-connection-client";
 import { readWebAppSettings } from "./web-settings-client";
 import { defaultSessionTitleFromPath } from "../lib/session-path";
 import { snapshotSeat } from "./seat-presentation";
-import type { ChatConfig, ChatMessage, ChatStreamEvent } from "../types/chat";
+import type { ChatConfig, ChatMessage } from "../types/chat";
 import type { AgentRun } from "../types/agent-run";
 import type { AgentRunnerDescriptor, AgentRunnerSelection } from "../types/agent-runner";
 import { webEvaluationClient } from "./web-evaluation-client";
@@ -89,25 +87,35 @@ import { webAgentTerminalClient } from "./web-agent-terminal-client";
 import { webUsageStatisticsClient } from "./web-usage-statistics-client";
 import { webMissionControlClient } from "./web-mission-control-client";
 import { webLoopClient } from "./web-loop-client";
-import {
-  clearWebLoopStateForTest,
-  clearWebLoopTimersAndSubscribers,
-  isWebLoopRoleSession,
-  listWebLoopDefinitions,
-  snapshotWebLoopRoleSessionIds,
-} from "./web-loop-state";
+import { isWebLoopRoleSession, listWebLoopDefinitions } from "./web-loop-state";
 
 export {
+  resetWebLoopsForTest,
   setWebLoopPhaseDelayForTest,
   simulateWebLoopRestartForTest,
 } from "./web-loop-state";
+import { webChatClient } from "./web-chat-client";
+
+export {
+  resolveWebMockToolApproval,
+  WEB_MOCK_PLAN_EXIT_TRIGGER,
+  WEB_MOCK_QUESTION_TRIGGER,
+} from "./web-chat-client";
+import { WEB_MOCK_PLAN_EXIT_TRIGGER, WEB_MOCK_QUESTION_TRIGGER } from "./web-chat-client";
 import {
-  findWebAgentRun,
-  isTerminalWebRunState,
-  prependWebAgentRun,
-  setWebAgentRunEvents,
-  updateWebAgentRun,
-} from "./web-agent-run-state";
+  createWebMessageId,
+  cancelWebActiveStream,
+  deleteWebActiveStream,
+  deleteWebChatSubscribers,
+  deleteWebSessionMessages,
+  emitWebChatEvent,
+  getWebSessionMessages,
+  hasWebActiveStream,
+  publishWebChatEvent,
+  setWebActiveStream,
+  setWebSessionMessages,
+} from "./web-chat-state";
+import { prependWebAgentRun, setWebAgentRunEvents } from "./web-agent-run-state";
 
 export {
   resetWebMissionControlRunsForTest,
@@ -156,11 +164,7 @@ function tr(key: string, values?: Record<string, string | number>) {
 /** Mirrors the desktop runtime's character-count compaction trigger (see `add-agent-context-compaction`), scaled down for deterministic mock sessions. */
 const mockCompactionTriggerCharacters = 2_000;
 
-let nextMessageId = 1;
 const recoveryReportsBySession = new Map<string, SessionRecoveryReport[]>();
-const messagesBySession = new Map<string, ChatMessage[]>();
-const subscribersBySession = new Map<string, Set<(event: ChatStreamEvent) => void>>();
-const activeStreams = new Map<string, { messageId: string; timeoutIds: Array<ReturnType<typeof setTimeout>> }>();
 const chatConfigStorageKey = "vanehub.session-chat-config.v1";
 let memoryChatConfigs: Record<string, ChatConfig> = {};
 
@@ -268,8 +272,8 @@ export function resetWebRecoverySessionsForTest() {
   const recoverySessionIds = new Set(recoveryReportsBySession.keys());
   replaceWebSessions(listWebSessions().filter((session) => !recoverySessionIds.has(session.id)));
   recoverySessionIds.forEach((sessionId) => {
-    messagesBySession.delete(sessionId);
-    activeStreams.delete(sessionId);
+    deleteWebSessionMessages(sessionId);
+    deleteWebActiveStream(sessionId);
   });
   recoveryReportsBySession.clear();
   const activeId = getWebActiveSessionId();
@@ -420,7 +424,7 @@ function sessionSearchMatches(session: Session, query: string): SessionSearchRes
   if (projectMatch) {
     matches.push({ kind: "project", excerpt: projectMatch });
   }
-  const messageMatch = getSessionMessages(session.id).find((message) => searchText(message.content, query));
+  const messageMatch = getWebSessionMessages(session.id).find((message) => searchText(message.content, query));
   if (messageMatch) {
     matches.push({
       kind: "message",
@@ -437,7 +441,7 @@ function serializeWebSessionExport(input: ExportSessionInput): SessionExportResu
     version: 1,
     exportedAt: nowIso(),
     session,
-    messages: getSessionMessages(session.id),
+    messages: getWebSessionMessages(session.id),
   };
   const content =
     input.format === "json"
@@ -459,214 +463,10 @@ function serializeWebSessionExport(input: ExportSessionInput): SessionExportResu
   };
 }
 
-function createMessageId() {
-  const id = `web-message-${nextMessageId}`;
-  nextMessageId += 1;
-  return id;
-}
-
-function getSessionMessages(sessionId: string) {
-  return messagesBySession.get(sessionId) ?? [];
-}
-
-function setSessionMessages(sessionId: string, nextMessages: ChatMessage[]) {
-  messagesBySession.set(sessionId, nextMessages);
-}
-
-function upsertMessage(message: ChatMessage) {
-  const messages = getSessionMessages(message.sessionId);
-  const index = messages.findIndex((candidate) => candidate.id === message.id);
-  if (index === -1) {
-    setSessionMessages(message.sessionId, [...messages, message]);
-    return;
-  }
-  const nextMessages = [...messages];
-  nextMessages[index] = message;
-  setSessionMessages(message.sessionId, nextMessages);
-}
-
-function emitChatEvent(event: ChatStreamEvent) {
-  const subscribers = subscribersBySession.get(event.sessionId);
-  subscribers?.forEach((handler) => handler(event));
-}
-
-function finishWebGeneration(sessionId: string, lifecycleState: Session["lifecycleState"]) {
-  const session = findWebSession(sessionId);
-  const runId = session.activeExecutionRunId;
-  if (runId) {
-    const run = findWebAgentRun(runId);
-    if (run && !isTerminalWebRunState(run.state)) {
-      updateWebAgentRun(
-        run.id,
-        run.version,
-        lifecycleState === "idle" ? "completed" : lifecycleState === "failed" ? "failed" : "cancelled",
-      );
-    }
-  }
-  updateWebSession(sessionId, {
-    lifecycleState,
-    activeExecutionRunId: null,
-    stateRevision: session.stateRevision + 1,
-  });
-}
-
-function applyStreamEvent(event: ChatStreamEvent) {
-  // The turn status belongs to the session, not to any message.
-  if (event.type === "turn_status") return;
-  const messages = getSessionMessages(event.sessionId);
-  const message = messages.find((candidate) => candidate.id === event.messageId);
-  if (!message) return;
-  const timestamp = nowIso();
-  if (event.type === "token") {
-    upsertMessage({ ...message, content: `${message.content}${event.contentDelta}`, updatedAt: timestamp });
-  } else if (event.type === "thinking") {
-    upsertMessage({
-      ...message,
-      thinkingContent: `${message.thinkingContent ?? ""}${event.contentDelta}`,
-      updatedAt: timestamp,
-    });
-  } else if (event.type === "tool_use") {
-    upsertMessage({ ...message, toolUse: upsertToolUse(message.toolUse ?? [], event.toolUse), updatedAt: timestamp });
-  } else if (event.type === "rich_block") {
-    const blocks = message.richBlocks ?? [];
-    const blockIndex = blocks.findIndex((block) => block.id === event.block.id);
-    const richBlocks =
-      blockIndex === -1
-        ? [...blocks, event.block]
-        : blocks.map((block, index) => (index === blockIndex ? event.block : block));
-    upsertMessage({ ...message, richBlocks, updatedAt: timestamp });
-  } else if (event.type === "completed") {
-    upsertMessage({ ...message, status: "completed", tokenUsage: event.tokenUsage, updatedAt: timestamp });
-    activeStreams.delete(event.sessionId);
-    finishWebGeneration(event.sessionId, "idle");
-  } else if (event.type === "failed") {
-    upsertMessage({ ...message, status: "failed", error: event.error, updatedAt: timestamp });
-    activeStreams.delete(event.sessionId);
-    finishWebGeneration(event.sessionId, "failed");
-  } else if (event.type === "cancelled") {
-    upsertMessage({ ...message, status: "cancelled", updatedAt: timestamp });
-    activeStreams.delete(event.sessionId);
-    finishWebGeneration(event.sessionId, "stopped");
-  }
-}
-
-function publishChatEvent(event: ChatStreamEvent) {
-  applyStreamEvent(event);
-  emitChatEvent(event);
-}
-
-/**
- * Resolves a simulated tool call awaiting approval and publishes the resulting `tool_use` event
- * — the same behavior `resolveToolApproval` used to provide directly on this client, extracted
- * to a plain export so `web-permissions-client.ts` can call it (`permissions-approval`'s
- * `resolvePendingApproval` is the new frontend entry point; this is its Web/mock backing).
- */
-export function resolveWebMockToolApproval(sessionId: string, callId: string, approved: boolean): boolean {
-  findWebSession(sessionId);
-  const pending = webPendingApprovals.get(callId);
-  if (!pending || pending.sessionId !== sessionId) return false;
-  webPendingApprovals.delete(callId);
-  publishChatEvent({
-    type: "tool_use",
-    sessionId,
-    messageId: pending.messageId,
-    toolUse: {
-      id: callId,
-      name: pending.toolName,
-      input: pending.input ?? { command: "echo mock" },
-      output: approved ? pending.output ?? "mock\n" : "Denied by user.",
-      status: approved ? "completed" : "failed",
-    },
-  });
-  return true;
-}
-
-/**
- * Web/mock backing for `resolveAgentQuestion`. Unlike the desktop runtime there is no blocked
- * generation to resume, so "delivered" means only that a tool block in this session was still
- * showing `awaiting_input` — the mock reports the round trip as simulated rather than implying a
- * real wait ended.
- */
-/**
- * Marker that makes the Web/mock runtime simulate a clarification round trip. Web/mock has no
- * model deciding when to ask, so the trigger stands in for that decision.
- */
-export const WEB_MOCK_QUESTION_TRIGGER = "[ask-me]";
-
-/**
- * Marker that makes the Web/mock runtime simulate a request to leave plan mode. Same reason as the
- * question trigger: the request blocks until decided, so emitting one every turn would leave every
- * other mock conversation waiting on a card.
- */
-export const WEB_MOCK_PLAN_EXIT_TRIGGER = "[plan-done]";
-
-function resolveSimulatedQuestion(sessionId: string, callId: string, answer: string): boolean {
-  findWebSession(sessionId);
-  const message = getSessionMessages(sessionId).find((entry) =>
-    entry.toolUse?.some((tool) => tool.id === callId && tool.status === "awaiting_input"),
-  );
-  const pending = message?.toolUse?.find((tool) => tool.id === callId);
-  if (!message || !pending) return false;
-  publishChatEvent({
-    type: "tool_use",
-    sessionId,
-    messageId: message.id,
-    toolUse: { ...pending, output: answer, status: "completed" },
-  });
-  return true;
-}
-
-/**
- * Web/mock backing for `resolvePlanExit`. Same simulation as an answer: nothing is blocked, so
- * "delivered" means a matching tool block was still showing `awaiting_input`. The recorded output
- * differs by decision so the mock cannot make a decline look like an approval.
- */
-function resolveSimulatedPlanExit(sessionId: string, callId: string, approved: boolean): boolean {
-  findWebSession(sessionId);
-  const message = getSessionMessages(sessionId).find((entry) =>
-    entry.toolUse?.some((tool) => tool.id === callId && tool.status === "awaiting_input"),
-  );
-  const pending = message?.toolUse?.find((tool) => tool.id === callId);
-  if (!message || !pending) return false;
-  publishChatEvent({
-    type: "tool_use",
-    sessionId,
-    messageId: message.id,
-    toolUse: {
-      ...pending,
-      output: approved
-        ? "The user approved your plan and this session has left plan mode."
-        : "The user did not approve this plan. The session is still in plan mode.",
-      status: approved ? "completed" : "failed",
-    },
-  });
-  return true;
-}
-
-function cancelActiveStream(sessionId: string) {
-  const activeStream = activeStreams.get(sessionId);
-  if (!activeStream) return false;
-  activeStream.timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
-  activeStreams.delete(sessionId);
-  publishChatEvent({ type: "cancelled", sessionId, messageId: activeStream.messageId });
-  return true;
-}
-
 /** `add-cli-memory-support`: the shared memory pool is no longer isolated per agent id, so tests
  * that seed memories can leak into later tests within the same file unless explicitly cleared. */
 export function resetWebAgentMemoriesForTest() {
   webAgentMemories = [];
-}
-
-// Split across the two owners rather than moved whole: the loop bindings live in the loop state
-// module, but `messagesBySession` is still owned here, so the ordering is preserved by calling the
-// loop module's two clear steps around the message cleanup.
-export function resetWebLoopsForTest() {
-  clearWebLoopTimersAndSubscribers();
-  const roleSessionIds = snapshotWebLoopRoleSessionIds();
-  replaceWebSessions(listWebSessions().filter((session) => !roleSessionIds.includes(session.id)));
-  roleSessionIds.forEach((sessionId) => messagesBySession.delete(sessionId));
-  clearWebLoopStateForTest();
 }
 
 const webCodeReviewClient = createWebCodeReviewClient(webSessionWorkspaceClient);
@@ -1117,10 +917,10 @@ export const webAgentClient: AgentService = {
 
   async deleteSession(sessionId: string) {
     findWebSession(sessionId);
-    cancelActiveStream(sessionId);
-    messagesBySession.delete(sessionId);
+    cancelWebActiveStream(sessionId);
+    deleteWebSessionMessages(sessionId);
     recoveryReportsBySession.delete(sessionId);
-    subscribersBySession.delete(sessionId);
+    deleteWebChatSubscribers(sessionId);
     const configs = { ...readChatConfigs() };
     delete configs[sessionId];
     writeChatConfigs(configs);
@@ -1244,7 +1044,7 @@ export const webAgentClient: AgentService = {
   },
 
   async archiveSession(sessionId: string) {
-    const cancelled = cancelActiveStream(sessionId);
+    const cancelled = cancelWebActiveStream(sessionId);
     const session = updateWebSession(sessionId, { archived: true, ...(cancelled ? { lifecycleState: "stopped" } : {}) });
     if (getWebActiveSessionId() === sessionId) {
       setWebActiveSessionId(null);
@@ -1280,14 +1080,14 @@ export const webAgentClient: AgentService = {
       config,
       agentPolicy,
     ).effectiveExecutionPolicy;
-    if (activeStreams.has(input.sessionId)) {
+    if (hasWebActiveStream(input.sessionId)) {
       throw new Error("A generation is already active for this session.");
     }
     const selectedRunner = selectWebRunner(input.sessionId, session.agentId, input.runner);
     const timestamp = nowIso();
     const activeSeats = (session.seats ?? []).filter((seat) => seat.leftAt == null);
     const firstSpeakerSeatId = activeSeats.length > 1 ? activeSeats[0]?.seatId : undefined;
-    const existingMessages = getSessionMessages(input.sessionId);
+    const existingMessages = getWebSessionMessages(input.sessionId);
     const nextSequence = existingMessages.reduce(
       (maximum, message) => Math.max(maximum, message.sessionSequence),
       0,
@@ -1311,7 +1111,7 @@ export const webAgentClient: AgentService = {
     });
     setWebAgentRunEvents(executionRunId, []);
     const userMessage: ChatMessage = {
-      id: createMessageId(),
+      id: createWebMessageId(),
       sessionId: input.sessionId,
       role: "user",
       content: input.content.trim(),
@@ -1323,7 +1123,7 @@ export const webAgentClient: AgentService = {
       executionRunId,
     };
     const assistantMessage: ChatMessage = {
-      id: createMessageId(),
+      id: createWebMessageId(),
       sessionId: input.sessionId,
       role: "assistant",
       speakerSeatId: firstSpeakerSeatId,
@@ -1334,7 +1134,7 @@ export const webAgentClient: AgentService = {
       sessionSequence: nextSequence + 1,
       executionRunId,
     };
-    setSessionMessages(input.sessionId, [...existingMessages, userMessage, assistantMessage]);
+    setWebSessionMessages(input.sessionId, [...existingMessages, userMessage, assistantMessage]);
     updateWebSession(input.sessionId, {
       lifecycleState: "running",
       activeExecutionRunId: executionRunId,
@@ -1355,10 +1155,10 @@ export const webAgentClient: AgentService = {
     const automaticCompactionEnabled = personalizationSettings.automaticContextCompactionEnabled;
     const timeoutIds: Array<ReturnType<typeof setTimeout>> = [];
     const startTimeoutId = setTimeout(() => {
-      emitChatEvent({ type: "started", sessionId: input.sessionId, messageId: assistantMessage.id });
+      emitWebChatEvent({ type: "started", sessionId: input.sessionId, messageId: assistantMessage.id });
     }, 80);
     timeoutIds.push(startTimeoutId);
-    const historyCharacterCount = getSessionMessages(input.sessionId).reduce(
+    const historyCharacterCount = getWebSessionMessages(input.sessionId).reduce(
       (total, message) => total + message.content.length,
       0,
     );
@@ -1369,7 +1169,7 @@ export const webAgentClient: AgentService = {
       );
       const savedCharacters = Math.max(0, historyCharacterCount - afterCharacters);
       const compactionTimeoutId = setTimeout(() => {
-        publishChatEvent({
+        publishWebChatEvent({
           type: "rich_block",
           sessionId: input.sessionId,
           messageId: assistantMessage.id,
@@ -1424,7 +1224,7 @@ export const webAgentClient: AgentService = {
             `Extracted from a long conversation: "${userMessage.content.slice(0, 60)}"`,
             "automatic",
           );
-          publishChatEvent({
+          publishWebChatEvent({
             type: "rich_block",
             sessionId: input.sessionId,
             messageId: assistantMessage.id,
@@ -1454,7 +1254,7 @@ export const webAgentClient: AgentService = {
           `Extracted from a CLI session: "${userMessage.content.slice(0, 60)}"`,
           "automatic",
         );
-        publishChatEvent({
+        publishWebChatEvent({
           type: "rich_block",
           sessionId: input.sessionId,
           messageId: assistantMessage.id,
@@ -1479,7 +1279,7 @@ export const webAgentClient: AgentService = {
       // source being configured — memory has to work on an installation without retrieval.
       const injected = simulateMemoryIndexInjection();
       const memoryInjectionTimeoutId = setTimeout(() => {
-        publishChatEvent({
+        publishWebChatEvent({
           type: "rich_block",
           sessionId: input.sessionId,
           messageId: assistantMessage.id,
@@ -1516,7 +1316,7 @@ export const webAgentClient: AgentService = {
       .map((skill) => skill.metadata.name);
     if (boundSkillNames.length > 0) {
       const skillTimeoutId = setTimeout(() => {
-        publishChatEvent({
+        publishWebChatEvent({
           type: "rich_block",
           sessionId: input.sessionId,
           messageId: assistantMessage.id,
@@ -1534,13 +1334,13 @@ export const webAgentClient: AgentService = {
     }
     tokens.forEach((contentDelta, index) => {
       const timeoutId = setTimeout(() => {
-        publishChatEvent({ type: "token", sessionId: input.sessionId, messageId: assistantMessage.id, contentDelta });
+        publishWebChatEvent({ type: "token", sessionId: input.sessionId, messageId: assistantMessage.id, contentDelta });
       }, 240 + index * 90);
       timeoutIds.push(timeoutId);
     });
     if (config.thinking) {
       const thinkingTimeoutId = setTimeout(() => {
-        publishChatEvent({
+        publishWebChatEvent({
           type: "thinking",
           sessionId: input.sessionId,
           messageId: assistantMessage.id,
@@ -1550,7 +1350,7 @@ export const webAgentClient: AgentService = {
       timeoutIds.push(thinkingTimeoutId);
     }
     const toolUseTimeoutId = setTimeout(() => {
-      publishChatEvent({
+      publishWebChatEvent({
         type: "tool_use",
         sessionId: input.sessionId,
         messageId: assistantMessage.id,
@@ -1572,7 +1372,7 @@ export const webAgentClient: AgentService = {
       const callId = `web-tool-approval-${assistantMessage.id}`;
       const approvalTimeoutId = setTimeout(() => {
         if (isTrusted) {
-          publishChatEvent({
+          publishWebChatEvent({
             type: "tool_use",
             sessionId: input.sessionId,
             messageId: assistantMessage.id,
@@ -1596,7 +1396,7 @@ export const webAgentClient: AgentService = {
           riskLevel: "L2",
           createdAt: new Date().toISOString(),
         });
-        publishChatEvent({
+        publishWebChatEvent({
           type: "tool_use",
           sessionId: input.sessionId,
           messageId: assistantMessage.id,
@@ -1614,7 +1414,7 @@ export const webAgentClient: AgentService = {
       // one unconditionally would leave every other mock conversation waiting on a card.
       if (input.content.includes(WEB_MOCK_QUESTION_TRIGGER)) {
         const questionTimeoutId = setTimeout(() => {
-          publishChatEvent({
+          publishWebChatEvent({
             type: "tool_use",
             sessionId: input.sessionId,
             messageId: assistantMessage.id,
@@ -1634,7 +1434,7 @@ export const webAgentClient: AgentService = {
       // Request to leave plan mode (`add-agent-plan-exit-request`).
       if (input.content.includes(WEB_MOCK_PLAN_EXIT_TRIGGER)) {
         const planExitTimeoutId = setTimeout(() => {
-          publishChatEvent({
+          publishWebChatEvent({
             type: "tool_use",
             sessionId: input.sessionId,
             messageId: assistantMessage.id,
@@ -1654,7 +1454,7 @@ export const webAgentClient: AgentService = {
       // `AutoApprove`, so it follows `remember`'s no-approval path rather than `shell`'s gated
       // one. Output is a fixed fake result — the Web runtime never touches a real filesystem.
       const grepTimeoutId = setTimeout(() => {
-        publishChatEvent({
+        publishWebChatEvent({
           type: "tool_use",
           sessionId: input.sessionId,
           messageId: assistantMessage.id,
@@ -1680,7 +1480,7 @@ export const webAgentClient: AgentService = {
             `User said: "${userMessage.content.slice(0, 60)}"`,
             "explicit",
           );
-          publishChatEvent({
+          publishWebChatEvent({
             type: "tool_use",
             sessionId: input.sessionId,
             messageId: assistantMessage.id,
@@ -1716,7 +1516,7 @@ export const webAgentClient: AgentService = {
       });
       const mcpApprovalTimeoutId = setTimeout(() => {
         if (!mcpSimulation.success) {
-          publishChatEvent({
+          publishWebChatEvent({
             type: "tool_use",
             sessionId: input.sessionId,
             messageId: assistantMessage.id,
@@ -1736,7 +1536,7 @@ export const webAgentClient: AgentService = {
           riskLevel: "L2",
           createdAt: new Date().toISOString(),
         });
-        publishChatEvent({
+        publishWebChatEvent({
           type: "tool_use",
           sessionId: input.sessionId,
           messageId: assistantMessage.id,
@@ -1746,7 +1546,7 @@ export const webAgentClient: AgentService = {
       timeoutIds.push(mcpApprovalTimeoutId);
     }
     const richCardTimeoutId = setTimeout(() => {
-      publishChatEvent({
+      publishWebChatEvent({
         type: "rich_block",
         sessionId: input.sessionId,
         messageId: assistantMessage.id,
@@ -1766,7 +1566,7 @@ export const webAgentClient: AgentService = {
     }, 260);
     timeoutIds.push(richCardTimeoutId);
     const richChecklistTimeoutId = setTimeout(() => {
-      publishChatEvent({
+      publishWebChatEvent({
         type: "rich_block",
         sessionId: input.sessionId,
         messageId: assistantMessage.id,
@@ -1784,89 +1584,20 @@ export const webAgentClient: AgentService = {
     }, 300);
     timeoutIds.push(richChecklistTimeoutId);
     const completeTimeoutId = setTimeout(() => {
-      publishChatEvent({
+      publishWebChatEvent({
         type: "completed",
         sessionId: input.sessionId,
         messageId: assistantMessage.id,
       });
     }, 320 + tokens.length * 90);
     timeoutIds.push(completeTimeoutId);
-    activeStreams.set(input.sessionId, { messageId: assistantMessage.id, timeoutIds });
+    setWebActiveStream(input.sessionId, { messageId: assistantMessage.id, timeoutIds });
     return assistantMessage;
   },
 
-  async listMessages(input) {
-    findWebSession(input.sessionId);
-    const limit = input.limit ?? 50;
-    const messages = getSessionMessages(input.sessionId);
-    const endIndex = input.beforeId
-      ? messages.findIndex((message) => message.id === input.beforeId)
-      : messages.length;
-    const boundedEndIndex = endIndex === -1 ? messages.length : endIndex;
-    return messages.slice(Math.max(0, boundedEndIndex - limit), boundedEndIndex);
-  },
-
-  async saveMessageFeedback(input) {
-    const message = Array.from(messagesBySession.values())
-      .flat()
-      .find((candidate) => candidate.id === input.messageId);
-    if (!message || message.role !== "assistant" || message.status !== "completed") {
-      throw new Error("message-not-eligible");
-    }
-    const currentRevision = message.feedback?.revision ?? 0;
-    if (currentRevision !== input.expectedRevision) {
-      throw new Error(`feedback-conflict:${currentRevision}`);
-    }
-    if (input.state === "corrected" && !input.correctionNote?.trim()) {
-      throw new Error("invalid-feedback");
-    }
-    if (input.state === null) {
-      message.feedback = { state: null, revision: currentRevision + 1 };
-      return message.feedback;
-    }
-    message.feedback = {
-      state: input.state,
-      revision: currentRevision + 1,
-      ...(input.correctionNote?.trim()
-        ? { correctionNote: input.correctionNote.trim().slice(0, 1_000) }
-        : {}),
-    };
-    return message.feedback;
-  },
   ...webUsageStatisticsClient,
-
-  /**
-   * The Web runtime simulates the round trip: nothing is actually blocked on the answer, so this
-   * reports delivery only when a matching tool block is still showing `awaiting_input` and marks
-   * it completed with the answer, rather than claiming a real generation resumed.
-   */
-  async resolveAgentQuestion(sessionId: string, callId: string, answer: string) {
-    return resolveSimulatedQuestion(sessionId, callId, answer);
-  },
-
-  async resolvePlanExit(sessionId: string, callId: string, approved: boolean) {
-    return resolveSimulatedPlanExit(sessionId, callId, approved);
-  },
-
-  async stopGeneration(sessionId: string) {
-    findWebSession(sessionId);
-    if (!cancelActiveStream(sessionId)) return;
-    updateWebSession(sessionId, { lifecycleState: "stopped" });
-  },
+  ...webChatClient,
   ...webAgentTerminalClient,
-
-  async subscribeMessageEvents(sessionId, handler) {
-    const subscribers = subscribersBySession.get(sessionId) ?? new Set<(event: ChatStreamEvent) => void>();
-    subscribers.add(handler);
-    subscribersBySession.set(sessionId, subscribers);
-    return () => {
-      const currentSubscribers = subscribersBySession.get(sessionId);
-      currentSubscribers?.delete(handler);
-      if (currentSubscribers?.size === 0) {
-        subscribersBySession.delete(sessionId);
-      }
-    };
-  },
 
   async subscribeSessionEvents(handler) {
     return subscribeWebSessionStateEvents(handler);

--- a/src/services/web-agent-client.ts
+++ b/src/services/web-agent-client.ts
@@ -9,14 +9,8 @@ import {
 } from "./web-permissions-mock-state";
 import type {
   UpdateSessionSeatsInput,
-  ExportSessionInput,
-  InteractionMode,
   Session,
   SessionSeat,
-  SessionExportResult,
-  SessionSearchInput,
-  SessionSearchResult,
-  SessionDetails,
   ImSessionConnector,
 } from "../types/agent";
 import { findWebSshConnection } from "./web-ssh-connection-client";
@@ -24,8 +18,6 @@ import { readWebAppSettings } from "./web-settings-client";
 import { defaultSessionTitleFromPath } from "../lib/session-path";
 import { snapshotSeat } from "./seat-presentation";
 import type { ChatMessage } from "../types/chat";
-import type { AgentRun } from "../types/agent-run";
-import type { AgentRunnerDescriptor, AgentRunnerSelection } from "../types/agent-runner";
 import { webEvaluationClient } from "./web-evaluation-client";
 import { webPromptHookClient } from "./web-prompt-hook-client";
 import { webApiAgentClient } from "./web-api-agent-client";
@@ -74,7 +66,7 @@ import { webAgentTerminalClient } from "./web-agent-terminal-client";
 import { webUsageStatisticsClient } from "./web-usage-statistics-client";
 import { webMissionControlClient } from "./web-mission-control-client";
 import { webLoopClient } from "./web-loop-client";
-import { isWebLoopRoleSession, listWebLoopDefinitions } from "./web-loop-state";
+import { listWebLoopDefinitions } from "./web-loop-state";
 
 export {
   resetWebLoopsForTest,
@@ -146,10 +138,11 @@ import {
   replaceWebSessions,
   setWebActiveSessionId,
   setWebWorkflowState,
-  sortWebSessions,
   subscribeWebSessionStateEvents,
   updateWebSession,
 } from "./web-session-state";
+import { webSessionQueryClient } from "./web-session-query-client";
+import { selectWebRunner, webRunRunner } from "./web-agent-runner";
 import type { Skill } from "../types/skill";
 import {
   listWebSkillApiAgentBindings,
@@ -202,147 +195,7 @@ export function seedWebImSessionForTest(connector: ImSessionConnector): Session 
 }
 
 
-function searchText(value: string | null | undefined, query: string) {
-  return (value ?? "").toLocaleLowerCase().includes(query.toLocaleLowerCase());
-}
-
-function sessionSearchMatches(session: Session, query: string): SessionSearchResult | null {
-  const matches: SessionSearchResult["matches"] = [];
-  if (searchText(session.title, query)) {
-    matches.push({ kind: "title", excerpt: session.title });
-  }
-  const remoteWorkspace = session.remoteWorkspace;
-  const projectMatch = [
-    session.folder,
-    session.projectPath,
-    session.worktreePath,
-    session.worktreeName,
-    session.worktreeBranch,
-    remoteWorkspace?.host,
-    remoteWorkspace?.user,
-    remoteWorkspace?.path,
-    remoteWorkspace?.displayName,
-    remoteWorkspace?.uri,
-  ].find((value) => searchText(value, query));
-  if (projectMatch) {
-    matches.push({ kind: "project", excerpt: projectMatch });
-  }
-  const messageMatch = getWebSessionMessages(session.id).find((message) => searchText(message.content, query));
-  if (messageMatch) {
-    matches.push({
-      kind: "message",
-      excerpt: messageMatch.content.slice(0, 160),
-      messageId: messageMatch.id,
-    });
-  }
-  return matches.length > 0 ? { session: { ...session }, matches } : null;
-}
-
-function serializeWebSessionExport(input: ExportSessionInput): SessionExportResult {
-  const session = findWebSession(input.sessionId);
-  const payload = {
-    version: 1,
-    exportedAt: nowIso(),
-    session,
-    messages: getWebSessionMessages(session.id),
-  };
-  const content =
-    input.format === "json"
-      ? JSON.stringify(payload, null, 2)
-      : [`# ${session.title}`, "", `- ID: \`${session.id}\``, `- Agent: \`${session.agentId}\``, "", "## Messages", ""]
-          .concat(
-            payload.messages.flatMap((message) => [
-              `### ${message.role.toUpperCase()} - \`${message.status}\``,
-              "",
-              message.content,
-              "",
-            ]),
-          )
-          .join("\n");
-  return {
-    status: input.destinationDirectory === null ? "cancelled" : "exported",
-    path: input.destinationDirectory ? `${input.destinationDirectory}\\${session.id}.${input.format === "json" ? "json" : "md"}` : null,
-    content,
-  };
-}
-
 const webCodeReviewClient = createWebCodeReviewClient(webSessionWorkspaceClient);
-
-function webRunnerDescriptors(sessionId: string, agentId: string): AgentRunnerDescriptor[] {
-  const session = findWebSession(sessionId);
-  if (session.agentId !== agentId) throw new Error("runner_invalid_selection");
-  const descriptors: AgentRunnerDescriptor[] = [{
-    selection: { kind: "local" },
-    label: "Local",
-    hostLabel: "This device",
-    available: true,
-    unavailableReason: null,
-    simulated: true,
-    capabilities: { interactiveInput: true, pty: false, cancellation: true, inspection: true, recovery: "none" },
-  }];
-  const connectionId = session.remoteSshConnectionId;
-  const revision = session.remoteSshConnectionRevision;
-  if (connectionId && revision && session.remoteWorkspace) {
-    const connection = findWebSshConnection(connectionId);
-    const credentialConfigured = connection?.authMode === "password" ? connection.hasPassword : Boolean(connection?.keyPath);
-    const available = Boolean(connection
-      && connection.revision === revision
-      && connection.host === session.remoteWorkspace.host
-      && connection.port === (session.remoteWorkspace.port ?? 22)
-      && connection.user === session.remoteWorkspace.user
-      && connection.hostTrust
-      && credentialConfigured);
-    descriptors.push({
-      selection: { kind: "ssh", targetId: connectionId, targetRevision: revision },
-      label: session.remoteWorkspace.displayName,
-      hostLabel: session.remoteWorkspace.host,
-      available,
-      unavailableReason: available ? null : "ssh_authority_unavailable",
-      simulated: true,
-      capabilities: { interactiveInput: true, pty: true, cancellation: true, inspection: true, recovery: "inspect_only" },
-    });
-  }
-  descriptors.push(
-    {
-      selection: { kind: "docker" }, label: "Docker / Sandbox", hostLabel: null,
-      available: false, unavailableReason: "runner_not_implemented", simulated: true,
-      capabilities: { interactiveInput: false, pty: false, cancellation: false, inspection: false, recovery: "none" },
-    },
-    {
-      selection: { kind: "cloud" }, label: "Cloud", hostLabel: null,
-      available: false, unavailableReason: "runner_not_implemented", simulated: true,
-      capabilities: { interactiveInput: false, pty: false, cancellation: false, inspection: false, recovery: "none" },
-    },
-  );
-  return descriptors;
-}
-
-function selectWebRunner(sessionId: string, agentId: string, requested?: AgentRunnerSelection): AgentRunnerDescriptor {
-  const selection = requested ?? { kind: "local" };
-  const descriptor = webRunnerDescriptors(sessionId, agentId).find((candidate) =>
-    candidate.selection.kind === selection.kind
-    && (candidate.selection.targetId ?? null) === (selection.targetId ?? null)
-    && (candidate.selection.targetRevision ?? null) === (selection.targetRevision ?? null));
-  if (!descriptor) throw new Error("runner_invalid_selection");
-  if (!descriptor.available) throw new Error("runner_unsupported_capability");
-  return descriptor;
-}
-
-function webRunRunner(descriptor: AgentRunnerDescriptor): NonNullable<AgentRun["runner"]> {
-  const targetId = descriptor.selection.targetId ?? "local";
-  const targetRevision = descriptor.selection.targetRevision ?? null;
-  return {
-    kind: descriptor.selection.kind as "local" | "ssh",
-    targetId,
-    targetRevision,
-    label: descriptor.label,
-    hostLabel: descriptor.hostLabel,
-    recovery: descriptor.capabilities.recovery,
-    capabilityWitness: `web-simulated:${descriptor.selection.kind}`,
-    authorityWitness: `web-simulated:${targetId}:${targetRevision ?? "none"}`,
-    recoveryReference: null,
-  };
-}
 
 export const webAgentClient: AgentService = {
   ...webEvaluationClient,
@@ -444,82 +297,10 @@ export const webAgentClient: AgentService = {
   },
   ...webExpertRoleClient,
 
-  async getWorkflowState() {
-    return getWebWorkflowState();
-  },
-
-  async selectAgent(agentId: string, interactionMode: InteractionMode) {
-    const agent = mockAgents.find((candidate) => candidate.id === agentId);
-    if (!agent) {
-      throw new Error(`Agent not found: ${agentId}`);
-    }
-    if (!agent.supportedInteractionModes.includes(interactionMode)) {
-      throw new Error(`${agent.displayName} does not support ${interactionMode}.`);
-    }
-    setWebWorkflowState({
-      ...getWebWorkflowState(),
-      activeAgentId: agentId,
-      activeInteractionMode: interactionMode,
-      lifecycleState: "idle",
-    });
-    return getWebWorkflowState();
-  },
-
-  async launchActiveWorkflow() {
-    setWebWorkflowState({
-      ...getWebWorkflowState(),
-      lifecycleState: getWebWorkflowState().activeAgentId ? "running" : "failed",
-    });
-    return {
-      workflow: getWebWorkflowState(),
-      message: getWebWorkflowState().activeAgentId
-        ? "Web preview session marked as running."
-        : "Select an agent before launching.",
-    };
-  },
-
-  async getSessionDetails(): Promise<SessionDetails> {
-    const adapter = getWebWorkflowState().activeInteractionMode ?? "none";
-    return {
-      agentId: getWebWorkflowState().activeAgentId,
-      interactionMode: getWebWorkflowState().activeInteractionMode,
-      lifecycleState: getWebWorkflowState().lifecycleState,
-      adapter,
-      details: {
-        runtime: "web",
-        storage: "in-memory",
-      },
-    };
-  },
-
-  async listSessions() {
-    return sortWebSessions(listWebSessions().filter((session) => !session.archived && !isWebLoopRoleSession(session.id)));
-  },
-
-  async listArchivedSessions() {
-    return sortWebSessions(listWebSessions().filter((session) => session.archived && !isWebLoopRoleSession(session.id)));
-  },
-
-  async searchSessions(input: SessionSearchInput) {
-    const query = input.query.trim();
-    if (!query) return [];
-    return sortWebSessions(listWebSessions().filter((session) => !isWebLoopRoleSession(session.id)))
-      .map((session) => sessionSearchMatches(session, query))
-      .filter((result): result is SessionSearchResult => result !== null)
-      .slice(0, input.limit ?? 50);
-  },
-
-  async getSession(sessionId: string) {
-    return findWebSession(sessionId);
-  },
+  ...webSessionQueryClient,
 
   ...webSessionRecoveryClient,
 
-  async getActiveSession() {
-    const sessionId = getWebActiveSessionId();
-    if (!sessionId) return null;
-    return listWebSessions().find((session) => session.id === sessionId) ?? null;
-  },
   ...webSessionCategoryClient,
   ...webLoopClient,
 
@@ -779,14 +560,6 @@ export const webAgentClient: AgentService = {
 
   async unarchiveSession(sessionId: string) {
     return updateWebSession(sessionId, { archived: false });
-  },
-
-  async exportSession(input: ExportSessionInput) {
-    return serializeWebSessionExport(input);
-  },
-
-  async listAgentRunners(sessionId, agentId) {
-    return structuredClone(webRunnerDescriptors(sessionId, agentId));
   },
 
   async sendMessage(input) {

--- a/src/services/web-agent-memory-client.ts
+++ b/src/services/web-agent-memory-client.ts
@@ -1,0 +1,20 @@
+import type { AgentMemoryService } from "./agent-memory-service";
+import {
+  clearWebAgentMemories,
+  deleteWebAgentMemory,
+  listWebAgentMemories,
+} from "./web-agent-memory-state";
+
+export const webAgentMemoryClient: AgentMemoryService = {
+  async listAllMemories() {
+    return listWebAgentMemories();
+  },
+
+  async deleteAgentMemory(memoryId: string) {
+    deleteWebAgentMemory(memoryId);
+  },
+
+  async resetAllMemories() {
+    clearWebAgentMemories();
+  },
+};

--- a/src/services/web-agent-memory-state.ts
+++ b/src/services/web-agent-memory-state.ts
@@ -1,0 +1,108 @@
+import type { AgentMemory, AgentMemoryType } from "../types/agent";
+import { nowIso } from "./web-mock-clock";
+
+/** Mock cross-session memories (`add-agent-cross-session-memory`, extended to CLI-wrapped agents
+ * by `add-cli-memory-support`) — a single host-level pool shared by every agent kind, matching
+ * the real backend's shared-pool model. Starts empty; real memories only ever come from a
+ * `remember` tool call or extraction, both simulated in `sendMessage`.
+ *
+ * Owned here and never exported. An exported mutable binding re-imported from two modules gives
+ * two divergent copies of the mock world, which surfaces as one UI panel showing stale data while
+ * another shows fresh. Callers reach the pool through the accessors below. */
+let webAgentMemories: AgentMemory[] = [];
+let nextAgentMemoryId = 1;
+
+/** Mirrors the native store's deterministic derivation: a writer that supplies no name gets one
+ * from the content, and only ASCII survives slugging, so non-Latin content falls back to the
+ * sequence number rather than producing an empty stem. */
+function deriveMemoryName(content: string, sequence: number): string {
+  const slug = content
+    .split(/[^a-zA-Z0-9]+/u)
+    .filter(Boolean)
+    .slice(0, 6)
+    .join("-")
+    .toLowerCase();
+  return slug || `memory-${sequence}`;
+}
+
+/** Mirrors the native bounds so the mock truncates where the desktop runtime would. */
+const WEB_MEMORY_INDEX_LINE_CAP = 200;
+
+/** Mirrors the native selection bound. */
+const WEB_MEMORY_SELECTION_CAP = 5;
+
+/** Returns the live array, matching what a direct read of the binding returned. */
+export function listWebAgentMemories(): AgentMemory[] {
+  return webAgentMemories;
+}
+
+export function deleteWebAgentMemory(memoryId: string): void {
+  webAgentMemories = webAgentMemories.filter((memory) => memory.id !== memoryId);
+}
+
+export function clearWebAgentMemories(): void {
+  webAgentMemories = [];
+}
+
+/**
+ * Simulates one generation's memory injection: an index over the whole pool, plus the handful of
+ * bodies a selection would have read in full.
+ *
+ * Deterministic rather than model-driven — the Web runtime must reproduce the desktop's observable
+ * shape without issuing a provider request, so it stands in for the selector with recency, which
+ * is the same ordering the index already uses.
+ */
+export function simulateWebMemoryIndexInjection(): { indexed: number; selected: AgentMemory[] } {
+  const indexed = Math.min(webAgentMemories.length, WEB_MEMORY_INDEX_LINE_CAP);
+  return {
+    indexed,
+    selected: webAgentMemories.slice(0, Math.min(indexed, WEB_MEMORY_SELECTION_CAP)),
+  };
+}
+
+function disambiguateMemoryName(base: string): string {
+  if (!webAgentMemories.some((memory) => memory.name === base)) {
+    return base;
+  }
+  let suffix = 2;
+  while (webAgentMemories.some((memory) => memory.name === `${base}-${suffix}`)) {
+    suffix += 1;
+  }
+  return `${base}-${suffix}`;
+}
+
+export function createWebAgentMemory(
+  agentId: string,
+  folder: string | null,
+  content: string,
+  source: AgentMemory["source"],
+  metadata: { name?: string; description?: string; memoryType?: AgentMemoryType | null } = {},
+): AgentMemory {
+  // An explicit name addresses an existing memory, so it is used as-is and replaces. A derived one
+  // must not: two agents recording the same fact are two memories in the shared pool, so the
+  // native store's collision suffix is mirrored here rather than silently merging them.
+  const name = metadata.name ?? disambiguateMemoryName(deriveMemoryName(content, nextAgentMemoryId));
+  const memory: AgentMemory = {
+    // The native store's identity is the file path, so the mock mirrors that shape rather than
+    // inventing an opaque id the management view would have to special-case.
+    id: `${name}.md`,
+    agentId,
+    folder,
+    name,
+    description: metadata.description ?? content.split("\n")[0] ?? content,
+    memoryType: metadata.memoryType ?? null,
+    content,
+    source,
+    createdAt: nowIso(),
+  };
+  nextAgentMemoryId += 1;
+  // Saving under an existing name replaces that memory, matching the native store's update path.
+  webAgentMemories = [memory, ...webAgentMemories.filter((existing) => existing.name !== name)];
+  return memory;
+}
+
+/** `add-cli-memory-support`: the shared memory pool is no longer isolated per agent id, so tests
+ * that seed memories can leak into later tests within the same file unless explicitly cleared. */
+export function resetWebAgentMemoriesForTest() {
+  webAgentMemories = [];
+}

--- a/src/services/web-agent-runner.ts
+++ b/src/services/web-agent-runner.ts
@@ -1,0 +1,80 @@
+import type { AgentRun } from "../types/agent-run";
+import type { AgentRunnerDescriptor, AgentRunnerSelection } from "../types/agent-runner";
+import { findWebSshConnection } from "./web-ssh-connection-client";
+import { findWebSession } from "./web-session-state";
+
+export function webRunnerDescriptors(sessionId: string, agentId: string): AgentRunnerDescriptor[] {
+  const session = findWebSession(sessionId);
+  if (session.agentId !== agentId) throw new Error("runner_invalid_selection");
+  const descriptors: AgentRunnerDescriptor[] = [{
+    selection: { kind: "local" },
+    label: "Local",
+    hostLabel: "This device",
+    available: true,
+    unavailableReason: null,
+    simulated: true,
+    capabilities: { interactiveInput: true, pty: false, cancellation: true, inspection: true, recovery: "none" },
+  }];
+  const connectionId = session.remoteSshConnectionId;
+  const revision = session.remoteSshConnectionRevision;
+  if (connectionId && revision && session.remoteWorkspace) {
+    const connection = findWebSshConnection(connectionId);
+    const credentialConfigured = connection?.authMode === "password" ? connection.hasPassword : Boolean(connection?.keyPath);
+    const available = Boolean(connection
+      && connection.revision === revision
+      && connection.host === session.remoteWorkspace.host
+      && connection.port === (session.remoteWorkspace.port ?? 22)
+      && connection.user === session.remoteWorkspace.user
+      && connection.hostTrust
+      && credentialConfigured);
+    descriptors.push({
+      selection: { kind: "ssh", targetId: connectionId, targetRevision: revision },
+      label: session.remoteWorkspace.displayName,
+      hostLabel: session.remoteWorkspace.host,
+      available,
+      unavailableReason: available ? null : "ssh_authority_unavailable",
+      simulated: true,
+      capabilities: { interactiveInput: true, pty: true, cancellation: true, inspection: true, recovery: "inspect_only" },
+    });
+  }
+  descriptors.push(
+    {
+      selection: { kind: "docker" }, label: "Docker / Sandbox", hostLabel: null,
+      available: false, unavailableReason: "runner_not_implemented", simulated: true,
+      capabilities: { interactiveInput: false, pty: false, cancellation: false, inspection: false, recovery: "none" },
+    },
+    {
+      selection: { kind: "cloud" }, label: "Cloud", hostLabel: null,
+      available: false, unavailableReason: "runner_not_implemented", simulated: true,
+      capabilities: { interactiveInput: false, pty: false, cancellation: false, inspection: false, recovery: "none" },
+    },
+  );
+  return descriptors;
+}
+
+export function selectWebRunner(sessionId: string, agentId: string, requested?: AgentRunnerSelection): AgentRunnerDescriptor {
+  const selection = requested ?? { kind: "local" };
+  const descriptor = webRunnerDescriptors(sessionId, agentId).find((candidate) =>
+    candidate.selection.kind === selection.kind
+    && (candidate.selection.targetId ?? null) === (selection.targetId ?? null)
+    && (candidate.selection.targetRevision ?? null) === (selection.targetRevision ?? null));
+  if (!descriptor) throw new Error("runner_invalid_selection");
+  if (!descriptor.available) throw new Error("runner_unsupported_capability");
+  return descriptor;
+}
+
+export function webRunRunner(descriptor: AgentRunnerDescriptor): NonNullable<AgentRun["runner"]> {
+  const targetId = descriptor.selection.targetId ?? "local";
+  const targetRevision = descriptor.selection.targetRevision ?? null;
+  return {
+    kind: descriptor.selection.kind as "local" | "ssh",
+    targetId,
+    targetRevision,
+    label: descriptor.label,
+    hostLabel: descriptor.hostLabel,
+    recovery: descriptor.capabilities.recovery,
+    capabilityWitness: `web-simulated:${descriptor.selection.kind}`,
+    authorityWitness: `web-simulated:${targetId}:${targetRevision ?? "none"}`,
+    recoveryReference: null,
+  };
+}

--- a/src/services/web-chat-client.ts
+++ b/src/services/web-chat-client.ts
@@ -1,0 +1,162 @@
+import type { ChatMessagingService } from "./chat-messaging-service";
+import { webPendingApprovals } from "./web-permissions-mock-state";
+import { findWebSession, updateWebSession } from "./web-session-state";
+import {
+  cancelWebActiveStream,
+  getWebSessionMessages,
+  listWebSessionMessageBuckets,
+  publishWebChatEvent,
+  subscribeWebChatEvents,
+} from "./web-chat-state";
+
+/**
+ * Resolves a simulated tool call awaiting approval and publishes the resulting `tool_use` event
+ * — the same behavior `resolveToolApproval` used to provide directly on this client, extracted
+ * to a plain export so `web-permissions-client.ts` can call it (`permissions-approval`'s
+ * `resolvePendingApproval` is the new frontend entry point; this is its Web/mock backing).
+ */
+export function resolveWebMockToolApproval(sessionId: string, callId: string, approved: boolean): boolean {
+  findWebSession(sessionId);
+  const pending = webPendingApprovals.get(callId);
+  if (!pending || pending.sessionId !== sessionId) return false;
+  webPendingApprovals.delete(callId);
+  publishWebChatEvent({
+    type: "tool_use",
+    sessionId,
+    messageId: pending.messageId,
+    toolUse: {
+      id: callId,
+      name: pending.toolName,
+      input: pending.input ?? { command: "echo mock" },
+      output: approved ? pending.output ?? "mock\n" : "Denied by user.",
+      status: approved ? "completed" : "failed",
+    },
+  });
+  return true;
+}
+
+/**
+ * Marker that makes the Web/mock runtime simulate a clarification round trip. Web/mock has no
+ * model deciding when to ask, so the trigger stands in for that decision.
+ */
+export const WEB_MOCK_QUESTION_TRIGGER = "[ask-me]";
+
+/**
+ * Marker that makes the Web/mock runtime simulate a request to leave plan mode. Same reason as the
+ * question trigger: the request blocks until decided, so emitting one every turn would leave every
+ * other mock conversation waiting on a card.
+ */
+export const WEB_MOCK_PLAN_EXIT_TRIGGER = "[plan-done]";
+
+/**
+ * Web/mock backing for `resolveAgentQuestion`. Unlike the desktop runtime there is no blocked
+ * generation to resume, so "delivered" means only that a tool block in this session was still
+ * showing `awaiting_input` — the mock reports the round trip as simulated rather than implying a
+ * real wait ended.
+ */
+function resolveSimulatedQuestion(sessionId: string, callId: string, answer: string): boolean {
+  findWebSession(sessionId);
+  const message = getWebSessionMessages(sessionId).find((entry) =>
+    entry.toolUse?.some((tool) => tool.id === callId && tool.status === "awaiting_input"),
+  );
+  const pending = message?.toolUse?.find((tool) => tool.id === callId);
+  if (!message || !pending) return false;
+  publishWebChatEvent({
+    type: "tool_use",
+    sessionId,
+    messageId: message.id,
+    toolUse: { ...pending, output: answer, status: "completed" },
+  });
+  return true;
+}
+
+/**
+ * Web/mock backing for `resolvePlanExit`. Same simulation as an answer: nothing is blocked, so
+ * "delivered" means a matching tool block was still showing `awaiting_input`. The recorded output
+ * differs by decision so the mock cannot make a decline look like an approval.
+ */
+function resolveSimulatedPlanExit(sessionId: string, callId: string, approved: boolean): boolean {
+  findWebSession(sessionId);
+  const message = getWebSessionMessages(sessionId).find((entry) =>
+    entry.toolUse?.some((tool) => tool.id === callId && tool.status === "awaiting_input"),
+  );
+  const pending = message?.toolUse?.find((tool) => tool.id === callId);
+  if (!message || !pending) return false;
+  publishWebChatEvent({
+    type: "tool_use",
+    sessionId,
+    messageId: message.id,
+    toolUse: {
+      ...pending,
+      output: approved
+        ? "The user approved your plan and this session has left plan mode."
+        : "The user did not approve this plan. The session is still in plan mode.",
+      status: approved ? "completed" : "failed",
+    },
+  });
+  return true;
+}
+
+export const webChatClient: ChatMessagingService = {
+  async listMessages(input) {
+    findWebSession(input.sessionId);
+    const limit = input.limit ?? 50;
+    const messages = getWebSessionMessages(input.sessionId);
+    const endIndex = input.beforeId
+      ? messages.findIndex((message) => message.id === input.beforeId)
+      : messages.length;
+    const boundedEndIndex = endIndex === -1 ? messages.length : endIndex;
+    return messages.slice(Math.max(0, boundedEndIndex - limit), boundedEndIndex);
+  },
+
+  async saveMessageFeedback(input) {
+    const message = listWebSessionMessageBuckets()
+      .flat()
+      .find((candidate) => candidate.id === input.messageId);
+    if (!message || message.role !== "assistant" || message.status !== "completed") {
+      throw new Error("message-not-eligible");
+    }
+    const currentRevision = message.feedback?.revision ?? 0;
+    if (currentRevision !== input.expectedRevision) {
+      throw new Error(`feedback-conflict:${currentRevision}`);
+    }
+    if (input.state === "corrected" && !input.correctionNote?.trim()) {
+      throw new Error("invalid-feedback");
+    }
+    if (input.state === null) {
+      message.feedback = { state: null, revision: currentRevision + 1 };
+      return message.feedback;
+    }
+    message.feedback = {
+      state: input.state,
+      revision: currentRevision + 1,
+      ...(input.correctionNote?.trim()
+        ? { correctionNote: input.correctionNote.trim().slice(0, 1_000) }
+        : {}),
+    };
+    return message.feedback;
+  },
+
+  /**
+   * The Web runtime simulates the round trip: nothing is actually blocked on the answer, so this
+   * reports delivery only when a matching tool block is still showing `awaiting_input` and marks
+   * it completed with the answer, rather than claiming a real generation resumed.
+   */
+  async resolveAgentQuestion(sessionId: string, callId: string, answer: string) {
+    return resolveSimulatedQuestion(sessionId, callId, answer);
+  },
+
+  async resolvePlanExit(sessionId: string, callId: string, approved: boolean) {
+    return resolveSimulatedPlanExit(sessionId, callId, approved);
+  },
+
+  async stopGeneration(sessionId: string) {
+    findWebSession(sessionId);
+    if (!cancelWebActiveStream(sessionId)) return;
+    updateWebSession(sessionId, { lifecycleState: "stopped" });
+  },
+
+  async subscribeMessageEvents(sessionId, handler) {
+    return subscribeWebChatEvents(sessionId, handler);
+  },
+};

--- a/src/services/web-chat-config-state.ts
+++ b/src/services/web-chat-config-state.ts
@@ -1,0 +1,27 @@
+import type { ChatConfig } from "../types/chat";
+import { readWebMockStorage, writeWebMockStorage } from "./web-mock-storage";
+
+const chatConfigStorageKey = "vanehub.session-chat-config.v1";
+
+// Owned here and never exported. An exported mutable binding re-imported from two modules gives
+// two divergent copies of the mock world, which surfaces as one UI panel showing stale data while
+// another shows fresh. Callers reach the configs through the accessors below.
+let memoryChatConfigs: Record<string, ChatConfig> = {};
+
+// Chat configs carry model and policy selections, never a credential, so browser storage stays
+// inside the "Honest Web/mock behavior" prohibition on persisting plaintext secrets.
+export function readWebChatConfigs(): Record<string, ChatConfig> {
+  return readWebMockStorage(chatConfigStorageKey, memoryChatConfigs);
+}
+
+export function writeWebChatConfigs(configs: Record<string, ChatConfig>) {
+  memoryChatConfigs = configs;
+  writeWebMockStorage(chatConfigStorageKey, configs);
+}
+
+/** Deleting a session drops its config, so the delete path is a step rather than a raw write. */
+export function deleteWebSessionChatConfig(sessionId: string): void {
+  const configs = { ...readWebChatConfigs() };
+  delete configs[sessionId];
+  writeWebChatConfigs(configs);
+}

--- a/src/services/web-chat-state.ts
+++ b/src/services/web-chat-state.ts
@@ -1,0 +1,173 @@
+import type { ChatMessage, ChatStreamEvent } from "../types/chat";
+import type { Session } from "../types/agent";
+import { upsertToolUse } from "./tool-use";
+import { nowIso } from "./web-mock-clock";
+import {
+  findWebAgentRun,
+  isTerminalWebRunState,
+  updateWebAgentRun,
+} from "./web-agent-run-state";
+import { findWebSession, updateWebSession } from "./web-session-state";
+
+/** One in-flight generation per session: the assistant message it is filling and every timer it scheduled. */
+export interface WebActiveStream {
+  messageId: string;
+  timeoutIds: Array<ReturnType<typeof setTimeout>>;
+}
+
+// These bindings are owned here and never exported. An exported mutable binding re-imported from
+// two modules gives two divergent copies of the mock world, which surfaces as one UI panel showing
+// stale data while another shows fresh. Callers reach the state through the accessors below, which
+// read the live binding on every call and so cannot fork.
+let nextMessageId = 1;
+const messagesBySession = new Map<string, ChatMessage[]>();
+const subscribersBySession = new Map<string, Set<(event: ChatStreamEvent) => void>>();
+const activeStreams = new Map<string, WebActiveStream>();
+
+/** Every call site read and advanced in one step, so the accessor does too. */
+export function createWebMessageId(): string {
+  const id = `web-message-${nextMessageId}`;
+  nextMessageId += 1;
+  return id;
+}
+
+/** Returns the live array, matching what a direct read of the binding returned. */
+export function getWebSessionMessages(sessionId: string): ChatMessage[] {
+  return messagesBySession.get(sessionId) ?? [];
+}
+
+export function setWebSessionMessages(sessionId: string, nextMessages: ChatMessage[]): void {
+  messagesBySession.set(sessionId, nextMessages);
+}
+
+export function deleteWebSessionMessages(sessionId: string): void {
+  messagesBySession.delete(sessionId);
+}
+
+/** Feedback is addressed by message id alone, so its lookup spans every session's bucket. */
+export function listWebSessionMessageBuckets(): ChatMessage[][] {
+  return Array.from(messagesBySession.values());
+}
+
+function upsertMessage(message: ChatMessage) {
+  const messages = getWebSessionMessages(message.sessionId);
+  const index = messages.findIndex((candidate) => candidate.id === message.id);
+  if (index === -1) {
+    setWebSessionMessages(message.sessionId, [...messages, message]);
+    return;
+  }
+  const nextMessages = [...messages];
+  nextMessages[index] = message;
+  setWebSessionMessages(message.sessionId, nextMessages);
+}
+
+export function emitWebChatEvent(event: ChatStreamEvent): void {
+  const subscribers = subscribersBySession.get(event.sessionId);
+  subscribers?.forEach((handler) => handler(event));
+}
+
+function finishWebGeneration(sessionId: string, lifecycleState: Session["lifecycleState"]) {
+  const session = findWebSession(sessionId);
+  const runId = session.activeExecutionRunId;
+  if (runId) {
+    const run = findWebAgentRun(runId);
+    if (run && !isTerminalWebRunState(run.state)) {
+      updateWebAgentRun(
+        run.id,
+        run.version,
+        lifecycleState === "idle" ? "completed" : lifecycleState === "failed" ? "failed" : "cancelled",
+      );
+    }
+  }
+  updateWebSession(sessionId, {
+    lifecycleState,
+    activeExecutionRunId: null,
+    stateRevision: session.stateRevision + 1,
+  });
+}
+
+function applyStreamEvent(event: ChatStreamEvent) {
+  // The turn status belongs to the session, not to any message.
+  if (event.type === "turn_status") return;
+  const messages = getWebSessionMessages(event.sessionId);
+  const message = messages.find((candidate) => candidate.id === event.messageId);
+  if (!message) return;
+  const timestamp = nowIso();
+  if (event.type === "token") {
+    upsertMessage({ ...message, content: `${message.content}${event.contentDelta}`, updatedAt: timestamp });
+  } else if (event.type === "thinking") {
+    upsertMessage({
+      ...message,
+      thinkingContent: `${message.thinkingContent ?? ""}${event.contentDelta}`,
+      updatedAt: timestamp,
+    });
+  } else if (event.type === "tool_use") {
+    upsertMessage({ ...message, toolUse: upsertToolUse(message.toolUse ?? [], event.toolUse), updatedAt: timestamp });
+  } else if (event.type === "rich_block") {
+    const blocks = message.richBlocks ?? [];
+    const blockIndex = blocks.findIndex((block) => block.id === event.block.id);
+    const richBlocks =
+      blockIndex === -1
+        ? [...blocks, event.block]
+        : blocks.map((block, index) => (index === blockIndex ? event.block : block));
+    upsertMessage({ ...message, richBlocks, updatedAt: timestamp });
+  } else if (event.type === "completed") {
+    upsertMessage({ ...message, status: "completed", tokenUsage: event.tokenUsage, updatedAt: timestamp });
+    activeStreams.delete(event.sessionId);
+    finishWebGeneration(event.sessionId, "idle");
+  } else if (event.type === "failed") {
+    upsertMessage({ ...message, status: "failed", error: event.error, updatedAt: timestamp });
+    activeStreams.delete(event.sessionId);
+    finishWebGeneration(event.sessionId, "failed");
+  } else if (event.type === "cancelled") {
+    upsertMessage({ ...message, status: "cancelled", updatedAt: timestamp });
+    activeStreams.delete(event.sessionId);
+    finishWebGeneration(event.sessionId, "stopped");
+  }
+}
+
+export function publishWebChatEvent(event: ChatStreamEvent): void {
+  applyStreamEvent(event);
+  emitWebChatEvent(event);
+}
+
+export function hasWebActiveStream(sessionId: string): boolean {
+  return activeStreams.has(sessionId);
+}
+
+export function setWebActiveStream(sessionId: string, stream: WebActiveStream): void {
+  activeStreams.set(sessionId, stream);
+}
+
+export function deleteWebActiveStream(sessionId: string): void {
+  activeStreams.delete(sessionId);
+}
+
+export function cancelWebActiveStream(sessionId: string): boolean {
+  const activeStream = activeStreams.get(sessionId);
+  if (!activeStream) return false;
+  activeStream.timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+  activeStreams.delete(sessionId);
+  publishWebChatEvent({ type: "cancelled", sessionId, messageId: activeStream.messageId });
+  return true;
+}
+
+export function subscribeWebChatEvents(
+  sessionId: string,
+  handler: (event: ChatStreamEvent) => void,
+): () => void {
+  const subscribers = subscribersBySession.get(sessionId) ?? new Set<(event: ChatStreamEvent) => void>();
+  subscribers.add(handler);
+  subscribersBySession.set(sessionId, subscribers);
+  return () => {
+    const currentSubscribers = subscribersBySession.get(sessionId);
+    currentSubscribers?.delete(handler);
+    if (currentSubscribers?.size === 0) {
+      subscribersBySession.delete(sessionId);
+    }
+  };
+}
+
+export function deleteWebChatSubscribers(sessionId: string): void {
+  subscribersBySession.delete(sessionId);
+}

--- a/src/services/web-loop-state.ts
+++ b/src/services/web-loop-state.ts
@@ -7,6 +7,8 @@ import type {
   LoopRun,
 } from "../types/loop";
 import { nowIso } from "./web-mock-clock";
+import { deleteWebSessionMessages } from "./web-chat-state";
+import { listWebSessions, replaceWebSessions } from "./web-session-state";
 
 // Owned here and never exported. The scheduler, the client and the composition root all reach this
 // state through the accessors below, so no importer can end up with a stale copy of it.
@@ -81,7 +83,7 @@ export function addWebLoopRoleSession(sessionId: string): void {
 }
 
 /** A snapshot, not the live Set: the composition root only reads it to filter sessions. */
-export function snapshotWebLoopRoleSessionIds(): string[] {
+function snapshotWebLoopRoleSessionIds(): string[] {
   return [...loopRoleSessionIds];
 }
 
@@ -156,15 +158,13 @@ export function createWebLoopIteration(runId: string, sequence: number, feedback
   };
 }
 
-/** Split from `resetWebLoopsForTest` so the composition root keeps the original ordering while the
- * chat message map it also clears stays where it is. */
-export function clearWebLoopTimersAndSubscribers(): void {
+export function resetWebLoopsForTest(): void {
   loopTimers.forEach((timer) => clearTimeout(timer));
   loopTimers.clear();
   loopSubscribers.clear();
-}
-
-export function clearWebLoopStateForTest(): void {
+  const roleSessionIds = snapshotWebLoopRoleSessionIds();
+  replaceWebSessions(listWebSessions().filter((session) => !roleSessionIds.includes(session.id)));
+  roleSessionIds.forEach((sessionId) => deleteWebSessionMessages(sessionId));
   loopRoleSessionIds.clear();
   loopDefinitions = [];
   loopRuns = [];

--- a/src/services/web-session-chat-config-client.ts
+++ b/src/services/web-session-chat-config-client.ts
@@ -1,0 +1,30 @@
+import type { SessionChatConfigService } from "./session-chat-config-service";
+import {
+  defaultChatConfigForSession,
+  normalizeChatConfigForSession,
+  withEffectiveExecutionPolicy,
+} from "./chat-configuration";
+import { getWebDefaultPolicyTemplate, webPrincipalTemplates } from "./web-permissions-mock-state";
+import { emitWebSessionEvent, findWebSession } from "./web-session-state";
+import { readWebChatConfigs, writeWebChatConfigs } from "./web-chat-config-state";
+
+export const webSessionChatConfigClient: SessionChatConfigService = {
+  async getSessionChatConfig(sessionId) {
+    const session = findWebSession(sessionId);
+    const stored = readWebChatConfigs()[sessionId];
+    const normalized = stored
+      ? normalizeChatConfigForSession(session, stored)
+      : defaultChatConfigForSession(session);
+    const policy = webPrincipalTemplates.get(session.agentId) ?? getWebDefaultPolicyTemplate();
+    return withEffectiveExecutionPolicy(normalized, policy);
+  },
+
+  async saveSessionChatConfig(sessionId, config) {
+    const session = findWebSession(sessionId);
+    const normalized = normalizeChatConfigForSession(session, config);
+    writeWebChatConfigs({ ...readWebChatConfigs(), [sessionId]: normalized });
+    emitWebSessionEvent({ kind: "configuration-changed", sessionId });
+    const policy = webPrincipalTemplates.get(session.agentId) ?? getWebDefaultPolicyTemplate();
+    return withEffectiveExecutionPolicy(normalized, policy);
+  },
+};

--- a/src/services/web-session-lifecycle-client.ts
+++ b/src/services/web-session-lifecycle-client.ts
@@ -1,0 +1,218 @@
+import type { Session } from "../types/agent";
+import type { SessionLifecycleService } from "./session-lifecycle-service";
+import { i18n } from "../i18n";
+import { mockAgents } from "./mock-agent-data";
+import { defaultSessionTitleFromPath } from "../lib/session-path";
+import { snapshotSeat } from "./seat-presentation";
+import { nowIso } from "./web-mock-clock";
+import { createWebMockOperation } from "./web-operation-client";
+import { findWebSshConnection } from "./web-ssh-connection-client";
+import { discoverWebSessionCodeIndex } from "./web-code-index-state";
+import { listWebExpertRoles } from "./web-expert-role-client";
+import {
+  cancelWebActiveStream,
+  deleteWebChatSubscribers,
+  deleteWebSessionMessages,
+} from "./web-chat-state";
+import { deleteWebSessionChatConfig } from "./web-chat-config-state";
+import { deleteWebRecoveryReports } from "./web-session-recovery-state";
+import {
+  inspectMockProject,
+  joinSiblingPath,
+  normalizeRemoteWorkspace,
+  resolveProjectPath,
+  upsertKnownProject,
+  upsertKnownRemoteWorkspace,
+  validateWorktreeName,
+} from "./web-known-workspace-client";
+import {
+  createWebSeatId,
+  emitWebSessionEvent,
+  findWebSession,
+  getWebActiveSessionId,
+  getWebWorkflowState,
+  listWebSessions,
+  nextWebSessionSequence,
+  prependWebSession,
+  replaceWebSessions,
+  setWebActiveSessionId,
+  setWebWorkflowState,
+  updateWebSession,
+} from "./web-session-state";
+
+export const webSessionLifecycleClient: SessionLifecycleService = {
+  async createSession(input) {
+    const agent = mockAgents.find((candidate) => candidate.id === input.agentId);
+    if (!agent) {
+      throw new Error(`Agent not found: ${input.agentId}`);
+    }
+    if (!agent.supportedInteractionModes.includes(input.interactionMode)) {
+      throw new Error(`${agent.displayName} does not support ${input.interactionMode}.`);
+    }
+    if (agent.availabilityState !== "available" && agent.availabilityState !== "unknown") {
+      throw new Error(agent.unavailableReason ?? `${agent.displayName} is not available.`);
+    }
+    const remoteWorkspace = input.remoteWorkspace ? normalizeRemoteWorkspace(input.remoteWorkspace) : null;
+    if (agent.id === "onepiece" && remoteWorkspace) {
+      throw new Error("OnePiece supports local projects and local Git worktrees only.");
+    }
+    const sshConnection = input.remoteWorkspace?.sshConnectionId
+      ? findWebSshConnection(input.remoteWorkspace.sshConnectionId)
+      : null;
+    if (input.remoteWorkspace?.sshConnectionId && !sshConnection) {
+      throw new Error(`SSH connection not found: ${input.remoteWorkspace.sshConnectionId}`);
+    }
+    if (
+      sshConnection &&
+      remoteWorkspace &&
+      (sshConnection.host !== remoteWorkspace.host ||
+        sshConnection.port !== (remoteWorkspace.port ?? 22) ||
+        sshConnection.user !== (remoteWorkspace.user ?? ""))
+    ) {
+      throw new Error(
+        "SSH connection endpoint does not match the remote workspace snapshot.",
+      );
+    }
+    if (remoteWorkspace && input.worktree?.enabled) {
+      throw new Error("Remote workspace cannot use Git worktree");
+    }
+    const projectPath = remoteWorkspace ? null : resolveProjectPath(input);
+    const inspection = projectPath ? inspectMockProject(projectPath) : null;
+    if (inspection) {
+      upsertKnownProject(inspection);
+    }
+    if (remoteWorkspace) {
+      upsertKnownRemoteWorkspace(remoteWorkspace);
+    }
+    let effectiveFolder = remoteWorkspace?.uri ?? projectPath;
+    let worktreePath: string | null = null;
+    let worktreeName: string | null = null;
+    let worktreeBranch: string | null = null;
+    if (input.worktree?.enabled) {
+      if (!inspection?.isGit) {
+        throw new Error("Git worktree unavailable");
+      }
+      worktreeName = validateWorktreeName(input.worktree.name ?? "");
+      worktreePath = joinSiblingPath(inspection.path, worktreeName);
+      worktreeBranch = `vanehub/${worktreeName}`;
+      effectiveFolder = worktreePath;
+    }
+    const timestamp = nowIso();
+    const titleSource = remoteWorkspace?.displayName || effectiveFolder || "";
+    const normalizedSeats = (input.seats?.length ? input.seats : [{ agentId: input.agentId, roleId: null }]).map(
+      (seat) => ({
+        ...snapshotSeat(seat, mockAgents, listWebExpertRoles()),
+        seatId: createWebSeatId(),
+        joinedAt: timestamp,
+        leftAt: null,
+      }),
+    );
+    const session: Session = {
+      id: `web-session-${nextWebSessionSequence()}`,
+      title: input.title?.trim() || defaultSessionTitleFromPath(titleSource) || i18n.t("createSession.sessionPlaceholder"),
+      agentId: normalizedSeats[0]?.agentId ?? input.agentId,
+      // Mirrors the native normalization: no seats means one seat built from the Agent.
+      seats: normalizedSeats,
+      interactionMode: input.interactionMode,
+      lifecycleState: "idle",
+      recoveryStatus: "clean",
+      recoveryRevision: 0,
+      stateRevision: 0,
+      historyRevision: 0,
+      activeExecutionRunId: null,
+      folder: effectiveFolder,
+      projectPath,
+      worktreePath,
+      worktreeName,
+      worktreeBranch,
+      remoteWorkspace,
+      remoteSshConnectionId: sshConnection?.id ?? null,
+      remoteSshConnectionRevision: sshConnection?.revision ?? null,
+      runtimeSessionId: null,
+      categoryId: null,
+      pinned: false,
+      archived: false,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    prependWebSession(session);
+    setWebActiveSessionId(session.id);
+    discoverWebSessionCodeIndex(session);
+    emitWebSessionEvent({ kind: "active-session-changed", sessionId: session.id });
+    setWebWorkflowState({
+      ...getWebWorkflowState(),
+      activeAgentId: session.agentId,
+      activeInteractionMode: session.interactionMode,
+      lifecycleState: session.lifecycleState,
+    });
+    return createWebMockOperation({
+      id: `web-session-create-${session.id}-${Date.now()}`,
+      kind: "workspace",
+      relatedEntityId: remoteWorkspace?.uri ?? projectPath,
+      message: `Created mock session ${session.id}`,
+      terminalStatus: "succeeded",
+      error: null,
+      result: session as unknown as Record<string, unknown>,
+    });
+  },
+
+  async deleteSession(sessionId: string) {
+    findWebSession(sessionId);
+    cancelWebActiveStream(sessionId);
+    deleteWebSessionMessages(sessionId);
+    deleteWebRecoveryReports(sessionId);
+    deleteWebChatSubscribers(sessionId);
+    deleteWebSessionChatConfig(sessionId);
+    replaceWebSessions(listWebSessions().filter((session) => session.id !== sessionId));
+    if (getWebActiveSessionId() === sessionId) {
+      setWebActiveSessionId(null);
+      emitWebSessionEvent({ kind: "active-session-changed", sessionId: null });
+    }
+  },
+
+  async switchSession(sessionId: string) {
+    const session = findWebSession(sessionId);
+    if (session.archived) {
+      throw new Error(`Cannot switch to archived session: ${sessionId}`);
+    }
+    setWebActiveSessionId(session.id);
+    emitWebSessionEvent({ kind: "active-session-changed", sessionId: session.id });
+    setWebWorkflowState({
+      ...getWebWorkflowState(),
+      activeAgentId: session.agentId,
+      activeInteractionMode: session.interactionMode,
+      lifecycleState: session.lifecycleState,
+    });
+    return session;
+  },
+
+  async renameSession(sessionId: string, title: string) {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      throw new Error(i18n.t("web.error.sessionTitleRequired"));
+    }
+    return updateWebSession(sessionId, { title: trimmedTitle });
+  },
+
+  async pinSession(sessionId: string) {
+    return updateWebSession(sessionId, { pinned: true });
+  },
+
+  async unpinSession(sessionId: string) {
+    return updateWebSession(sessionId, { pinned: false });
+  },
+
+  async archiveSession(sessionId: string) {
+    const cancelled = cancelWebActiveStream(sessionId);
+    const session = updateWebSession(sessionId, { archived: true, ...(cancelled ? { lifecycleState: "stopped" } : {}) });
+    if (getWebActiveSessionId() === sessionId) {
+      setWebActiveSessionId(null);
+      emitWebSessionEvent({ kind: "active-session-changed", sessionId: null });
+    }
+    return session;
+  },
+
+  async unarchiveSession(sessionId: string) {
+    return updateWebSession(sessionId, { archived: false });
+  },
+};

--- a/src/services/web-session-query-client.ts
+++ b/src/services/web-session-query-client.ts
@@ -1,0 +1,172 @@
+import type {
+  ExportSessionInput,
+  InteractionMode,
+  Session,
+  SessionDetails,
+  SessionExportResult,
+  SessionSearchInput,
+  SessionSearchResult,
+} from "../types/agent";
+import type { SessionQueryService } from "./session-query-service";
+import { mockAgents } from "./mock-agent-data";
+import { nowIso } from "./web-mock-clock";
+import { getWebSessionMessages } from "./web-chat-state";
+import { isWebLoopRoleSession } from "./web-loop-state";
+import { webRunnerDescriptors } from "./web-agent-runner";
+import {
+  findWebSession,
+  getWebActiveSessionId,
+  getWebWorkflowState,
+  listWebSessions,
+  setWebWorkflowState,
+  sortWebSessions,
+} from "./web-session-state";
+
+function searchText(value: string | null | undefined, query: string) {
+  return (value ?? "").toLocaleLowerCase().includes(query.toLocaleLowerCase());
+}
+
+function sessionSearchMatches(session: Session, query: string): SessionSearchResult | null {
+  const matches: SessionSearchResult["matches"] = [];
+  if (searchText(session.title, query)) {
+    matches.push({ kind: "title", excerpt: session.title });
+  }
+  const remoteWorkspace = session.remoteWorkspace;
+  const projectMatch = [
+    session.folder,
+    session.projectPath,
+    session.worktreePath,
+    session.worktreeName,
+    session.worktreeBranch,
+    remoteWorkspace?.host,
+    remoteWorkspace?.user,
+    remoteWorkspace?.path,
+    remoteWorkspace?.displayName,
+    remoteWorkspace?.uri,
+  ].find((value) => searchText(value, query));
+  if (projectMatch) {
+    matches.push({ kind: "project", excerpt: projectMatch });
+  }
+  const messageMatch = getWebSessionMessages(session.id).find((message) => searchText(message.content, query));
+  if (messageMatch) {
+    matches.push({
+      kind: "message",
+      excerpt: messageMatch.content.slice(0, 160),
+      messageId: messageMatch.id,
+    });
+  }
+  return matches.length > 0 ? { session: { ...session }, matches } : null;
+}
+
+function serializeWebSessionExport(input: ExportSessionInput): SessionExportResult {
+  const session = findWebSession(input.sessionId);
+  const payload = {
+    version: 1,
+    exportedAt: nowIso(),
+    session,
+    messages: getWebSessionMessages(session.id),
+  };
+  const content =
+    input.format === "json"
+      ? JSON.stringify(payload, null, 2)
+      : [`# ${session.title}`, "", `- ID: \`${session.id}\``, `- Agent: \`${session.agentId}\``, "", "## Messages", ""]
+          .concat(
+            payload.messages.flatMap((message) => [
+              `### ${message.role.toUpperCase()} - \`${message.status}\``,
+              "",
+              message.content,
+              "",
+            ]),
+          )
+          .join("\n");
+  return {
+    status: input.destinationDirectory === null ? "cancelled" : "exported",
+    path: input.destinationDirectory ? `${input.destinationDirectory}\\${session.id}.${input.format === "json" ? "json" : "md"}` : null,
+    content,
+  };
+}
+
+export const webSessionQueryClient: SessionQueryService = {
+  async getWorkflowState() {
+    return getWebWorkflowState();
+  },
+
+  async selectAgent(agentId: string, interactionMode: InteractionMode) {
+    const agent = mockAgents.find((candidate) => candidate.id === agentId);
+    if (!agent) {
+      throw new Error(`Agent not found: ${agentId}`);
+    }
+    if (!agent.supportedInteractionModes.includes(interactionMode)) {
+      throw new Error(`${agent.displayName} does not support ${interactionMode}.`);
+    }
+    setWebWorkflowState({
+      ...getWebWorkflowState(),
+      activeAgentId: agentId,
+      activeInteractionMode: interactionMode,
+      lifecycleState: "idle",
+    });
+    return getWebWorkflowState();
+  },
+
+  async launchActiveWorkflow() {
+    setWebWorkflowState({
+      ...getWebWorkflowState(),
+      lifecycleState: getWebWorkflowState().activeAgentId ? "running" : "failed",
+    });
+    return {
+      workflow: getWebWorkflowState(),
+      message: getWebWorkflowState().activeAgentId
+        ? "Web preview session marked as running."
+        : "Select an agent before launching.",
+    };
+  },
+
+  async getSessionDetails(): Promise<SessionDetails> {
+    const adapter = getWebWorkflowState().activeInteractionMode ?? "none";
+    return {
+      agentId: getWebWorkflowState().activeAgentId,
+      interactionMode: getWebWorkflowState().activeInteractionMode,
+      lifecycleState: getWebWorkflowState().lifecycleState,
+      adapter,
+      details: {
+        runtime: "web",
+        storage: "in-memory",
+      },
+    };
+  },
+
+  async listSessions() {
+    return sortWebSessions(listWebSessions().filter((session) => !session.archived && !isWebLoopRoleSession(session.id)));
+  },
+
+  async listArchivedSessions() {
+    return sortWebSessions(listWebSessions().filter((session) => session.archived && !isWebLoopRoleSession(session.id)));
+  },
+
+  async searchSessions(input: SessionSearchInput) {
+    const query = input.query.trim();
+    if (!query) return [];
+    return sortWebSessions(listWebSessions().filter((session) => !isWebLoopRoleSession(session.id)))
+      .map((session) => sessionSearchMatches(session, query))
+      .filter((result): result is SessionSearchResult => result !== null)
+      .slice(0, input.limit ?? 50);
+  },
+
+  async getSession(sessionId: string) {
+    return findWebSession(sessionId);
+  },
+
+  async getActiveSession() {
+    const sessionId = getWebActiveSessionId();
+    if (!sessionId) return null;
+    return listWebSessions().find((session) => session.id === sessionId) ?? null;
+  },
+
+  async exportSession(input: ExportSessionInput) {
+    return serializeWebSessionExport(input);
+  },
+
+  async listAgentRunners(sessionId, agentId) {
+    return structuredClone(webRunnerDescriptors(sessionId, agentId));
+  },
+};

--- a/src/services/web-session-recovery-client.ts
+++ b/src/services/web-session-recovery-client.ts
@@ -1,0 +1,54 @@
+import type { SessionRecoveryAcknowledgement } from "./agent-service";
+import type { SessionRecoveryService } from "./session-recovery-service";
+import { emitWebSessionEvent, findWebSession, updateWebSession } from "./web-session-state";
+import {
+  listWebRecoveryReports,
+  mockRecoveryReport,
+  setWebRecoveryReports,
+  webRecoverySummary,
+} from "./web-session-recovery-state";
+
+export const webSessionRecoveryClient: SessionRecoveryService = {
+  async getSessionRecoverySummary(sessionId: string) {
+    return structuredClone(webRecoverySummary(sessionId));
+  },
+
+  async listSessionRecoveryReports(sessionId: string, limit = 20) {
+    findWebSession(sessionId);
+    const boundedLimit = Math.max(1, Math.min(100, Math.trunc(limit)));
+    return structuredClone(listWebRecoveryReports(sessionId).slice(0, boundedLimit));
+  },
+
+  async acknowledgeSessionRecovery(
+    sessionId: string,
+    expectedRecoveryRevision: number,
+  ): Promise<SessionRecoveryAcknowledgement> {
+    const session = findWebSession(sessionId);
+    if (session.recoveryStatus === "quarantined") {
+      throw new Error(`Recovery acknowledgement is not allowed for quarantined session ${sessionId}.`);
+    }
+    if (session.recoveryStatus !== "action_required") {
+      throw new Error(`Recovery acknowledgement is not allowed for session ${sessionId}.`);
+    }
+    if (session.recoveryRevision !== expectedRecoveryRevision) {
+      throw new Error(
+        `Recovery revision conflict for session ${sessionId}; current revision is ${session.recoveryRevision}.`,
+      );
+    }
+    const recoveryRevision = session.recoveryRevision + 1;
+    const updated = updateWebSession(sessionId, {
+      recoveryStatus: "clean",
+      recoveryRevision,
+      stateRevision: session.stateRevision + 1,
+      activeExecutionRunId: null,
+    });
+    const report = mockRecoveryReport(updated, recoveryRevision, "acknowledged");
+    setWebRecoveryReports(sessionId, [report, ...listWebRecoveryReports(sessionId)]);
+    emitWebSessionEvent({
+      kind: "recovery-acknowledged",
+      sessionId,
+      recoveryRevision,
+    });
+    return structuredClone({ session: updated, report });
+  },
+};

--- a/src/services/web-session-recovery-state.ts
+++ b/src/services/web-session-recovery-state.ts
@@ -1,0 +1,138 @@
+import type {
+  RecoveryDecision,
+  SessionRecoveryReport,
+  SessionRecoverySummary,
+} from "./agent-service";
+import type { Session } from "../types/agent";
+import { nowIso } from "./web-mock-clock";
+import { deleteWebActiveStream, deleteWebSessionMessages } from "./web-chat-state";
+import {
+  emitWebSessionEvent,
+  findWebSession,
+  getWebActiveSessionId,
+  listWebSessions,
+  nextWebSessionSequence,
+  prependWebSession,
+  replaceWebSessions,
+  setWebActiveSessionId,
+  updateWebSession,
+} from "./web-session-state";
+
+// Owned here and never exported. An exported mutable binding re-imported from two modules gives
+// two divergent copies of the mock world, which surfaces as one UI panel showing stale data while
+// another shows fresh. Callers reach the reports through the accessors below.
+const recoveryReportsBySession = new Map<string, SessionRecoveryReport[]>();
+
+export function mockRecoveryReport(
+  session: Session,
+  recoveryRevision: number,
+  decision: RecoveryDecision,
+): SessionRecoveryReport {
+  return {
+    reportId: `web-recovery-${session.id}-${recoveryRevision}`,
+    sessionId: session.id,
+    recoveryRevision,
+    trigger: decision === "acknowledged" ? "user_acknowledgement" : "startup",
+    observedLifecycle: session.lifecycleState,
+    observedExecutionRunId: session.activeExecutionRunId,
+    decision,
+    reasonCodes: decision === "acknowledged"
+      ? ["acknowledged_by_user"]
+      : ["unfinished_tool_activity"],
+    evidenceRefs: [{
+      kind: "session",
+      sessionId: session.id,
+      stateRevision: session.stateRevision,
+      historyRevision: session.historyRevision,
+    }],
+    createdAt: nowIso(),
+  };
+}
+
+/** Returns the live array, matching what a direct `.get()` on the binding returned. */
+export function listWebRecoveryReports(sessionId: string): SessionRecoveryReport[] {
+  return recoveryReportsBySession.get(sessionId) ?? [];
+}
+
+export function setWebRecoveryReports(sessionId: string, reports: SessionRecoveryReport[]): void {
+  recoveryReportsBySession.set(sessionId, reports);
+}
+
+export function deleteWebRecoveryReports(sessionId: string): void {
+  recoveryReportsBySession.delete(sessionId);
+}
+
+export function webRecoverySummary(sessionId: string): SessionRecoverySummary {
+  const session = findWebSession(sessionId);
+  return {
+    session,
+    latestReport: recoveryReportsBySession.get(sessionId)?.[0] ?? null,
+  };
+}
+
+export function seedWebRecoverySessionForTest(
+  status: "action_required" | "quarantined" = "action_required",
+): Session {
+  const timestamp = nowIso();
+  const session: Session = {
+    id: `web-recovery-session-${nextWebSessionSequence()}`,
+    title: "Recovered Web session",
+    agentId: "onepiece",
+    interactionMode: "api",
+    lifecycleState: "failed",
+    recoveryStatus: "clean",
+    recoveryRevision: 0,
+    stateRevision: 0,
+    historyRevision: 0,
+    activeExecutionRunId: null,
+    folder: "D:\\example\\recovery-project",
+    projectPath: "D:\\example\\recovery-project",
+    worktreePath: null,
+    worktreeName: null,
+    worktreeBranch: null,
+    remoteWorkspace: null,
+    remoteSshConnectionId: null,
+    remoteSshConnectionRevision: null,
+    runtimeSessionId: null,
+    categoryId: null,
+    pinned: false,
+    archived: false,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  prependWebSession(session);
+  setWebActiveSessionId(session.id);
+  const recoveryRevision = 1;
+  const recovered = updateWebSession(session.id, {
+    lifecycleState: "failed",
+    recoveryStatus: status,
+    recoveryRevision,
+    stateRevision: session.stateRevision + 1,
+    activeExecutionRunId: null,
+  });
+  recoveryReportsBySession.set(recovered.id, [
+    mockRecoveryReport(
+      recovered,
+      recoveryRevision,
+      status === "quarantined" ? "quarantined" : "action_required",
+    ),
+  ]);
+  emitWebSessionEvent({
+    kind: status === "quarantined" ? "recovery-quarantined" : "recovery-action-required",
+    sessionId: recovered.id,
+    recoveryRevision,
+  });
+  return recovered;
+}
+
+export function resetWebRecoverySessionsForTest() {
+  const recoverySessionIds = new Set(recoveryReportsBySession.keys());
+  replaceWebSessions(listWebSessions().filter((session) => !recoverySessionIds.has(session.id)));
+  recoverySessionIds.forEach((sessionId) => {
+    deleteWebSessionMessages(sessionId);
+    deleteWebActiveStream(sessionId);
+  });
+  recoveryReportsBySession.clear();
+  const activeId = getWebActiveSessionId();
+  if (activeId && recoverySessionIds.has(activeId)) setWebActiveSessionId(null);
+}

--- a/src/services/web-session-seat-client.ts
+++ b/src/services/web-session-seat-client.ts
@@ -1,0 +1,87 @@
+import type { SessionSeat, UpdateSessionSeatsInput } from "../types/agent";
+import type { SessionSeatService } from "./session-lifecycle-service";
+import { nowIso } from "./web-mock-clock";
+import { findWebSshConnection } from "./web-ssh-connection-client";
+import { createWebSeatId, findWebSession, updateWebSession } from "./web-session-state";
+
+export const webSessionSeatClient: SessionSeatService = {
+  async updateSessionSeats(input: UpdateSessionSeatsInput) {
+    const session = findWebSession(input.sessionId);
+    if (session.updatedAt !== input.expectedUpdatedAt) {
+      throw new Error("validation error: Session participants changed since they were loaded.");
+    }
+    if (input.seats.length === 0) {
+      throw new Error("validation error: A session must keep at least one active participant.");
+    }
+    const changedAt = nowIso();
+    const historical = session.seats ?? [{
+      seatId: `${session.id}:seat:0`,
+      agentId: session.agentId,
+      roleId: null,
+      joinedAt: session.createdAt,
+      leftAt: null,
+    }];
+    const retained = new Set<string>();
+    const additions: SessionSeat[] = [];
+    for (const requested of input.seats) {
+      const existing = historical.find((seat) =>
+        seat.leftAt == null && !retained.has(seat.seatId ?? "") &&
+        ((Boolean(requested.seatId) && seat.seatId === requested.seatId &&
+          seat.agentId === requested.agentId && seat.roleId === requested.roleId) ||
+          (!requested.seatId && seat.agentId === requested.agentId && seat.roleId === requested.roleId)),
+      );
+      if (existing?.seatId) {
+        retained.add(existing.seatId);
+      } else {
+        additions.push({
+          ...requested,
+          seatId: createWebSeatId(),
+          joinedAt: changedAt,
+          leftAt: null,
+        });
+      }
+    }
+    const seats = [
+      ...historical.map((seat) =>
+        seat.leftAt == null && !retained.has(seat.seatId ?? "")
+          ? { ...seat, leftAt: changedAt }
+          : seat,
+      ),
+      ...additions,
+    ];
+    const firstActive = seats.find((seat) => seat.leftAt == null);
+    if (!firstActive) {
+      throw new Error("validation error: A session must keep at least one active participant.");
+    }
+    return updateWebSession(input.sessionId, { seats, agentId: firstActive.agentId });
+  },
+
+  async rebindRemoteSessionSshConnection(
+    sessionId: string,
+    connectionId: string,
+  ) {
+    const session = findWebSession(sessionId);
+    if (!session.remoteWorkspace) {
+      throw new Error(
+        "Only remote workspace sessions can bind an SSH connection.",
+      );
+    }
+    const connection = findWebSshConnection(connectionId);
+    if (!connection) {
+      throw new Error(`SSH connection not found: ${connectionId}`);
+    }
+    if (
+      connection.host !== session.remoteWorkspace.host ||
+      connection.port !== (session.remoteWorkspace.port ?? 22) ||
+      connection.user !== (session.remoteWorkspace.user ?? "")
+    ) {
+      throw new Error(
+        "SSH connection endpoint does not match the remote workspace snapshot.",
+      );
+    }
+    return updateWebSession(sessionId, {
+      remoteSshConnectionId: connection.id,
+      remoteSshConnectionRevision: connection.revision,
+    });
+  },
+};


### PR DESCRIPTION
Implements `extract-web-client-chat-state`, continuing exactly where #175 stopped.

#175 broke the shared-state hub down to a 20-method component over 8 bindings and left 39 methods across three contexts (chat/messaging, memories, session lifecycle) for a follow-up, each needing its own state module first.

## Result

| File | Before | After |
|---|---:|---:|
| `web-agent-client.ts` | 1,877 | **822** (−56%) |
| `agent-service.ts` | 364 | **308** |

From the 6,013 lines this work stream started at, `web-agent-client.ts` is now **86% smaller**.

35 of 39 remaining methods moved into 18 new modules across seven commits: chat/messaging (6), memories (3), recovery (3), chat configs (2), session queries + workflow + runners (11), lifecycle (8), seats (2).

**The composition root now holds zero mutable module-level bindings.**

## Two corrections to #175's own analysis, verified before building on it

#175's headline numbers hold — 8 bindings, 39 methods, 20 in the shared component, 19 already disjoint — but two details needed correction, found by rebuilding the state-ownership map from the AST rather than trusting the prior report:

1. **The shared component is 25 units, not 20.** Five exported top-level helper functions sit in it beside the 20 methods — load-bearing, since `resetWebRecoverySessionsForTest` fuses recovery to chat *independently* of `deleteSession`. Missing this would have meant recovery looked freeable by handling `deleteSession` alone, when it is not.
2. **Chat had to be extracted first, not last.** Removing memories alone, recovery alone, or chat configs alone each leaves the component in **one** piece. Only removing the chat core splits it — into exactly two. This reverses the order implied by #175's deferral note.

Also collapsed the seam #175 explicitly left as a marker for this moment: `resetWebLoopsForTest` was split across two exported half-steps because it touched both loop state and `messagesBySession`. It's one function again now that chat state has its own module.

## 4 methods remain, none for state reasons

- **`sendMessage`** — 529 lines. `max-lines` is hard at 300 and `eslint.config.js`'s debt list is closed to new entries, so a module holding it needs a forbidden exemption. Making it fit means hoisting roughly 15 interleaved `setTimeout` blocks into scheduling helpers — which would rewrite the one method whose observable contract *is* that ordering and those delays, inside a change whose entire safety argument is verbatim moves. This wants its own change, shaped like `decompose-api-tool-use-loop` (#179): admission rules, coverage-gap check before cutting, seams justified individually.
- `deleteApiAgent`, `applyCliConfigProfile`, `subscribeSessionEvents` — each is a fully disjoint, one-method context; a dedicated module would be more boilerplate than body.

## Line budget

`src/services` 19,087 → **19,347 (+260)** across 18 new modules, about 14 lines each — in line with the per-module fixed cost #168 and #175 both measured. `web-agent-client.ts`'s per-file budget ratcheted down at every group boundary: 1877 → 1608 → 1514 → 1332 → 1105 → 822. Both `web-agent-client.ts` and `agent-service.ts` keep their `eslint.config.js` entries; the former can't close while `sendMessage` (529 lines) stays inline.

## Verified, not asserted

- `grep '^export let\|^export var'` over `src/services` is **empty** — the no-exported-mutable-binding constraint from #168 held through a third stage.
- `webAgentClient: AgentService` intact; every signature **moved** out of `agent-service.ts`, none copied.
- `git diff --stat -- src/services/tauri-agent-client.ts` is **empty** — byte-identical.
- No `this: AgentService` was needed anywhere — the AST confirmed none of the 39 methods used `this`.
- No `.tsx` or `.rs` file in the diff.

## Verification

| Command | Result |
|---|---|
| `npx tsc --noEmit` | pass, after each of 5 groups |
| `npm run lint:ci`, `npm run build` | pass |
| `npm run test` | **286 files / 1301 tests**, run 5×, identical to baseline, no test file edited |
| `npm run contracts:check` | 3/3, run 5×, `contract-conformance.test.ts` unedited |
| `npm run architecture:check` | pass, 41/41 |
| `npx playwright test` | **156 passed** (9.8m) |
| `openspec validate --strict` | pass, specs 138/138 |
| `npm run docs:check` | pass |

## Two things worth flagging for review

- The first `npm run test` run showed one flaky failure in `skills-page-interactions.test.tsx`, self-inflicted by editing files while that run was still in flight. It passed in isolation and in all five subsequent full runs.
- Five **pre-existing** exported `const` Maps remain elsewhere in `src/services` (`web-api-provider-state.ts`, `web-code-index-state.ts`, `web-permissions-mock-state.ts`) — not added or touched here. A `const` binding can't be reassigned, so it's a weaker hazard than an exported `let` (re-import can't fork it into two copies), but they're the last places in the subtree where a binding rather than behaviour crosses a module edge. Noted as follow-up scope, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
