### PR TITLE
feat(permissions): recovery paths for the Claude Code permission hook + locale-independent git classification

### DIFF
--- a/crates/vanehub-permission-hook/src/main.rs
+++ b/crates/vanehub-permission-hook/src/main.rs
@@ -7,8 +7,12 @@
 //! `contexts/permissions/infrastructure/hook_bridge_discovery.rs` by hand and must be kept in
 //! sync there.
 //!
-//! Always exits 0 with a `hookSpecificOutput` JSON body on stdout — Claude Code's documented
-//! contract encodes the actual allow/deny decision in that JSON, not in the process exit code.
+//! In hook mode (no arguments) it always exits 0 with a `hookSpecificOutput` JSON body on
+//! stdout — Claude Code's documented contract encodes the actual allow/deny decision in that
+//! JSON, not in the process exit code. The human-invoked `--uninstall` mode (`uninstall.rs`)
+//! uses conventional exit codes instead.
+
+mod uninstall;
 
 use serde::{Deserialize, Serialize};
 use std::io::{self, Read, Write};
@@ -22,8 +26,23 @@ use std::time::Duration;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(320);
 
 fn main() {
-    let decision = run(DEFAULT_TIMEOUT);
-    print_hook_output(&decision);
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    match arguments.as_slice() {
+        [] => print_hook_output(&run(DEFAULT_TIMEOUT)),
+        [flag] if flag == "--uninstall" => match uninstall::run() {
+            Ok(message) => println!("{message}"),
+            Err(message) => {
+                eprintln!("vanehub-permission-hook --uninstall failed: {message}");
+                std::process::exit(1);
+            }
+        },
+        // Never fall back to hook mode on unrecognized arguments: hook mode blocks on stdin,
+        // which for a human typo means a silently hung terminal instead of an error.
+        _ => {
+            eprintln!("usage: vanehub-permission-hook [--uninstall]");
+            std::process::exit(2);
+        }
+    }
 }
 
 enum Decision {
@@ -68,7 +87,18 @@ fn run(timeout: Duration) -> Decision {
         return Decision::Deny("could not parse the tool-use request");
     };
 
-    let response = read_discovery().and_then(|discovery| {
+    let discovery = read_discovery();
+    // Which offline story applies if the request below yields nothing: discovery data that led
+    // nowhere means a VaneHub instance registered and then went away; no discovery data means
+    // none ever registered here. The deny messages differ so the reader of the denial knows
+    // which situation they are recovering from (`add-permission-hook-recovery`'s "Offline
+    // denial names its recovery paths").
+    let offline = if discovery.is_some() {
+        OfflineKind::Unreachable
+    } else {
+        OfflineKind::NoDiscovery
+    };
+    let response = discovery.and_then(|discovery| {
         let body = serde_json::to_string(&WrapperRequest {
             tool_name: &request.tool_name,
             tool_input: &request.tool_input,
@@ -79,7 +109,14 @@ fn run(timeout: Duration) -> Decision {
         send_request(discovery.port, &discovery.token, &body, timeout)
     });
 
-    decide(response, &request.tool_name)
+    decide(response, offline, &request.tool_name)
+}
+
+/// How the wrapper ended up without a server response — see the comment in `run`.
+#[derive(Clone, Copy)]
+enum OfflineKind {
+    NoDiscovery,
+    Unreachable,
 }
 
 fn parse_hook_request(stdin: &str) -> Option<HookRequest> {
@@ -144,12 +181,23 @@ fn parse_http_response(raw: &[u8]) -> Option<HttpResponse> {
 /// deny, no allowlist exception: a reachable-but-corrupt response is a more concerning failure
 /// mode than plain absence (design.md D5's clarification; `claude-code-permission-hook`'s
 /// "Malformed hook payloads fail closed").
-fn decide(response: Option<HttpResponse>, tool_name: &str) -> Decision {
+fn decide(response: Option<HttpResponse>, offline: OfflineKind, tool_name: &str) -> Decision {
     match response {
         None if is_offline_allowlisted(tool_name) => Decision::Allow,
-        None => {
-            Decision::Deny("VaneHub is unreachable and this tool is not in the offline allowlist")
-        }
+        None => Decision::Deny(match offline {
+            OfflineKind::Unreachable => {
+                "VaneHub is unreachable and this tool is not in the offline allowlist. The \
+                 VaneHub instance that installed this hook is not running; start VaneHub to \
+                 resume approvals, or run `vanehub-permission-hook --uninstall` to remove the \
+                 hook from Claude Code's global settings"
+            }
+            OfflineKind::NoDiscovery => {
+                "no VaneHub instance has registered on this machine and this tool is not in the \
+                 offline allowlist; start VaneHub to enable approvals, or run \
+                 `vanehub-permission-hook --uninstall` to remove the hook from Claude Code's \
+                 global settings"
+            }
+        }),
         Some(response) if response.status == 200 => {
             match serde_json::from_str::<serde_json::Value>(&response.body) {
                 Ok(value) if value.get("decision").and_then(|d| d.as_str()) == Some("allow") => {
@@ -219,14 +267,47 @@ mod tests {
 
     #[test]
     fn unreachable_server_fails_open_for_allowlisted_tools() {
-        assert!(matches!(decide(None, "Read"), Decision::Allow));
-        assert!(matches!(decide(None, "Glob"), Decision::Allow));
+        assert!(matches!(
+            decide(None, OfflineKind::Unreachable, "Read"),
+            Decision::Allow
+        ));
+        assert!(matches!(
+            decide(None, OfflineKind::NoDiscovery, "Glob"),
+            Decision::Allow
+        ));
     }
 
     #[test]
     fn unreachable_server_fails_closed_for_everything_else() {
-        assert!(matches!(decide(None, "Bash"), Decision::Deny(_)));
-        assert!(matches!(decide(None, "SomeFutureTool"), Decision::Deny(_)));
+        assert!(matches!(
+            decide(None, OfflineKind::Unreachable, "Bash"),
+            Decision::Deny(_)
+        ));
+        assert!(matches!(
+            decide(None, OfflineKind::NoDiscovery, "SomeFutureTool"),
+            Decision::Deny(_)
+        ));
+    }
+
+    #[test]
+    fn offline_deny_reasons_differ_by_state_and_both_name_the_recovery_actions() {
+        let Decision::Deny(unreachable) = decide(None, OfflineKind::Unreachable, "Bash") else {
+            panic!("unreachable must deny");
+        };
+        let Decision::Deny(no_discovery) = decide(None, OfflineKind::NoDiscovery, "Bash") else {
+            panic!("no-discovery must deny");
+        };
+        assert_ne!(unreachable, no_discovery);
+        for reason in [unreachable, no_discovery] {
+            assert!(
+                reason.contains("--uninstall"),
+                "missing escape hatch: {reason}"
+            );
+            assert!(
+                reason.contains("start VaneHub"),
+                "missing restart path: {reason}"
+            );
+        }
     }
 
     #[test]
@@ -235,7 +316,10 @@ mod tests {
             status: 200,
             body: "not json".to_string(),
         };
-        assert!(matches!(decide(Some(garbage), "Read"), Decision::Deny(_)));
+        assert!(matches!(
+            decide(Some(garbage), OfflineKind::Unreachable, "Read"),
+            Decision::Deny(_)
+        ));
     }
 
     #[test]
@@ -244,7 +328,10 @@ mod tests {
             status: 500,
             body: r#"{"decision":"allow"}"#.to_string(),
         };
-        assert!(matches!(decide(Some(response), "Read"), Decision::Deny(_)));
+        assert!(matches!(
+            decide(Some(response), OfflineKind::Unreachable, "Read"),
+            Decision::Deny(_)
+        ));
     }
 
     #[test]
@@ -253,7 +340,10 @@ mod tests {
             status: 200,
             body: r#"{"decision":"allow"}"#.to_string(),
         };
-        assert!(matches!(decide(Some(response), "Bash"), Decision::Allow));
+        assert!(matches!(
+            decide(Some(response), OfflineKind::Unreachable, "Bash"),
+            Decision::Allow
+        ));
     }
 
     #[test]
@@ -262,7 +352,10 @@ mod tests {
             status: 200,
             body: r#"{"decision":"deny"}"#.to_string(),
         };
-        assert!(matches!(decide(Some(response), "Bash"), Decision::Deny(_)));
+        assert!(matches!(
+            decide(Some(response), OfflineKind::Unreachable, "Bash"),
+            Decision::Deny(_)
+        ));
     }
 
     #[test]

--- a/crates/vanehub-permission-hook/src/uninstall.rs
+++ b/crates/vanehub-permission-hook/src/uninstall.rs
@@ -1,0 +1,250 @@
+//! The `--uninstall` escape hatch (`add-permission-hook-recovery`'s "Wrapper provides a
+//! standalone uninstall escape hatch"): removes VaneHub's own `PreToolUse` entries from Claude
+//! Code's global settings so a machine whose VaneHub instance is gone can be released with one
+//! command instead of hand-edited JSON. Runs entirely offline — it must work precisely when
+//! VaneHub cannot.
+//!
+//! The settings path (`~/.claude/settings.json`), the ownership marker, and the removal
+//! predicate are duplicated by hand from `contexts/tooling/cli_config`'s `primary_path`,
+//! `PERMISSION_HOOK_MARKER`, and `is_vanehub_owned` — the same keep-in-sync contract as the
+//! discovery-file duplication documented in `main.rs`, and for the same reason: this binary
+//! deliberately never links `vanehub_ai_lib`.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Must match `live_config.rs`'s `PERMISSION_HOOK_MARKER`, which in turn names this very
+/// binary — an entry is VaneHub-owned iff any of its hook commands mentions it.
+const PERMISSION_HOOK_MARKER: &str = "vanehub-permission-hook";
+
+pub(crate) fn run() -> Result<String, String> {
+    uninstall_from(&settings_path()?)
+}
+
+/// Must match `live_config.rs`'s `primary_path("claude-code")`.
+fn settings_path() -> Result<PathBuf, String> {
+    dirs::home_dir()
+        .map(|home| home.join(".claude").join("settings.json"))
+        .ok_or_else(|| "could not resolve the home directory".to_string())
+}
+
+fn uninstall_from(path: &Path) -> Result<String, String> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(format!(
+                "nothing to remove: {} does not exist",
+                path.display()
+            ));
+        }
+        Err(error) => return Err(format!("could not read {}: {error}", path.display())),
+    };
+    let mut document: serde_json::Value = serde_json::from_str(&raw).map_err(|error| {
+        format!(
+            "{} is not valid JSON ({error}); refusing to modify it",
+            path.display()
+        )
+    })?;
+
+    let removed = remove_owned_entries(&mut document)
+        .map_err(|reason| format!("{}: {reason}; refusing to modify it", path.display()))?;
+    if removed == 0 {
+        return Ok(format!(
+            "nothing to remove: no VaneHub-owned PreToolUse entries in {}",
+            path.display()
+        ));
+    }
+
+    let bytes = serde_json::to_vec_pretty(&document)
+        .map_err(|error| format!("could not re-serialize the settings document: {error}"))?;
+    write_replacing(path, &bytes)?;
+    Ok(format!(
+        "removed {removed} VaneHub-owned PreToolUse hook entr{} from {}",
+        if removed == 1 { "y" } else { "ies" },
+        path.display()
+    ))
+}
+
+/// `Ok(0)` when the hooks structure simply isn't there; `Err` when it exists with an unexpected
+/// shape — guessing at a malformed document risks destroying settings this tool doesn't own.
+fn remove_owned_entries(document: &mut serde_json::Value) -> Result<usize, &'static str> {
+    let Some(root) = document.as_object_mut() else {
+        return Err("root is not a JSON object");
+    };
+    let Some(hooks) = root.get_mut("hooks") else {
+        return Ok(0);
+    };
+    let Some(hooks) = hooks.as_object_mut() else {
+        return Err("hooks is not a JSON object");
+    };
+    let Some(pre_tool_use) = hooks.get_mut("PreToolUse") else {
+        return Ok(0);
+    };
+    let Some(pre_tool_use) = pre_tool_use.as_array_mut() else {
+        return Err("hooks.PreToolUse is not a JSON array");
+    };
+    let before = pre_tool_use.len();
+    pre_tool_use.retain(|entry| !is_vanehub_owned(entry));
+    Ok(before - pre_tool_use.len())
+}
+
+/// Must match `live_config.rs`'s `is_vanehub_owned`.
+fn is_vanehub_owned(entry: &serde_json::Value) -> bool {
+    entry
+        .get("hooks")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|hooks| {
+            hooks.iter().any(|hook| {
+                hook.get("command")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|command| command.contains(PERMISSION_HOOK_MARKER))
+            })
+        })
+}
+
+/// Same-directory temp file plus rename, so a crash mid-write can never leave a truncated
+/// settings file behind — this tool's whole reason to exist is recovering from crashes.
+fn write_replacing(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let mut file_name = path
+        .file_name()
+        .map(std::ffi::OsStr::to_os_string)
+        .ok_or_else(|| format!("{} has no file name to replace", path.display()))?;
+    file_name.push(format!(".vanehub-uninstall-{}", std::process::id()));
+    let temp_path = path.with_file_name(file_name);
+
+    std::fs::write(&temp_path, bytes)
+        .map_err(|error| format!("could not write {}: {error}", temp_path.display()))?;
+    std::fs::rename(&temp_path, path).map_err(|error| {
+        let _ = std::fs::remove_file(&temp_path);
+        format!("could not replace {}: {error}", path.display())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    struct TempSettings {
+        directory: PathBuf,
+    }
+
+    impl TempSettings {
+        fn new(name: &str) -> Self {
+            let directory = std::env::temp_dir().join(format!(
+                "vanehub-hook-uninstall-test-{}-{name}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&directory).expect("create temp directory");
+            Self { directory }
+        }
+
+        fn path(&self) -> PathBuf {
+            self.directory.join("settings.json")
+        }
+    }
+
+    impl Drop for TempSettings {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.directory);
+        }
+    }
+
+    fn owned_entry() -> serde_json::Value {
+        json!({
+            "matcher": "Bash|Edit|Write|Read|Glob|Grep",
+            "hooks": [{"type": "command", "command": "/opt/bin/vanehub-permission-hook", "timeout": 330}]
+        })
+    }
+
+    fn foreign_entry() -> serde_json::Value {
+        json!({
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": "/usr/local/bin/some-other-guard"}]
+        })
+    }
+
+    #[test]
+    fn removes_owned_entries_and_preserves_everything_else() {
+        let temp = TempSettings::new("removes");
+        let document = json!({
+            "model": "sonnet",
+            "hooks": {
+                "PreToolUse": [owned_entry(), foreign_entry(), owned_entry()],
+                "PostToolUse": [{"matcher": "Edit", "hooks": []}]
+            }
+        });
+        std::fs::write(temp.path(), document.to_string()).expect("seed settings");
+
+        let message = uninstall_from(&temp.path()).expect("uninstall should succeed");
+        assert!(
+            message.contains("removed 2"),
+            "unexpected message: {message}"
+        );
+
+        let raw = std::fs::read_to_string(temp.path()).expect("read back");
+        let value: serde_json::Value = serde_json::from_str(&raw).expect("valid json");
+        assert_eq!(value["model"], "sonnet");
+        assert_eq!(value["hooks"]["PreToolUse"], json!([foreign_entry()]));
+        assert_eq!(value["hooks"]["PostToolUse"][0]["matcher"], "Edit");
+    }
+
+    #[test]
+    fn missing_file_is_a_successful_no_op() {
+        let temp = TempSettings::new("missing");
+        let message = uninstall_from(&temp.path()).expect("should succeed");
+        assert!(message.contains("nothing to remove"));
+        assert!(!temp.path().exists());
+    }
+
+    #[test]
+    fn settings_without_owned_entries_are_left_byte_identical() {
+        let temp = TempSettings::new("no-owned");
+        let original = json!({"hooks": {"PreToolUse": [foreign_entry()]}}).to_string();
+        std::fs::write(temp.path(), &original).expect("seed settings");
+
+        let message = uninstall_from(&temp.path()).expect("should succeed");
+        assert!(message.contains("nothing to remove"));
+        assert_eq!(
+            std::fs::read_to_string(temp.path()).expect("read back"),
+            original
+        );
+    }
+
+    #[test]
+    fn unparseable_settings_fail_without_modification() {
+        let temp = TempSettings::new("garbage");
+        std::fs::write(temp.path(), "{not json").expect("seed settings");
+
+        let error = uninstall_from(&temp.path()).expect_err("should refuse");
+        assert!(
+            error.contains("not valid JSON"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(temp.path()).expect("read back"),
+            "{not json"
+        );
+    }
+
+    #[test]
+    fn malformed_hooks_shape_fails_without_modification() {
+        let temp = TempSettings::new("bad-shape");
+        let original = json!({"hooks": {"PreToolUse": "not an array"}}).to_string();
+        std::fs::write(temp.path(), &original).expect("seed settings");
+
+        let error = uninstall_from(&temp.path()).expect_err("should refuse");
+        assert!(error.contains("PreToolUse"), "unexpected error: {error}");
+        assert_eq!(
+            std::fs::read_to_string(temp.path()).expect("read back"),
+            original
+        );
+    }
+
+    #[test]
+    fn ownership_predicate_matches_live_config_semantics() {
+        assert!(is_vanehub_owned(&owned_entry()));
+        assert!(!is_vanehub_owned(&foreign_entry()));
+        assert!(!is_vanehub_owned(&json!({"matcher": "Bash"})));
+    }
+}

--- a/openspec/changes/archive/2026-08-20-add-permission-hook-recovery/design.md
+++ b/openspec/changes/archive/2026-08-20-add-permission-hook-recovery/design.md
@@ -1,0 +1,27 @@
+# Design
+
+## D1: The global installation model stays
+
+The hook living in Claude Code's global `settings.json` — outliving the VaneHub process and governing every session on the machine — is the original design intent (`add-claude-code-permission-callback` D7; the adapter's own doc comment). This change treats "all sessions degrade to read-only when VaneHub is gone" as correct fail-closed behavior with an unacceptable *recovery cost*, and fixes only the recovery cost. Per-session injection (`claude --settings`) would eliminate the failure class but also the governance property; it is a scope decision for a separate proposal, noted in `proposal.md`'s out-of-scope list.
+
+## D2: The escape hatch lives in the wrapper, not in a new tool
+
+`vanehub-permission-hook --uninstall` reuses the one binary guaranteed to be on disk wherever the problem exists — the installed hook entry names its absolute path, so the stuck user can read the path straight out of the deny situation's `settings.json` (or their PATH'd copy) and run it. There is no privilege escalation: any process able to run the wrapper can already edit `~/.claude/settings.json` directly.
+
+The wrapper deliberately does not link `vanehub_ai_lib`, so three facts are duplicated by hand and must be kept in sync, extending the existing discovery-file duplication contract already documented at the top of `main.rs`:
+
+- the settings path `~/.claude/settings.json` (from `live_config.rs`'s `primary_path("claude-code")`),
+- the ownership marker `vanehub-permission-hook` (from `live_config.rs`'s `PERMISSION_HOOK_MARKER`),
+- the removal predicate: an entry is VaneHub-owned iff any of its `hooks[].command` strings contains the marker (from `live_config.rs`'s `is_vanehub_owned`).
+
+Uninstall edits only `hooks.PreToolUse`, removing owned entries and leaving every other key — including entries other tools added to the same array — untouched, mirroring `set_permission_hook_entries`'s retain-then-extend semantics with an empty extend. An unparseable settings file fails without writing anything. The write goes through a same-directory temp file plus rename so a crash mid-write cannot truncate the user's settings.
+
+Exit-code contract: hook mode keeps "always exit 0, decision in JSON" (Claude Code's documented contract); uninstall mode is human-invoked and uses conventional exit codes (0 success including nothing-to-remove, nonzero failure with a message on stderr).
+
+## D3: Deny reasons differentiate on signals the wrapper already has
+
+The wrapper can already distinguish "no discovery file" from "discovery present but connection failed" — today both collapse into one `None`. Splitting them costs a two-variant enum and buys precise messages ("VaneHub has not registered on this machine" vs "the VaneHub instance that installed this hook is not running"). A PID-liveness check in the discovery file was considered and rejected: cross-platform liveness probing needs `libc`/`winapi` in a deliberately dependency-minimal binary, and the discovery-present/absent split already carries the diagnostic value. Both messages name both recovery actions so the blocked session's user (or the blocked Claude, relaying to its user) sees the way out in the denial itself.
+
+## D4: Startup reconvergence keys off the assigned principal row
+
+"Hook management enabled" has exactly one durable representation today: the `claude-code` principal has a real (non-synthesized) row, which is what `assign_template` creates when it installs the hook. Startup therefore re-runs `install()` iff `find_principal(CLAUDE_CODE_AGENT_ID)` reports an assigned row. This refreshes the wrapper path after application updates (the entry otherwise keeps naming the old install location forever) and re-heals a hand-mangled entry. It is best-effort in `bootstrap/permissions.rs`, matching the file's existing philosophy for `start_hook_bridge_server`: a failure (for example a missing wrapper binary in a dev build) leaves CLI sessions in the same risk-tiered offline fallback they were already in, and must not fail permissions bootstrap. When no assigned row exists, startup does not touch the settings file at all — a user who never enabled hook management keeps a byte-identical `settings.json`.

--- a/openspec/changes/archive/2026-08-20-add-permission-hook-recovery/proposal.md
+++ b/openspec/changes/archive/2026-08-20-add-permission-hook-recovery/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The permission hook is deliberately installed into Claude Code's *global* `settings.json` so that governance outlives the VaneHub process (fail-closed by design). But when the VaneHub instance dies without the user disabling hook management — a crash, a killed dev build, an e2e run's test client — every Claude Code session on the machine degrades to read-only (`Read`/`Glob`/`Grep` offline allowlist), and the only recovery today is a human hand-editing `~/.claude/settings.json`. Claude Code itself cannot self-recover: editing settings requires the `Edit` tool, which the very hook being removed denies. The deny message names the condition but no way out. A stale wrapper path left behind by an application update (the entry points at a binary location that no longer exists) has the same all-sessions blast radius with even less diagnosability.
+
+This change keeps the fail-closed semantics untouched and fixes the recovery paths around them.
+
+## What Changes
+
+- Add a standalone `--uninstall` escape hatch to the `vanehub-permission-hook` wrapper binary: it removes only VaneHub-owned `PreToolUse` entries from Claude Code's global settings, preserves everything else, and works with no VaneHub instance running — recovery becomes one command instead of hand-edited JSON.
+- Make the offline deny reasons actionable and state-differentiated: "discovery data present but the instance is unreachable" and "no discovery data at all" produce distinct messages, and both name the two recovery actions (start VaneHub, or run `vanehub-permission-hook --uninstall`).
+- Reconverge the hook registration at desktop startup: when the `claude-code` principal already has an assigned template row, the startup path re-projects the hook entries so the wrapper path is refreshed after an application update; failure is best-effort and never blocks startup.
+- The offline fallback allowlist, the fail-closed deny for reachable-but-malformed responses, and the global-settings installation model are explicitly unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `claude-code-permission-hook`: the wrapper gains a standalone uninstall mode, offline denials explain their recovery paths, and hook registration reconverges at desktop startup.
+
+## Impact
+
+- `crates/vanehub-permission-hook`: argument handling for `--uninstall`, settings-file surgery mirroring `cli_config`'s ownership marker, and differentiated deny reasons.
+- `src-tauri/src/contexts/permissions`: a startup reconvergence entry point on `PermissionsApi`; `bootstrap/permissions.rs` wires it best-effort.
+- No Tauri command signature changes, no SQLite schema changes, no frontend changes, no Web/mock runtime impact.
+- Out of scope (recorded for a follow-up): preventing dev/e2e builds from installing the hook into the real user's global settings, and any per-session (`claude --settings`) injection model — both change the governance scope itself rather than its recovery paths.

--- a/openspec/changes/archive/2026-08-20-add-permission-hook-recovery/specs/claude-code-permission-hook/spec.md
+++ b/openspec/changes/archive/2026-08-20-add-permission-hook-recovery/specs/claude-code-permission-hook/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Wrapper provides a standalone uninstall escape hatch
+
+The hook wrapper SHALL support a `--uninstall` invocation that removes only VaneHub-owned `PreToolUse` entries — identified by the wrapper binary's name appearing in an entry's hook command — from Claude Code's global settings file, SHALL preserve every other key and every non-owned hook entry, SHALL work without any running VaneHub instance or discovery data, and SHALL NOT modify the file when it cannot be parsed.
+
+#### Scenario: Owned entries are removed and everything else survives
+
+- **WHEN** `--uninstall` runs against a settings file containing VaneHub-owned `PreToolUse` entries alongside other keys and non-owned hook entries
+- **THEN** the owned entries SHALL be removed
+- **AND** every other key and non-owned hook entry SHALL be preserved
+- **AND** the process SHALL exit successfully
+
+#### Scenario: Nothing to remove is success, not failure
+
+- **WHEN** `--uninstall` runs and the settings file is absent or contains no VaneHub-owned entries
+- **THEN** the process SHALL exit successfully without modifying the file
+
+#### Scenario: An unparseable settings file is left untouched
+
+- **WHEN** `--uninstall` runs against a settings file that is not valid JSON
+- **THEN** the file SHALL NOT be modified
+- **AND** the process SHALL exit with a nonzero status and an error message
+
+### Requirement: Offline denial names its recovery paths
+
+The hook wrapper SHALL, when denying a tool call because the loopback server cannot be reached, produce a deny reason that distinguishes the absence of discovery data from a present-but-unreachable instance, and SHALL name both recovery actions — starting VaneHub, and running the wrapper's `--uninstall` escape hatch — in each variant.
+
+#### Scenario: Discovery data exists but the instance is unreachable
+
+- **WHEN** discovery data is present and the connection to the loopback server fails
+- **THEN** the deny reason SHALL state that the VaneHub instance is not reachable
+- **AND** SHALL name both recovery actions
+
+#### Scenario: No discovery data exists
+
+- **WHEN** no discovery data can be read at all
+- **THEN** the deny reason SHALL state that no VaneHub instance has registered on this machine
+- **AND** SHALL name both recovery actions
+
+### Requirement: Hook registration reconverges at desktop startup
+
+The desktop application SHALL, at startup, re-project the permission-hook entries into Claude Code's global settings when and only when the `claude-code` principal has a previously assigned template row, so that the entries name the current wrapper binary path after an application update. A reconvergence failure SHALL NOT block the rest of permissions bootstrap.
+
+#### Scenario: Hook management was previously enabled
+
+- **WHEN** the desktop application starts and the `claude-code` principal has an assigned template row
+- **THEN** the hook entries SHALL be re-projected naming the currently resolved wrapper path
+
+#### Scenario: Hook management was never enabled
+
+- **WHEN** the desktop application starts and the `claude-code` principal has no assigned template row
+- **THEN** Claude Code's global settings SHALL NOT be modified
+
+#### Scenario: Reconvergence fails
+
+- **WHEN** the startup re-projection fails for any reason
+- **THEN** permissions bootstrap SHALL continue
+- **AND** CLI sessions SHALL remain governed by the existing offline fallback behavior

--- a/openspec/changes/archive/2026-08-20-add-permission-hook-recovery/tasks.md
+++ b/openspec/changes/archive/2026-08-20-add-permission-hook-recovery/tasks.md
@@ -1,0 +1,14 @@
+## 1. Wrapper escape hatch and deny messaging
+
+- [x] 1.1 Add `--uninstall` mode to `crates/vanehub-permission-hook`: path-injectable settings surgery that removes only marker-owned `PreToolUse` entries via a temp-file-plus-rename write, with tests for removal, preservation, idempotent no-op, and unparseable-file refusal.
+- [x] 1.2 Split the wrapper's offline state into no-discovery vs unreachable and emit distinct deny reasons that name both recovery actions, with tests covering both variants and the unchanged allowlist behavior.
+
+## 2. Desktop startup reconvergence
+
+- [x] 2.1 Add a `PermissionsApi` reconvergence entry point that re-runs `install()` iff the `claude-code` principal has an assigned row, with tests for the assigned, unassigned, and failing-install cases.
+- [x] 2.2 Wire the reconvergence best-effort into `bootstrap/permissions.rs` startup assembly.
+
+## 3. Verification
+
+- [x] 3.1 Run `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`, `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `npm run native:panic:check`, and `cargo test --workspace` (one pre-existing, unrelated failure skipped: `git_fixtures_cover_non_git_and_common_worktree_states` breaks on zh_CN locale machines because git localizes "not a git repository" — everything else green).
+- [x] 3.2 Run `openspec validate add-permission-hook-recovery --strict` and `openspec validate --specs --strict`.

--- a/openspec/changes/archive/2026-08-20-pin-git-message-locale/design.md
+++ b/openspec/changes/archive/2026-08-20-pin-git-message-locale/design.md
@@ -1,0 +1,17 @@
+# Design
+
+## D1: Pin at the adapter, not at call sites
+
+`LC_ALL=C` is set once in `GitAdapter`'s shared request builder rather than by each caller: every consumer that classifies git output by text (today `session_queries.rs`, tomorrow anyone) gets the guarantee for free, and no future call site can silently reintroduce the bug. `LC_ALL` sits above `LC_MESSAGES` and `LANG` in libc's precedence, so pinning that single variable defeats any inherited language configuration.
+
+## D2: Callers can still override
+
+The pin is applied before caller-supplied environment in `execute_with_environment`, so an explicit `LC_ALL` from a caller replaces it (BTreeMap insert semantics). No current caller does; the door stays open for a deliberate future need without weakening the default.
+
+## D3: What is deliberately not changed
+
+Classification stays substring-based on English text — introducing exit-code or `rev-parse`-probe classification would be a larger behavioral change than this fix warrants. Filename handling is untouched: git emits paths as bytes and callers already pass `core.quotepath=false`, so `LC_ALL=C` does not alter path round-tripping.
+
+## D4: Test strategy
+
+Deterministic on every host: one test drives a hostile language environment (`LANG`/`LC_MESSAGES`/`LANGUAGE` = zh_CN) through `execute_with_environment` and asserts the English marker still appears; one asserts `execute` yields the English marker in a non-git directory (vacuously green on English hosts, the real regression on zh_CN hosts); one asserts override precedence purely via `ProcessRequest::command()`'s `get_envs()` without spawning git, avoiding dependence on which locales the host has generated.

--- a/openspec/changes/archive/2026-08-20-pin-git-message-locale/proposal.md
+++ b/openspec/changes/archive/2026-08-20-pin-git-message-locale/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`session_queries.rs` classifies Git command outcomes by matching English stderr substrings: `"not a git repository"` decides whether a session root is a non-Git directory (twice), and `"did not match any files"`/`"pathspec"` decides whether a path is untracked. But `GitAdapter::execute` inherits the host environment, so on any machine with a non-English locale (for example `LANG=zh_CN.UTF-8`, where git prints "不是 git 仓库") the substrings never match. The user-visible result violates `session-project-inspection`'s existing "Non-Git session" scenario: instead of the localized non-Git empty state, the Changes tab surfaces a raw "Git status failed." error for every non-Git folder, and untracked-path probes misreport as hard failures. The unit test `git_fixtures_cover_non_git_and_common_worktree_states` fails on such machines for the same reason — CI's English runners never see it.
+
+## What Changes
+
+- Pin the message locale (`LC_ALL=C`) on every Git invocation `GitAdapter` makes, so stderr/stdout classification is stable regardless of the host's display language. Caller-supplied environment in `execute_with_environment` still wins over the pinned default.
+- No change to how classified outcomes are presented: user-facing labels stay localized per the existing spec; only the *classification input* becomes locale-independent.
+- Add regression coverage that exercises outcome classification under a non-English locale.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `session-project-inspection`: Git inspection outcome classification is locale-independent; the non-Git empty state and untracked detection work on hosts with any display language.
+
+## Impact
+
+- `src-tauri/src/platform/git/mod.rs`: `execute`/`execute_with_environment` pin `LC_ALL=C` for the spawned git process only.
+- `src-tauri/src/contexts/workspaces/infrastructure/session_queries.rs`: no logic change expected; its substring matching becomes reliable. Its git fixture test starts passing on non-English machines.
+- No Tauri command changes, no schema changes, no frontend changes. Filename handling is unaffected: git emits paths as bytes and callers already pass `core.quotepath=false`.

--- a/openspec/changes/archive/2026-08-20-pin-git-message-locale/specs/session-project-inspection/spec.md
+++ b/openspec/changes/archive/2026-08-20-pin-git-message-locale/specs/session-project-inspection/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Git inspection outcomes are locale-independent
+
+The native runtime SHALL execute Git inspection commands with a pinned message locale so that outcome classification — non-Git detection and untracked-path detection in particular — does not depend on the host system's display language. User-facing presentation of the classified outcome SHALL remain localized as specified elsewhere in this capability.
+
+#### Scenario: Non-Git directory on a non-English host
+
+- **WHEN** the selected session root is not a Git repository and the host locale is not English
+- **THEN** the runtime SHALL classify it as the non-Git case
+- **AND** Changes SHALL show the localized non-Git empty state rather than a raw command failure
+
+#### Scenario: Untracked path on a non-English host
+
+- **WHEN** an untracked path is probed on a host whose locale is not English
+- **THEN** the runtime SHALL classify it as untracked rather than as a Git command failure
+
+#### Scenario: Caller-supplied environment still applies
+
+- **WHEN** a Git invocation is made with explicit caller-supplied environment variables
+- **THEN** those variables SHALL take precedence over the pinned locale default for that invocation

--- a/openspec/changes/archive/2026-08-20-pin-git-message-locale/tasks.md
+++ b/openspec/changes/archive/2026-08-20-pin-git-message-locale/tasks.md
@@ -1,0 +1,10 @@
+## 1. Pin the locale at the adapter
+
+- [x] 1.1 Set `LC_ALL=C` on the git process in `GitAdapter::execute`, and in `execute_with_environment` apply it before caller-supplied variables so explicit environment still wins.
+- [x] 1.2 Add regression coverage that classifies a non-Git directory and an untracked path with a non-English locale in the parent environment (for example `LANG`/`LC_ALL` set to `zh_CN.UTF-8` around the adapter call).
+
+## 2. Verification
+
+- [x] 2.1 Confirm `git_fixtures_cover_non_git_and_common_worktree_states` passes on a zh_CN-locale machine without `--skip`.
+- [x] 2.2 Run `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`, `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `npm run native:panic:check`, and `cargo test --workspace`.
+- [x] 2.3 Run `openspec validate pin-git-message-locale --strict` and `openspec validate --specs --strict`.

--- a/openspec/changes/archive/README.md
+++ b/openspec/changes/archive/README.md
@@ -97,7 +97,7 @@ Online archive location: `openspec/changes/archive/`
 | 2026-08-01 | add-loop-api-agent-support | loop-engineering-runtime | `openspec/changes/archive/2026-08-01-add-loop-api-agent-support/` |
 | 2026-08-01 | fix-terminal-usage-integrity | agent-execution-observability, agent-terminal-runtime, usage-statistics | `openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/` |
 | 2026-08-02 | add-cli-agent-global-config-switching | agent-switching, cli-agent-config-management | `openspec/changes/archive/2026-08-02-add-cli-agent-global-config-switching/` |
-| 2026-08-02 | add-common-application-locales | application-localization, app-settings, desktop-background-lifecycle, settings-basic-configuration-ui | `openspec/changes/archive/2026-08-02-add-common-application-locales/` |
+| 2026-08-02 | add-common-application-locales | app-settings, application-localization, desktop-background-lifecycle, settings-basic-configuration-ui | `openspec/changes/archive/2026-08-02-add-common-application-locales/` |
 | 2026-08-02 | harden-skill-management-reliability | agent-lifecycle-management, agent-skill-injection, settings-skill-management-ui, skill-management | `openspec/changes/archive/2026-08-02-harden-skill-management-reliability/` |
 | 2026-08-02 | optimize-runtime-performance-foundation | agent-terminal-runtime, runtime-performance-governance, session-management, settings-center-ui | `openspec/changes/archive/2026-08-02-optimize-runtime-performance-foundation/` |
 | 2026-08-02 | recover-webview-white-screen | desktop-webview-reliability | `openspec/changes/archive/2026-08-02-recover-webview-white-screen/` |
@@ -162,10 +162,10 @@ Online archive location: `openspec/changes/archive/`
 | 2026-08-14 | add-onepiece-context-optimizer | agent-context-compaction, agent-context-optimization | `openspec/changes/archive/2026-08-14-add-onepiece-context-optimizer/` |
 | 2026-08-14 | add-onepiece-context-quality-and-policy-evaluation | agent-context-evidence-projection, agent-context-quality-evaluation, app-settings, frontend-runtime-architecture, settings-cli-management-ui | `openspec/changes/archive/2026-08-14-add-onepiece-context-quality-and-policy-evaluation/` |
 | 2026-08-14 | add-onepiece-context-trigger-and-suppression | agent-context-compaction, agent-context-compaction-control, agent-context-measurement | `openspec/changes/archive/2026-08-14-add-onepiece-context-trigger-and-suppression/` |
-| 2026-08-14 | address-workspace-destinations-by-route | frontend-runtime-architecture, main-layout-ui | `openspec/changes/archive/2026-08-14-address-workspace-destinations-by-route/` |
 | 2026-08-14 | add-skill-evolution-evidence-pipeline | agent-execution-observability, chat-experience, settings-skill-management-ui, skill-evolution-evidence, skill-management | `openspec/changes/archive/2026-08-14-add-skill-evolution-evidence-pipeline/` |
 | 2026-08-14 | add-unified-todo-board | main-layout-ui, plan-management, scheduled-task-management, session-management, unified-todo-board | `openspec/changes/archive/2026-08-14-add-unified-todo-board/` |
 | 2026-08-14 | add-utility-skill-delegation-runtime | effective-skill-runtime, settings-skill-management-ui, skill-management, utility-skill-delegation-runtime | `openspec/changes/archive/2026-08-14-add-utility-skill-delegation-runtime/` |
+| 2026-08-14 | address-workspace-destinations-by-route | frontend-runtime-architecture, main-layout-ui | `openspec/changes/archive/2026-08-14-address-workspace-destinations-by-route/` |
 | 2026-08-14 | complete-onepiece-builtin-tool-system | agent-chat-configuration, agent-tool-execution, local-extension-management, onepiece-artifact-publishing, onepiece-browser-automation, onepiece-cli-delegation, onepiece-code-execution, onepiece-native-agent, onepiece-ocr-tool, onepiece-tool-governance, onepiece-web-research | `openspec/changes/archive/2026-08-14-complete-onepiece-builtin-tool-system/` |
 | 2026-08-14 | expand-file-mention-candidate-coverage | chat-experience | `openspec/changes/archive/2026-08-14-expand-file-mention-candidate-coverage/` |
 | 2026-08-14 | harden-workspace-dialogs-and-empty-states | loop-management-ui, main-layout-ui, visual-design-system | `openspec/changes/archive/2026-08-14-harden-workspace-dialogs-and-empty-states/` |
@@ -195,7 +195,7 @@ Online archive location: `openspec/changes/archive/`
 | 2026-08-17 | add-sandboxed-skill-tool-runtime | agent-tool-execution, permissions-approval, permissions-core, settings-skill-management-ui, skill-management, skill-tool-runtime | `openspec/changes/archive/2026-08-17-add-sandboxed-skill-tool-runtime/` |
 | 2026-08-17 | expand-runtime-performance-budgets | agent-context-engine, agent-context-measurement, agent-execution-observability, agent-mission-control, agent-run-state-management, lsp-code-intelligence, remote-terminal-runtime, runtime-performance-governance | `openspec/changes/archive/2026-08-17-expand-runtime-performance-budgets/` |
 | 2026-08-17 | extend-provider-runtime-plugin-sdk | agent-provider-runtime, provider-plugin-sdk | `openspec/changes/archive/2026-08-17-extend-provider-runtime-plugin-sdk/` |
-| 2026-08-18 | add-agent-runner-abstraction | agent-mission-control, agent-provider-runtime, agent-runner-runtime, agent-run-state-management, permissions-core, remote-terminal-runtime, runtime-performance-governance, unified-log-management | `openspec/changes/archive/2026-08-18-add-agent-runner-abstraction/` |
+| 2026-08-18 | add-agent-runner-abstraction | agent-mission-control, agent-provider-runtime, agent-run-state-management, agent-runner-runtime, permissions-core, remote-terminal-runtime, runtime-performance-governance, unified-log-management | `openspec/changes/archive/2026-08-18-add-agent-runner-abstraction/` |
 | 2026-08-18 | add-hybrid-local-model-runtime | agent-context-engine, agent-context-measurement, api-agent-runtime, hybrid-local-model-runtime, onepiece-native-agent | `openspec/changes/archive/2026-08-18-add-hybrid-local-model-runtime/` |
 | 2026-08-18 | extract-api-adapter-inline-tests | - | `openspec/changes/archive/2026-08-18-extract-api-adapter-inline-tests/` |
 | 2026-08-18 | freeze-large-file-line-budgets | repository-governance | `openspec/changes/archive/2026-08-18-freeze-large-file-line-budgets/` |
@@ -208,5 +208,7 @@ Online archive location: `openspec/changes/archive/`
 | 2026-08-19 | relocate-heavyweight-inline-tests | - | `openspec/changes/archive/2026-08-19-relocate-heavyweight-inline-tests/` |
 | 2026-08-19 | retire-panic-shortcut-whitelist | repository-governance | `openspec/changes/archive/2026-08-19-retire-panic-shortcut-whitelist/` |
 | 2026-08-19 | split-api-adapter-modules | - | `openspec/changes/archive/2026-08-19-split-api-adapter-modules/` |
+| 2026-08-20 | add-permission-hook-recovery | claude-code-permission-hook | `openspec/changes/archive/2026-08-20-add-permission-hook-recovery/` |
+| 2026-08-20 | pin-git-message-locale | session-project-inspection | `openspec/changes/archive/2026-08-20-pin-git-message-locale/` |
 
 Cold-archive destinations are recorded in `openspec/archive-cold-migrations.md`.

--- a/openspec/changes/archive/archive-index.json
+++ b/openspec/changes/archive/archive-index.json
@@ -1,3040 +1,3044 @@
 {
-    "schemaVersion":  1,
-    "archives":  [
-                     {
-                         "archivedOn":  "2026-07-13",
-                         "changeName":  "unify-ai-agent-tool-management",
-                         "path":  "openspec/changes/archive/2026-07-13-unify-ai-agent-tool-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-switching",
-                                              "agent-tool-registry",
-                                              "interaction-modes"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-14",
-                         "changeName":  "add-mcp-client-management",
-                         "path":  "openspec/changes/archive/2026-07-14-add-mcp-client-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "mcp-client-management",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-14",
-                         "changeName":  "support-native-package-builds",
-                         "path":  "openspec/changes/archive/2026-07-14-support-native-package-builds/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "native-app-packaging"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-14",
-                         "changeName":  "support-switchable-ucd-settings-ui",
-                         "path":  "openspec/changes/archive/2026-07-14-support-switchable-ucd-settings-ui/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-switching",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-15",
-                         "changeName":  "add-session-management",
-                         "path":  "openspec/changes/archive/2026-07-15-add-session-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui",
-                                              "session-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-15",
-                         "changeName":  "implement-main-chat-experience",
-                         "path":  "openspec/changes/archive/2026-07-15-implement-main-chat-experience/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "main-layout-ui",
-                                              "session-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-15",
-                         "changeName":  "improve-architecture-extensibility",
-                         "path":  "openspec/changes/archive/2026-07-15-improve-architecture-extensibility/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-switching",
-                                              "agent-tool-registry",
-                                              "contract-and-task-foundation",
-                                              "frontend-runtime-architecture",
-                                              "interaction-modes",
-                                              "mcp-client-management",
-                                              "native-runtime-architecture",
-                                              "sdk-dependency-management",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-15",
-                         "changeName":  "improve-main-layout-ui",
-                         "path":  "openspec/changes/archive/2026-07-15-improve-main-layout-ui/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-15",
-                         "changeName":  "replace-main-content-with-chat",
-                         "path":  "openspec/changes/archive/2026-07-15-replace-main-content-with-chat/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-15",
-                         "changeName":  "support-sdk-dependency-management",
-                         "path":  "openspec/changes/archive/2026-07-15-support-sdk-dependency-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-registry",
-                                              "sdk-dependency-management",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-16",
-                         "changeName":  "add-skill-management-settings",
-                         "path":  "openspec/changes/archive/2026-07-16-add-skill-management-settings/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "settings-center-ui",
-                                              "skill-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-16",
-                         "changeName":  "add-unified-log-management",
-                         "path":  "openspec/changes/archive/2026-07-16-add-unified-log-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-registry",
-                                              "app-settings",
-                                              "native-runtime-architecture",
-                                              "sdk-dependency-management",
-                                              "settings-center-ui",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-16",
-                         "changeName":  "complete-general-settings-i18n-font-fix",
-                         "path":  "openspec/changes/archive/2026-07-16-complete-general-settings-i18n-font-fix/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "app-settings",
-                                              "frontend-runtime-architecture",
-                                              "main-layout-ui",
-                                              "native-runtime-architecture",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-16",
-                         "changeName":  "complete-session-management",
-                         "path":  "openspec/changes/archive/2026-07-16-complete-session-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "main-layout-ui",
-                                              "native-runtime-architecture",
-                                              "project-worktree-management",
-                                              "session-management",
-                                              "session-runtime-management",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-16",
-                         "changeName":  "replace-provider-management-with-cli-management",
-                         "path":  "openspec/changes/archive/2026-07-16-replace-provider-management-with-cli-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-registry",
-                                              "native-runtime-architecture",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "add-about-page",
-                         "path":  "openspec/changes/archive/2026-07-17-add-about-page/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "add-cli-parameter-management",
-                         "path":  "openspec/changes/archive/2026-07-17-add-cli-parameter-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "cli-parameter-management",
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "add-desktop-floating-assistant",
-                         "path":  "openspec/changes/archive/2026-07-17-add-desktop-floating-assistant/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "desktop-floating-assistant",
-                                              "session-chat-configuration",
-                                              "settings-center-ui",
-                                              "visual-design-system"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "add-im-connectors",
-                         "path":  "openspec/changes/archive/2026-07-17-add-im-connectors/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "desktop-background-lifecycle",
-                                              "frontend-runtime-architecture",
-                                              "im-connector-management",
-                                              "main-layout-ui",
-                                              "native-runtime-architecture",
-                                              "session-runtime-management",
-                                              "settings-center-ui",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "add-local-extension-capabilities",
-                         "path":  "openspec/changes/archive/2026-07-17-add-local-extension-capabilities/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "local-extension-management",
-                                              "settings-center-ui",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "add-network-proxy-settings",
-                         "path":  "openspec/changes/archive/2026-07-17-add-network-proxy-settings/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "app-settings",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "add-openspec-archive-catalog",
-                         "path":  "openspec/changes/archive/2026-07-17-add-openspec-archive-catalog/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "openspec-archive-governance"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "add-spec-optimizer",
-                         "path":  "openspec/changes/archive/2026-07-17-add-spec-optimizer/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "spec-optimization"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "add-unified-notification-framework",
-                         "path":  "openspec/changes/archive/2026-07-17-add-unified-notification-framework/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui",
-                                              "notification-system"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "add-usage-statistics-settings",
-                         "path":  "openspec/changes/archive/2026-07-17-add-usage-statistics-settings/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture",
-                                              "settings-center-ui",
-                                              "usage-statistics"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "analyze-settings-center-spec-compression",
-                         "path":  "openspec/changes/archive/2026-07-17-analyze-settings-center-spec-compression/",
-                         "artifacts":  [
-                                           "proposal"
-                                       ],
-                         "capabilities":  [
-
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "fix-i18n-page-copy",
-                         "path":  "openspec/changes/archive/2026-07-17-fix-i18n-page-copy/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "frontend-runtime-architecture",
-                                              "main-layout-ui",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "fix-sdk-page-cli-errors",
-                         "path":  "openspec/changes/archive/2026-07-17-fix-sdk-page-cli-errors/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture",
-                                              "sdk-dependency-management",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "govern-openspec-archive-lifecycle",
-                         "path":  "openspec/changes/archive/2026-07-17-govern-openspec-archive-lifecycle/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "openspec-archive-governance"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "implement-cli-chat-runtime-v1",
-                         "path":  "openspec/changes/archive/2026-07-17-implement-cli-chat-runtime-v1/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "session-runtime-management",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "optimize-long-running-operations",
-                         "path":  "openspec/changes/archive/2026-07-17-optimize-long-running-operations/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "optimize-session-workspace-tabs",
-                         "path":  "openspec/changes/archive/2026-07-17-optimize-session-workspace-tabs/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui",
-                                              "session-log-viewer",
-                                              "session-project-inspection",
-                                              "session-shell",
-                                              "session-workspace-tabs",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "optimize-ui-polish",
-                         "path":  "openspec/changes/archive/2026-07-17-optimize-ui-polish/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui",
-                                              "settings-center-ui",
-                                              "visual-design-system"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "split-settings-center-ui-spec",
-                         "path":  "openspec/changes/archive/2026-07-17-split-settings-center-ui-spec/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "settings-basic-configuration-ui",
-                                              "settings-center-ui",
-                                              "settings-cli-management-ui",
-                                              "settings-extension-management-ui",
-                                              "settings-floating-assistant-ui",
-                                              "settings-im-management-ui",
-                                              "settings-skill-management-ui",
-                                              "settings-usage-statistics-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-17",
-                         "changeName":  "upgrade-usage-statistics-monitoring",
-                         "path":  "openspec/changes/archive/2026-07-17-upgrade-usage-statistics-monitoring/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture",
-                                              "session-runtime-management",
-                                              "settings-center-ui",
-                                              "usage-statistics"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-18",
-                         "changeName":  "add-github-plugin-integration",
-                         "path":  "openspec/changes/archive/2026-07-18-add-github-plugin-integration/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "frontend-runtime-architecture",
-                                              "plugin-integration-management",
-                                              "settings-center-ui",
-                                              "settings-plugin-integration-ui",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-18",
-                         "changeName":  "add-remote-workspace",
-                         "path":  "openspec/changes/archive/2026-07-18-add-remote-workspace/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "project-worktree-management",
-                                              "session-management",
-                                              "session-workspace-tabs"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-18",
-                         "changeName":  "add-rich-block-chat-rendering",
-                         "path":  "openspec/changes/archive/2026-07-18-add-rich-block-chat-rendering/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-18",
-                         "changeName":  "add-workspace-activity-bar",
-                         "path":  "openspec/changes/archive/2026-07-18-add-workspace-activity-bar/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-18",
-                         "changeName":  "enhance-prompt-hook-management",
-                         "path":  "openspec/changes/archive/2026-07-18-enhance-prompt-hook-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture",
-                                              "prompt-hook-management",
-                                              "settings-center-ui",
-                                              "settings-prompt-hooks-ui",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-18",
-                         "changeName":  "fix-log-performance-and-error-reporting",
-                         "path":  "openspec/changes/archive/2026-07-18-fix-log-performance-and-error-reporting/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "session-log-viewer",
-                                              "session-workspace-tabs",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-18",
-                         "changeName":  "improve-session-management",
-                         "path":  "openspec/changes/archive/2026-07-18-improve-session-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "app-settings",
-                                              "chat-experience",
-                                              "frontend-runtime-architecture",
-                                              "main-layout-ui",
-                                              "native-runtime-architecture",
-                                              "session-category-management",
-                                              "session-export",
-                                              "session-management",
-                                              "session-runtime-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-18",
-                         "changeName":  "optimize-cli-local-environment-management",
-                         "path":  "openspec/changes/archive/2026-07-18-optimize-cli-local-environment-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-registry",
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-18",
-                         "changeName":  "optimize-cli-management-and-about",
-                         "path":  "openspec/changes/archive/2026-07-18-optimize-cli-management-and-about/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "settings-cli-management-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-18",
-                         "changeName":  "optimize-settings-ui-and-runtime-controls",
-                         "path":  "openspec/changes/archive/2026-07-18-optimize-settings-ui-and-runtime-controls/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "app-settings",
-                                              "desktop-floating-assistant",
-                                              "desktop-startup-controls",
-                                              "main-layout-ui",
-                                              "native-runtime-architecture",
-                                              "session-management",
-                                              "settings-basic-configuration-ui",
-                                              "settings-center-ui",
-                                              "settings-data-management",
-                                              "settings-extension-management-ui",
-                                              "settings-floating-assistant-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-19",
-                         "changeName":  "add-scheduled-tasks",
-                         "path":  "openspec/changes/archive/2026-07-19-add-scheduled-tasks/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui",
-                                              "scheduled-task-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-19",
-                         "changeName":  "add-workspace-folder-openers",
-                         "path":  "openspec/changes/archive/2026-07-19-add-workspace-folder-openers/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "app-settings",
-                                              "session-workspace-tabs",
-                                              "settings-basic-configuration-ui",
-                                              "workspace-folder-openers"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-19",
-                         "changeName":  "fix-agent-workspace-logs-and-cli-launch",
-                         "path":  "openspec/changes/archive/2026-07-19-fix-agent-workspace-logs-and-cli-launch/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-terminal-runtime",
-                                              "main-layout-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-19",
-                         "changeName":  "fix-session-creation-and-cli-runtime",
-                         "path":  "openspec/changes/archive/2026-07-19-fix-session-creation-and-cli-runtime/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "cli-parameter-management",
-                                              "interaction-modes",
-                                              "main-layout-ui",
-                                              "session-management",
-                                              "session-runtime-management",
-                                              "settings-cli-management-ui",
-                                              "workspace-folder-openers"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-19",
-                         "changeName":  "redesign-cross-platform-app-icon",
-                         "path":  "openspec/changes/archive/2026-07-19-redesign-cross-platform-app-icon/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "cross-platform-app-icon"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-19",
-                         "changeName":  "refactor-rust-ddd-architecture",
-                         "path":  "openspec/changes/archive/2026-07-19-refactor-rust-ddd-architecture/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "native-runtime-architecture"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-19",
-                         "changeName":  "replace-chat-with-agent-terminal-session",
-                         "path":  "openspec/changes/archive/2026-07-19-replace-chat-with-agent-terminal-session/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-terminal-runtime",
-                                              "cli-parameter-management",
-                                              "main-layout-ui",
-                                              "native-runtime-architecture",
-                                              "session-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-20",
-                         "changeName":  "fix-agent-terminal-retention",
-                         "path":  "openspec/changes/archive/2026-07-20-fix-agent-terminal-retention/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-terminal-runtime",
-                                              "native-runtime-architecture"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-20",
-                         "changeName":  "optimize-session-info-panel",
-                         "path":  "openspec/changes/archive/2026-07-20-optimize-session-info-panel/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "frontend-runtime-architecture",
-                                              "main-layout-ui",
-                                              "usage-statistics"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-20",
-                         "changeName":  "optimize-session-management-page",
-                         "path":  "openspec/changes/archive/2026-07-20-optimize-session-management-page/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui",
-                                              "session-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-21",
-                         "changeName":  "settings-about-page-layout",
-                         "path":  "openspec/changes/archive/2026-07-21-settings-about-page-layout/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-22",
-                         "changeName":  "add-ssh-connection-management",
-                         "path":  "openspec/changes/archive/2026-07-22-add-ssh-connection-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "session-management",
-                                              "settings-center-ui",
-                                              "settings-ssh-connection-ui",
-                                              "ssh-connection-management",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-22",
-                         "changeName":  "configure-github-repository",
-                         "path":  "openspec/changes/archive/2026-07-22-configure-github-repository/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "continuous-integration",
-                                              "desktop-release-delivery",
-                                              "repository-governance",
-                                              "software-supply-chain-security"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-22",
-                         "changeName":  "enhance-session-resume-and-project-sidebar",
-                         "path":  "openspec/changes/archive/2026-07-22-enhance-session-resume-and-project-sidebar/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-terminal-runtime",
-                                              "main-layout-ui",
-                                              "session-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-22",
-                         "changeName":  "fix-ssh-connection-management-defects",
-                         "path":  "openspec/changes/archive/2026-07-22-fix-ssh-connection-management-defects/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "session-management",
-                                              "settings-ssh-connection-ui",
-                                              "ssh-connection-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-23",
-                         "changeName":  "add-loop-engineering-runtime",
-                         "path":  "openspec/changes/archive/2026-07-23-add-loop-engineering-runtime/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "loop-engineering-runtime",
-                                              "loop-management-ui",
-                                              "main-layout-ui",
-                                              "project-worktree-management",
-                                              "session-runtime-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-23",
-                         "changeName":  "add-multi-agent-coordination",
-                         "path":  "openspec/changes/archive/2026-07-23-add-multi-agent-coordination/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-execution-observability",
-                                              "multi-agent-coordination"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-23",
-                         "changeName":  "agent-execution-observability",
-                         "path":  "openspec/changes/archive/2026-07-23-agent-execution-observability/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-execution-observability",
-                                              "app-settings",
-                                              "contract-and-task-foundation",
-                                              "mcp-client-management",
-                                              "session-runtime-management",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-23",
-                         "changeName":  "optimize-frontend-rendering-and-loading",
-                         "path":  "openspec/changes/archive/2026-07-23-optimize-frontend-rendering-and-loading/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "frontend-runtime-architecture",
-                                              "main-layout-ui",
-                                              "session-log-viewer",
-                                              "session-workspace-tabs",
-                                              "settings-center-ui",
-                                              "settings-prompt-hooks-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-24",
-                         "changeName":  "add-remote-terminal-management",
-                         "path":  "openspec/changes/archive/2026-07-24-add-remote-terminal-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "remote-terminal-runtime",
-                                              "session-management",
-                                              "session-shell",
-                                              "ssh-connection-management",
-                                              "terminal-command-management",
-                                              "terminal-output-search",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-24",
-                         "changeName":  "enhance-prompt-library-advanced-features",
-                         "path":  "openspec/changes/archive/2026-07-24-enhance-prompt-library-advanced-features/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture",
-                                              "prompt-hook-management",
-                                              "settings-prompt-hooks-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-24",
-                         "changeName":  "establish-multilingual-documentation",
-                         "path":  "openspec/changes/archive/2026-07-24-establish-multilingual-documentation/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "multilingual-readme",
-                                              "native-developer-documentation",
-                                              "user-guide-documentation"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-24",
-                         "changeName":  "optimize-rust-build-and-release",
-                         "path":  "openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "continuous-integration",
-                                              "native-app-packaging",
-                                              "native-build-optimization"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-26",
-                         "changeName":  "fix-embedded-terminal-tui-contrast",
-                         "path":  "openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "session-workspace-tabs"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-28",
-                         "changeName":  "dynamic-llm-model-discovery",
-                         "path":  "openspec/changes/archive/2026-07-28-dynamic-llm-model-discovery/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "cli-parameter-management",
-                                              "custom-model-display",
-                                              "native-model-discovery",
-                                              "session-chat-configuration"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-28",
-                         "changeName":  "fix-session-workspace-ui-defects",
-                         "path":  "openspec/changes/archive/2026-07-28-fix-session-workspace-ui-defects/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "session-workspace-tabs"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-28",
-                         "changeName":  "fix-settings-hydration-flash",
-                         "path":  "openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "app-settings"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-31",
-                         "changeName":  "add-reported-usage-ingestion",
-                         "path":  "openspec/changes/archive/2026-07-31-add-reported-usage-ingestion/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "usage-statistics"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-31",
-                         "changeName":  "add-terminal-usage-tracking",
-                         "path":  "openspec/changes/archive/2026-07-31-add-terminal-usage-tracking/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "usage-statistics"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-31",
-                         "changeName":  "establish-test-coverage-and-integration-gates",
-                         "path":  "openspec/changes/archive/2026-07-31-establish-test-coverage-and-integration-gates/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "continuous-integration",
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-31",
-                         "changeName":  "fix-cli-terminal-session-resume-capture",
-                         "path":  "openspec/changes/archive/2026-07-31-fix-cli-terminal-session-resume-capture/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-terminal-runtime"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-07-31",
-                         "changeName":  "pool-native-sqlite-connections",
-                         "path":  "openspec/changes/archive/2026-07-31-pool-native-sqlite-connections/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "native-runtime-architecture"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-01",
-                         "changeName":  "add-agent-chat-configuration",
-                         "path":  "openspec/changes/archive/2026-08-01-add-agent-chat-configuration/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-chat-configuration"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-01",
-                         "changeName":  "add-agent-context-compaction",
-                         "path":  "openspec/changes/archive/2026-08-01-add-agent-context-compaction/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-context-compaction"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-01",
-                         "changeName":  "add-agent-cross-session-memory",
-                         "path":  "openspec/changes/archive/2026-08-01-add-agent-cross-session-memory/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-cross-session-memory"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-01",
-                         "changeName":  "add-agent-lifecycle-management",
-                         "path":  "openspec/changes/archive/2026-08-01-add-agent-lifecycle-management/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-lifecycle-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-01",
-                         "changeName":  "add-agent-mcp-tools",
-                         "path":  "openspec/changes/archive/2026-08-01-add-agent-mcp-tools/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "agent-mcp-tools"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-01",
-                         "changeName":  "add-agent-skill-support",
-                         "path":  "openspec/changes/archive/2026-08-01-add-agent-skill-support/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-skill-injection"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-01",
-                         "changeName":  "add-agent-tool-execution",
-                         "path":  "openspec/changes/archive/2026-08-01-add-agent-tool-execution/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-execution"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-01",
-                         "changeName":  "add-agent-tool-trust",
-                         "path":  "openspec/changes/archive/2026-08-01-add-agent-tool-trust/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-trust"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-01",
-                         "changeName":  "add-custom-agent-registration",
-                         "path":  "openspec/changes/archive/2026-08-01-add-custom-agent-registration/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-registry",
-                                              "api-agent-runtime",
-                                              "chat-experience",
-                                              "interaction-modes"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-01",
-                         "changeName":  "add-loop-api-agent-support",
-                         "path":  "openspec/changes/archive/2026-08-01-add-loop-api-agent-support/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "loop-engineering-runtime"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-01",
-                         "changeName":  "fix-terminal-usage-integrity",
-                         "path":  "openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-execution-observability",
-                                              "agent-terminal-runtime",
-                                              "usage-statistics"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-02",
-                         "changeName":  "add-cli-agent-global-config-switching",
-                         "path":  "openspec/changes/archive/2026-08-02-add-cli-agent-global-config-switching/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-switching",
-                                              "cli-agent-config-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-02",
-                         "changeName":  "add-common-application-locales",
-                         "path":  "openspec/changes/archive/2026-08-02-add-common-application-locales/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "application-localization",
-                                              "app-settings",
-                                              "desktop-background-lifecycle",
-                                              "settings-basic-configuration-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-02",
-                         "changeName":  "harden-skill-management-reliability",
-                         "path":  "openspec/changes/archive/2026-08-02-harden-skill-management-reliability/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "agent-lifecycle-management",
-                                              "agent-skill-injection",
-                                              "settings-skill-management-ui",
-                                              "skill-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-02",
-                         "changeName":  "optimize-runtime-performance-foundation",
-                         "path":  "openspec/changes/archive/2026-08-02-optimize-runtime-performance-foundation/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "agent-terminal-runtime",
-                                              "runtime-performance-governance",
-                                              "session-management",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-02",
-                         "changeName":  "recover-webview-white-screen",
-                         "path":  "openspec/changes/archive/2026-08-02-recover-webview-white-screen/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "desktop-webview-reliability"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-02",
-                         "changeName":  "refine-basic-settings-information-architecture",
-                         "path":  "openspec/changes/archive/2026-08-02-refine-basic-settings-information-architecture/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "settings-basic-configuration-ui",
-                                              "settings-floating-assistant-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-03",
-                         "changeName":  "harden-mcp-runtime-reliability",
-                         "path":  "openspec/changes/archive/2026-08-03-harden-mcp-runtime-reliability/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "agent-mcp-tools",
-                                              "mcp-client-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-03",
-                         "changeName":  "harden-skill-mount-root-links",
-                         "path":  "openspec/changes/archive/2026-08-03-harden-skill-mount-root-links/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "settings-skill-management-ui",
-                                              "skill-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-03",
-                         "changeName":  "optimize-skill-management-ui",
-                         "path":  "openspec/changes/archive/2026-08-03-optimize-skill-management-ui/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui",
-                                              "settings-skill-management-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-03",
-                         "changeName":  "refine-skill-agent-selection-ui",
-                         "path":  "openspec/changes/archive/2026-08-03-refine-skill-agent-selection-ui/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "settings-skill-management-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-04",
-                         "changeName":  "add-onepiece-native-agent",
-                         "path":  "openspec/changes/archive/2026-08-04-add-onepiece-native-agent/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "agent-lifecycle-management",
-                                              "agent-skill-injection",
-                                              "api-agent-runtime",
-                                              "onepiece-native-agent",
-                                              "session-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-04",
-                         "changeName":  "enhance-chat-rich-media",
-                         "path":  "openspec/changes/archive/2026-08-04-enhance-chat-rich-media/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-04",
-                         "changeName":  "harden-im-runtime-reliability",
-                         "path":  "openspec/changes/archive/2026-08-04-harden-im-runtime-reliability/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "frontend-runtime-architecture",
-                                              "im-connector-management",
-                                              "native-runtime-architecture",
-                                              "session-runtime-management",
-                                              "settings-im-management-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-04",
-                         "changeName":  "maximize-main-window-on-startup",
-                         "path":  "openspec/changes/archive/2026-08-04-maximize-main-window-on-startup/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "desktop-background-lifecycle"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-04",
-                         "changeName":  "remove-agent-management-page",
-                         "path":  "openspec/changes/archive/2026-08-04-remove-agent-management-page/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-switching",
-                                              "cli-agent-config-management",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-05",
-                         "changeName":  "add-permissions-core",
-                         "path":  "openspec/changes/archive/2026-08-05-add-permissions-core/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-execution",
-                                              "agent-tool-trust",
-                                              "permissions-approval",
-                                              "permissions-core"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-05",
-                         "changeName":  "add-permissions-settings-ui",
-                         "path":  "openspec/changes/archive/2026-08-05-add-permissions-settings-ui/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "permissions-approval",
-                                              "permissions-core"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-05",
-                         "changeName":  "polish-workspace-visual-consistency",
-                         "path":  "openspec/changes/archive/2026-08-05-polish-workspace-visual-consistency/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-terminal-runtime",
-                                              "main-layout-ui",
-                                              "notification-system",
-                                              "visual-design-system"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-06",
-                         "changeName":  "add-claude-code-permission-callback",
-                         "path":  "openspec/changes/archive/2026-08-06-add-claude-code-permission-callback/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "claude-code-permission-hook",
-                                              "cli-agent-config-management",
-                                              "permissions-approval",
-                                              "permissions-core"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-06",
-                         "changeName":  "add-cli-agent-permission-launch-flags",
-                         "path":  "openspec/changes/archive/2026-08-06-add-cli-agent-permission-launch-flags/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-terminal-runtime",
-                                              "cli-agent-permission-launch-flags",
-                                              "cli-parameter-management",
-                                              "permissions-approval"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-06",
-                         "changeName":  "add-cli-custom-instructions-injection",
-                         "path":  "openspec/changes/archive/2026-08-06-add-cli-custom-instructions-injection/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "custom-instructions",
-                                              "native-runtime-architecture"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-06",
-                         "changeName":  "add-cli-memory-support",
-                         "path":  "openspec/changes/archive/2026-08-06-add-cli-memory-support/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-cross-session-memory",
-                                              "native-runtime-architecture"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-06",
-                         "changeName":  "add-onepiece-search-and-edit-tools",
-                         "path":  "openspec/changes/archive/2026-08-06-add-onepiece-search-and-edit-tools/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-chat-configuration",
-                                              "agent-context-compaction",
-                                              "agent-tool-execution",
-                                              "agent-tool-trust",
-                                              "onepiece-native-agent"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-06",
-                         "changeName":  "add-personalization-settings",
-                         "path":  "openspec/changes/archive/2026-08-06-add-personalization-settings/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-cross-session-memory",
-                                              "agent-skill-injection",
-                                              "app-settings",
-                                              "custom-instructions",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-06",
-                         "changeName":  "remove-multi-agent-coordination",
-                         "path":  "openspec/changes/archive/2026-08-06-remove-multi-agent-coordination/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-execution-observability",
-                                              "multi-agent-coordination",
-                                              "multilingual-readme",
-                                              "user-guide-documentation"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-07",
-                         "changeName":  "add-multi-agent-group-chat-session",
-                         "path":  "openspec/changes/archive/2026-08-07-add-multi-agent-group-chat-session/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "expert-role-management",
-                                              "multi-agent-group-chat",
-                                              "session-management",
-                                              "session-workspace-tabs",
-                                              "settings-center-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-07",
-                         "changeName":  "add-retrieval-vector-search",
-                         "path":  "openspec/changes/archive/2026-08-07-add-retrieval-vector-search/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-cross-session-memory",
-                                              "retrieval-vector-search"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-07",
-                         "changeName":  "bound-short-query-message-search",
-                         "path":  "openspec/changes/archive/2026-08-07-bound-short-query-message-search/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "session-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-07",
-                         "changeName":  "contain-timed-out-process-trees",
-                         "path":  "openspec/changes/archive/2026-08-07-contain-timed-out-process-trees/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "native-runtime-architecture"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-07",
-                         "changeName":  "surface-cli-error-results",
-                         "path":  "openspec/changes/archive/2026-08-07-surface-cli-error-results/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "session-runtime-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-08",
-                         "changeName":  "add-plan-execution-foundation",
-                         "path":  "openspec/changes/archive/2026-08-08-add-plan-execution-foundation/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "agent-execution-observability",
-                                              "frontend-runtime-architecture",
-                                              "onepiece-native-agent",
-                                              "plan-execution-runtime",
-                                              "plan-management",
-                                              "project-worktree-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-08",
-                         "changeName":  "workspace-code-indexing-foundation",
-                         "path":  "openspec/changes/archive/2026-08-08-workspace-code-indexing-foundation/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "retrieval-vector-search",
-                                              "workspace-code-indexing"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-09",
-                         "changeName":  "add-antigravity-cli",
-                         "path":  "openspec/changes/archive/2026-08-09-add-antigravity-cli/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-cross-session-memory",
-                                              "agent-terminal-runtime",
-                                              "chat-experience",
-                                              "cli-agent-config-management",
-                                              "cli-agent-permission-launch-flags",
-                                              "cli-parameter-management",
-                                              "main-layout-ui",
-                                              "native-model-discovery",
-                                              "native-runtime-architecture",
-                                              "permissions-approval",
-                                              "prompt-hook-management",
-                                              "settings-cli-management-ui",
-                                              "skill-management",
-                                              "usage-statistics"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-09",
-                         "changeName":  "add-gemini-cli-terminal-usage-tracking",
-                         "path":  "openspec/changes/archive/2026-08-09-add-gemini-cli-terminal-usage-tracking/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "usage-statistics"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-09",
-                         "changeName":  "add-local-code-index-mode",
-                         "path":  "openspec/changes/archive/2026-08-09-add-local-code-index-mode/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "workspace-code-indexing"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-09",
-                         "changeName":  "deduplicate-skill-spec-requirements",
-                         "path":  "openspec/changes/archive/2026-08-09-deduplicate-skill-spec-requirements/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-09",
-                         "changeName":  "harden-runtime-concurrency-and-query-efficiency",
-                         "path":  "openspec/changes/archive/2026-08-09-harden-runtime-concurrency-and-query-efficiency/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture",
-                                              "runtime-performance-governance"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-09",
-                         "changeName":  "introduce-agent-provider-contract",
-                         "path":  "openspec/changes/archive/2026-08-09-introduce-agent-provider-contract/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-provider-runtime"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-09",
-                         "changeName":  "publish-github-preview-release",
-                         "path":  "openspec/changes/archive/2026-08-09-publish-github-preview-release/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "desktop-release-delivery",
-                                              "multilingual-readme",
-                                              "native-app-packaging"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-09",
-                         "changeName":  "reconcile-builtin-skill-seeding",
-                         "path":  "openspec/changes/archive/2026-08-09-reconcile-builtin-skill-seeding/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "skill-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-09",
-                         "changeName":  "refuse-missing-permission-hook-binary",
-                         "path":  "openspec/changes/archive/2026-08-09-refuse-missing-permission-hook-binary/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "claude-code-permission-hook"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-09",
-                         "changeName":  "scope-readme-guides-per-language",
-                         "path":  "openspec/changes/archive/2026-08-09-scope-readme-guides-per-language/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "multilingual-readme"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-09",
-                         "changeName":  "suppress-probe-console-windows",
-                         "path":  "openspec/changes/archive/2026-08-09-suppress-probe-console-windows/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "native-runtime-architecture"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-10",
-                         "changeName":  "add-session-recovery-evidence-foundation",
-                         "path":  "openspec/changes/archive/2026-08-10-add-session-recovery-evidence-foundation/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "loop-engineering-runtime",
-                                              "native-runtime-architecture",
-                                              "plan-execution-runtime",
-                                              "session-management",
-                                              "session-recovery",
-                                              "session-runtime-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-10",
-                         "changeName":  "establish-effective-skill-runtime",
-                         "path":  "openspec/changes/archive/2026-08-10-establish-effective-skill-runtime/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-chat-configuration",
-                                              "agent-skill-injection",
-                                              "agent-tool-execution",
-                                              "effective-skill-runtime",
-                                              "settings-skill-management-ui",
-                                              "skill-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-10",
-                         "changeName":  "refine-effective-skill-management-ui",
-                         "path":  "openspec/changes/archive/2026-08-10-refine-effective-skill-management-ui/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "settings-skill-management-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-11",
-                         "changeName":  "add-lsp-code-intelligence-foundation",
-                         "path":  "openspec/changes/archive/2026-08-11-add-lsp-code-intelligence-foundation/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-chat-configuration",
-                                              "agent-tool-execution",
-                                              "lsp-code-intelligence",
-                                              "lsp-server-management",
-                                              "settings-center-ui",
-                                              "unified-log-management",
-                                              "workspace-code-indexing"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-11",
-                         "changeName":  "complete-multi-agent-session-presence",
-                         "path":  "openspec/changes/archive/2026-08-11-complete-multi-agent-session-presence/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "main-layout-ui",
-                                              "multi-agent-group-chat",
-                                              "session-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-12",
-                         "changeName":  "add-skill-overlay-governance",
-                         "path":  "openspec/changes/archive/2026-08-12-add-skill-overlay-governance/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-skill-injection",
-                                              "settings-skill-management-ui",
-                                              "skill-management",
-                                              "skill-overlay-governance"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-12",
-                         "changeName":  "compact-chat-tool-activity",
-                         "path":  "openspec/changes/archive/2026-08-12-compact-chat-tool-activity/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-12",
-                         "changeName":  "fix-onepiece-tool-permission-mapping",
-                         "path":  "openspec/changes/archive/2026-08-12-fix-onepiece-tool-permission-mapping/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-12",
-                         "changeName":  "optimize-session-switching-performance",
-                         "path":  "openspec/changes/archive/2026-08-12-optimize-session-switching-performance/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-12",
-                         "changeName":  "polish-settings-and-agent-integrations",
-                         "path":  "openspec/changes/archive/2026-08-12-polish-settings-and-agent-integrations/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "cli-agent-config-management",
-                                              "cli-parameter-management",
-                                              "im-connector-management",
-                                              "main-layout-ui",
-                                              "scheduled-task-management",
-                                              "settings-center-ui",
-                                              "settings-cli-management-ui",
-                                              "visual-design-system"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-12",
-                         "changeName":  "remove-plan-execution",
-                         "path":  "openspec/changes/archive/2026-08-12-remove-plan-execution/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-execution-observability",
-                                              "frontend-runtime-architecture",
-                                              "onepiece-native-agent",
-                                              "plan-execution-runtime",
-                                              "plan-management",
-                                              "project-worktree-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-12",
-                         "changeName":  "standardize-cli-ui-order",
-                         "path":  "openspec/changes/archive/2026-08-12-standardize-cli-ui-order/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-ui-ordering",
-                                              "session-management",
-                                              "settings-cli-management-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-12",
-                         "changeName":  "unify-agent-session-execution-policy",
-                         "path":  "openspec/changes/archive/2026-08-12-unify-agent-session-execution-policy/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "cli-agent-permission-launch-flags",
-                                              "cli-parameter-management",
-                                              "session-chat-configuration",
-                                              "session-execution-policy"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-13",
-                         "changeName":  "complete-onepiece-plan-agent-loop",
-                         "path":  "openspec/changes/archive/2026-08-13-complete-onepiece-plan-agent-loop/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-chat-configuration",
-                                              "agent-execution-observability",
-                                              "frontend-runtime-architecture",
-                                              "onepiece-native-agent",
-                                              "plan-execution-runtime",
-                                              "plan-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-13",
-                         "changeName":  "establish-fine-grained-token-accounting",
-                         "path":  "openspec/changes/archive/2026-08-13-establish-fine-grained-token-accounting/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "agent-terminal-runtime",
-                                              "api-agent-runtime",
-                                              "onepiece-native-agent",
-                                              "settings-usage-statistics-ui",
-                                              "token-accounting",
-                                              "usage-statistics"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-13",
-                         "changeName":  "optimize-im-session-binding",
-                         "path":  "openspec/changes/archive/2026-08-13-optimize-im-session-binding/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "im-connector-management",
-                                              "im-session-binding-ui",
-                                              "settings-im-management-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "add-background-shell-execution",
-                         "path":  "openspec/changes/archive/2026-08-14-add-background-shell-execution/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-execution"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "add-file-reference-line-ranges",
-                         "path":  "openspec/changes/archive/2026-08-14-add-file-reference-line-ranges/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "add-onepiece-context-evidence-and-controls-ui",
-                         "path":  "openspec/changes/archive/2026-08-14-add-onepiece-context-evidence-and-controls-ui/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-context-compaction-control",
-                                              "agent-context-evidence-projection",
-                                              "app-settings",
-                                              "chat-experience",
-                                              "settings-cli-management-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "add-onepiece-context-measurement-and-classification",
-                         "path":  "openspec/changes/archive/2026-08-14-add-onepiece-context-measurement-and-classification/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-context-compaction",
-                                              "agent-context-measurement"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "add-onepiece-context-optimizer",
-                         "path":  "openspec/changes/archive/2026-08-14-add-onepiece-context-optimizer/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-context-compaction",
-                                              "agent-context-optimization"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "add-onepiece-context-quality-and-policy-evaluation",
-                         "path":  "openspec/changes/archive/2026-08-14-add-onepiece-context-quality-and-policy-evaluation/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "agent-context-evidence-projection",
-                                              "agent-context-quality-evaluation",
-                                              "app-settings",
-                                              "frontend-runtime-architecture",
-                                              "settings-cli-management-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "add-onepiece-context-trigger-and-suppression",
-                         "path":  "openspec/changes/archive/2026-08-14-add-onepiece-context-trigger-and-suppression/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-context-compaction",
-                                              "agent-context-compaction-control",
-                                              "agent-context-measurement"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "address-workspace-destinations-by-route",
-                         "path":  "openspec/changes/archive/2026-08-14-address-workspace-destinations-by-route/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "frontend-runtime-architecture",
-                                              "main-layout-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "add-skill-evolution-evidence-pipeline",
-                         "path":  "openspec/changes/archive/2026-08-14-add-skill-evolution-evidence-pipeline/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-execution-observability",
-                                              "chat-experience",
-                                              "settings-skill-management-ui",
-                                              "skill-evolution-evidence",
-                                              "skill-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "add-unified-todo-board",
-                         "path":  "openspec/changes/archive/2026-08-14-add-unified-todo-board/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "main-layout-ui",
-                                              "plan-management",
-                                              "scheduled-task-management",
-                                              "session-management",
-                                              "unified-todo-board"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "add-utility-skill-delegation-runtime",
-                         "path":  "openspec/changes/archive/2026-08-14-add-utility-skill-delegation-runtime/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "effective-skill-runtime",
-                                              "settings-skill-management-ui",
-                                              "skill-management",
-                                              "utility-skill-delegation-runtime"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "complete-onepiece-builtin-tool-system",
-                         "path":  "openspec/changes/archive/2026-08-14-complete-onepiece-builtin-tool-system/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "agent-chat-configuration",
-                                              "agent-tool-execution",
-                                              "local-extension-management",
-                                              "onepiece-artifact-publishing",
-                                              "onepiece-browser-automation",
-                                              "onepiece-cli-delegation",
-                                              "onepiece-code-execution",
-                                              "onepiece-native-agent",
-                                              "onepiece-ocr-tool",
-                                              "onepiece-tool-governance",
-                                              "onepiece-web-research"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "expand-file-mention-candidate-coverage",
-                         "path":  "openspec/changes/archive/2026-08-14-expand-file-mention-candidate-coverage/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-14",
-                         "changeName":  "harden-workspace-dialogs-and-empty-states",
-                         "path":  "openspec/changes/archive/2026-08-14-harden-workspace-dialogs-and-empty-states/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "loop-management-ui",
-                                              "main-layout-ui",
-                                              "visual-design-system"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "add-agent-image-input",
-                         "path":  "openspec/changes/archive/2026-08-15-add-agent-image-input/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-image-input",
-                                              "agent-provider-runtime"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "add-agent-notebook-tool",
-                         "path":  "openspec/changes/archive/2026-08-15-add-agent-notebook-tool/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-notebook-editing"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "add-agent-plan-exit-request",
-                         "path":  "openspec/changes/archive/2026-08-15-add-agent-plan-exit-request/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-chat-configuration",
-                                              "agent-plan-exit-request"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "add-agent-task-list",
-                         "path":  "openspec/changes/archive/2026-08-15-add-agent-task-list/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-task-list",
-                                              "agent-tool-execution"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "add-agent-user-question",
-                         "path":  "openspec/changes/archive/2026-08-15-add-agent-user-question/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-execution",
-                                              "agent-user-question"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "add-file-reference-drag-and-paste",
-                         "path":  "openspec/changes/archive/2026-08-15-add-file-reference-drag-and-paste/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "add-file-reference-preview-picker",
-                         "path":  "openspec/changes/archive/2026-08-15-add-file-reference-preview-picker/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "add-goal-system",
-                         "path":  "openspec/changes/archive/2026-08-15-add-goal-system/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "goal-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "add-ocr-rendered-page-return",
-                         "path":  "openspec/changes/archive/2026-08-15-add-ocr-rendered-page-return/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-image-input"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "add-onepiece-subagents",
-                         "path":  "openspec/changes/archive/2026-08-15-add-onepiece-subagents/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-execution",
-                                              "onepiece-subagents"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "add-onepiece-visual-tool-returns",
-                         "path":  "openspec/changes/archive/2026-08-15-add-onepiece-visual-tool-returns/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-image-input"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-15",
-                         "changeName":  "migrate-agent-memory-to-file-store",
-                         "path":  "openspec/changes/archive/2026-08-15-migrate-agent-memory-to-file-store/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-cross-session-memory",
-                                              "retrieval-vector-search"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-16",
-                         "changeName":  "add-agent-code-review-center",
-                         "path":  "openspec/changes/archive/2026-08-16-add-agent-code-review-center/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-code-review",
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture",
-                                              "session-project-inspection",
-                                              "session-workspace-tabs",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-16",
-                         "changeName":  "add-agent-evaluation-platform",
-                         "path":  "openspec/changes/archive/2026-08-16-add-agent-evaluation-platform/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-evaluation"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-16",
-                         "changeName":  "add-cross-platform-desktop-automation",
-                         "path":  "openspec/changes/archive/2026-08-16-add-cross-platform-desktop-automation/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "continuous-integration",
-                                              "desktop-runtime-verification"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-16",
-                         "changeName":  "add-onepiece-slash-commands",
-                         "path":  "openspec/changes/archive/2026-08-16-add-onepiece-slash-commands/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "chat-experience",
-                                              "slash-command-runtime"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-16",
-                         "changeName":  "add-signed-release-auto-update",
-                         "path":  "openspec/changes/archive/2026-08-16-add-signed-release-auto-update/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "desktop-release-delivery",
-                                              "signed-desktop-auto-update"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-16",
-                         "changeName":  "add-two-tier-memory-recall",
-                         "path":  "openspec/changes/archive/2026-08-16-add-two-tier-memory-recall/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-cross-session-memory",
-                                              "retrieval-vector-search"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-16",
-                         "changeName":  "enforce-architecture-fitness-functions",
-                         "path":  "openspec/changes/archive/2026-08-16-enforce-architecture-fitness-functions/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "continuous-integration",
-                                              "frontend-runtime-architecture",
-                                              "native-runtime-architecture",
-                                              "repository-governance"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-16",
-                         "changeName":  "fix-direct-connection-os-proxy-inheritance",
-                         "path":  "openspec/changes/archive/2026-08-16-fix-direct-connection-os-proxy-inheritance/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "app-settings"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-16",
-                         "changeName":  "unify-agent-context-engine",
-                         "path":  "openspec/changes/archive/2026-08-16-unify-agent-context-engine/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-context-engine",
-                                              "agent-context-evidence-projection",
-                                              "agent-context-measurement",
-                                              "agent-cross-session-memory",
-                                              "lsp-code-intelligence",
-                                              "onepiece-native-agent",
-                                              "retrieval-vector-search",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-16",
-                         "changeName":  "unify-agent-run-state-machine",
-                         "path":  "openspec/changes/archive/2026-08-16-unify-agent-run-state-machine/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-execution-observability",
-                                              "agent-run-state-management",
-                                              "agent-user-question",
-                                              "goal-management",
-                                              "loop-engineering-runtime",
-                                              "multi-agent-group-chat",
-                                              "permissions-approval",
-                                              "plan-execution-runtime",
-                                              "session-recovery",
-                                              "session-runtime-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-17",
-                         "changeName":  "add-agent-mission-control",
-                         "path":  "openspec/changes/archive/2026-08-17-add-agent-mission-control/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-mission-control",
-                                              "agent-run-state-management",
-                                              "main-layout-ui"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-17",
-                         "changeName":  "add-sandboxed-skill-tool-runtime",
-                         "path":  "openspec/changes/archive/2026-08-17-add-sandboxed-skill-tool-runtime/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-tool-execution",
-                                              "permissions-approval",
-                                              "permissions-core",
-                                              "settings-skill-management-ui",
-                                              "skill-management",
-                                              "skill-tool-runtime"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-17",
-                         "changeName":  "expand-runtime-performance-budgets",
-                         "path":  "openspec/changes/archive/2026-08-17-expand-runtime-performance-budgets/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-context-engine",
-                                              "agent-context-measurement",
-                                              "agent-execution-observability",
-                                              "agent-mission-control",
-                                              "agent-run-state-management",
-                                              "lsp-code-intelligence",
-                                              "remote-terminal-runtime",
-                                              "runtime-performance-governance"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-17",
-                         "changeName":  "extend-provider-runtime-plugin-sdk",
-                         "path":  "openspec/changes/archive/2026-08-17-extend-provider-runtime-plugin-sdk/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "agent-provider-runtime",
-                                              "provider-plugin-sdk"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-18",
-                         "changeName":  "add-agent-runner-abstraction",
-                         "path":  "openspec/changes/archive/2026-08-18-add-agent-runner-abstraction/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "agent-mission-control",
-                                              "agent-provider-runtime",
-                                              "agent-runner-runtime",
-                                              "agent-run-state-management",
-                                              "permissions-core",
-                                              "remote-terminal-runtime",
-                                              "runtime-performance-governance",
-                                              "unified-log-management"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-18",
-                         "changeName":  "add-hybrid-local-model-runtime",
-                         "path":  "openspec/changes/archive/2026-08-18-add-hybrid-local-model-runtime/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks",
-                                           "verification"
-                                       ],
-                         "capabilities":  [
-                                              "agent-context-engine",
-                                              "agent-context-measurement",
-                                              "api-agent-runtime",
-                                              "hybrid-local-model-runtime",
-                                              "onepiece-native-agent"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-18",
-                         "changeName":  "extract-api-adapter-inline-tests",
-                         "path":  "openspec/changes/archive/2026-08-18-extract-api-adapter-inline-tests/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-18",
-                         "changeName":  "freeze-large-file-line-budgets",
-                         "path":  "openspec/changes/archive/2026-08-18-freeze-large-file-line-budgets/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "repository-governance"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-18",
-                         "changeName":  "split-database-migrations",
-                         "path":  "openspec/changes/archive/2026-08-18-split-database-migrations/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-18",
-                         "changeName":  "split-web-agent-client",
-                         "path":  "openspec/changes/archive/2026-08-18-split-web-agent-client/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-19",
-                         "changeName":  "decompose-api-tool-use-loop",
-                         "path":  "openspec/changes/archive/2026-08-19-decompose-api-tool-use-loop/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-19",
-                         "changeName":  "extract-web-client-chat-state",
-                         "path":  "openspec/changes/archive/2026-08-19-extract-web-client-chat-state/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-19",
-                         "changeName":  "freeze-panic-shortcuts-in-production-code",
-                         "path":  "openspec/changes/archive/2026-08-19-freeze-panic-shortcuts-in-production-code/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "repository-governance"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-19",
-                         "changeName":  "prune-unused-dependencies",
-                         "path":  "openspec/changes/archive/2026-08-19-prune-unused-dependencies/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-19",
-                         "changeName":  "relocate-heavyweight-inline-tests",
-                         "path":  "openspec/changes/archive/2026-08-19-relocate-heavyweight-inline-tests/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-19",
-                         "changeName":  "retire-panic-shortcut-whitelist",
-                         "path":  "openspec/changes/archive/2026-08-19-retire-panic-shortcut-whitelist/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-                                              "repository-governance"
-                                          ]
-                     },
-                     {
-                         "archivedOn":  "2026-08-19",
-                         "changeName":  "split-api-adapter-modules",
-                         "path":  "openspec/changes/archive/2026-08-19-split-api-adapter-modules/",
-                         "artifacts":  [
-                                           "proposal",
-                                           "design",
-                                           "tasks"
-                                       ],
-                         "capabilities":  [
-
-                                          ]
-                     }
-                 ]
+  "schemaVersion": 1,
+  "archives": [
+    {
+      "archivedOn": "2026-07-13",
+      "changeName": "unify-ai-agent-tool-management",
+      "path": "openspec/changes/archive/2026-07-13-unify-ai-agent-tool-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-switching",
+        "agent-tool-registry",
+        "interaction-modes"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-14",
+      "changeName": "add-mcp-client-management",
+      "path": "openspec/changes/archive/2026-07-14-add-mcp-client-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "mcp-client-management",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-14",
+      "changeName": "support-native-package-builds",
+      "path": "openspec/changes/archive/2026-07-14-support-native-package-builds/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "native-app-packaging"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-14",
+      "changeName": "support-switchable-ucd-settings-ui",
+      "path": "openspec/changes/archive/2026-07-14-support-switchable-ucd-settings-ui/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-switching",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-15",
+      "changeName": "add-session-management",
+      "path": "openspec/changes/archive/2026-07-15-add-session-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui",
+        "session-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-15",
+      "changeName": "implement-main-chat-experience",
+      "path": "openspec/changes/archive/2026-07-15-implement-main-chat-experience/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "main-layout-ui",
+        "session-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-15",
+      "changeName": "improve-architecture-extensibility",
+      "path": "openspec/changes/archive/2026-07-15-improve-architecture-extensibility/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-switching",
+        "agent-tool-registry",
+        "contract-and-task-foundation",
+        "frontend-runtime-architecture",
+        "interaction-modes",
+        "mcp-client-management",
+        "native-runtime-architecture",
+        "sdk-dependency-management",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-15",
+      "changeName": "improve-main-layout-ui",
+      "path": "openspec/changes/archive/2026-07-15-improve-main-layout-ui/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-15",
+      "changeName": "replace-main-content-with-chat",
+      "path": "openspec/changes/archive/2026-07-15-replace-main-content-with-chat/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-15",
+      "changeName": "support-sdk-dependency-management",
+      "path": "openspec/changes/archive/2026-07-15-support-sdk-dependency-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-registry",
+        "sdk-dependency-management",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-16",
+      "changeName": "add-skill-management-settings",
+      "path": "openspec/changes/archive/2026-07-16-add-skill-management-settings/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "settings-center-ui",
+        "skill-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-16",
+      "changeName": "add-unified-log-management",
+      "path": "openspec/changes/archive/2026-07-16-add-unified-log-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-registry",
+        "app-settings",
+        "native-runtime-architecture",
+        "sdk-dependency-management",
+        "settings-center-ui",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-16",
+      "changeName": "complete-general-settings-i18n-font-fix",
+      "path": "openspec/changes/archive/2026-07-16-complete-general-settings-i18n-font-fix/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "app-settings",
+        "frontend-runtime-architecture",
+        "main-layout-ui",
+        "native-runtime-architecture",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-16",
+      "changeName": "complete-session-management",
+      "path": "openspec/changes/archive/2026-07-16-complete-session-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "main-layout-ui",
+        "native-runtime-architecture",
+        "project-worktree-management",
+        "session-management",
+        "session-runtime-management",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-16",
+      "changeName": "replace-provider-management-with-cli-management",
+      "path": "openspec/changes/archive/2026-07-16-replace-provider-management-with-cli-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-registry",
+        "native-runtime-architecture",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "add-about-page",
+      "path": "openspec/changes/archive/2026-07-17-add-about-page/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "add-cli-parameter-management",
+      "path": "openspec/changes/archive/2026-07-17-add-cli-parameter-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "cli-parameter-management",
+        "frontend-runtime-architecture",
+        "native-runtime-architecture",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "add-desktop-floating-assistant",
+      "path": "openspec/changes/archive/2026-07-17-add-desktop-floating-assistant/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "desktop-floating-assistant",
+        "session-chat-configuration",
+        "settings-center-ui",
+        "visual-design-system"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "add-im-connectors",
+      "path": "openspec/changes/archive/2026-07-17-add-im-connectors/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "desktop-background-lifecycle",
+        "frontend-runtime-architecture",
+        "im-connector-management",
+        "main-layout-ui",
+        "native-runtime-architecture",
+        "session-runtime-management",
+        "settings-center-ui",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "add-local-extension-capabilities",
+      "path": "openspec/changes/archive/2026-07-17-add-local-extension-capabilities/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "local-extension-management",
+        "settings-center-ui",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "add-network-proxy-settings",
+      "path": "openspec/changes/archive/2026-07-17-add-network-proxy-settings/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "app-settings",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "add-openspec-archive-catalog",
+      "path": "openspec/changes/archive/2026-07-17-add-openspec-archive-catalog/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "openspec-archive-governance"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "add-spec-optimizer",
+      "path": "openspec/changes/archive/2026-07-17-add-spec-optimizer/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "spec-optimization"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "add-unified-notification-framework",
+      "path": "openspec/changes/archive/2026-07-17-add-unified-notification-framework/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui",
+        "notification-system"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "add-usage-statistics-settings",
+      "path": "openspec/changes/archive/2026-07-17-add-usage-statistics-settings/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "frontend-runtime-architecture",
+        "native-runtime-architecture",
+        "settings-center-ui",
+        "usage-statistics"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "analyze-settings-center-spec-compression",
+      "path": "openspec/changes/archive/2026-07-17-analyze-settings-center-spec-compression/",
+      "artifacts": [
+        "proposal"
+      ],
+      "capabilities": []
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "fix-i18n-page-copy",
+      "path": "openspec/changes/archive/2026-07-17-fix-i18n-page-copy/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "frontend-runtime-architecture",
+        "main-layout-ui",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "fix-sdk-page-cli-errors",
+      "path": "openspec/changes/archive/2026-07-17-fix-sdk-page-cli-errors/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "frontend-runtime-architecture",
+        "native-runtime-architecture",
+        "sdk-dependency-management",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "govern-openspec-archive-lifecycle",
+      "path": "openspec/changes/archive/2026-07-17-govern-openspec-archive-lifecycle/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "openspec-archive-governance"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "implement-cli-chat-runtime-v1",
+      "path": "openspec/changes/archive/2026-07-17-implement-cli-chat-runtime-v1/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "session-runtime-management",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "optimize-long-running-operations",
+      "path": "openspec/changes/archive/2026-07-17-optimize-long-running-operations/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "frontend-runtime-architecture",
+        "native-runtime-architecture"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "optimize-session-workspace-tabs",
+      "path": "openspec/changes/archive/2026-07-17-optimize-session-workspace-tabs/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui",
+        "session-log-viewer",
+        "session-project-inspection",
+        "session-shell",
+        "session-workspace-tabs",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "optimize-ui-polish",
+      "path": "openspec/changes/archive/2026-07-17-optimize-ui-polish/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui",
+        "settings-center-ui",
+        "visual-design-system"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "split-settings-center-ui-spec",
+      "path": "openspec/changes/archive/2026-07-17-split-settings-center-ui-spec/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "settings-basic-configuration-ui",
+        "settings-center-ui",
+        "settings-cli-management-ui",
+        "settings-extension-management-ui",
+        "settings-floating-assistant-ui",
+        "settings-im-management-ui",
+        "settings-skill-management-ui",
+        "settings-usage-statistics-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-17",
+      "changeName": "upgrade-usage-statistics-monitoring",
+      "path": "openspec/changes/archive/2026-07-17-upgrade-usage-statistics-monitoring/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "frontend-runtime-architecture",
+        "native-runtime-architecture",
+        "session-runtime-management",
+        "settings-center-ui",
+        "usage-statistics"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-18",
+      "changeName": "add-github-plugin-integration",
+      "path": "openspec/changes/archive/2026-07-18-add-github-plugin-integration/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "frontend-runtime-architecture",
+        "plugin-integration-management",
+        "settings-center-ui",
+        "settings-plugin-integration-ui",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-18",
+      "changeName": "add-remote-workspace",
+      "path": "openspec/changes/archive/2026-07-18-add-remote-workspace/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "project-worktree-management",
+        "session-management",
+        "session-workspace-tabs"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-18",
+      "changeName": "add-rich-block-chat-rendering",
+      "path": "openspec/changes/archive/2026-07-18-add-rich-block-chat-rendering/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-18",
+      "changeName": "add-workspace-activity-bar",
+      "path": "openspec/changes/archive/2026-07-18-add-workspace-activity-bar/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-18",
+      "changeName": "enhance-prompt-hook-management",
+      "path": "openspec/changes/archive/2026-07-18-enhance-prompt-hook-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "frontend-runtime-architecture",
+        "native-runtime-architecture",
+        "prompt-hook-management",
+        "settings-center-ui",
+        "settings-prompt-hooks-ui",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-18",
+      "changeName": "fix-log-performance-and-error-reporting",
+      "path": "openspec/changes/archive/2026-07-18-fix-log-performance-and-error-reporting/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "session-log-viewer",
+        "session-workspace-tabs",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-18",
+      "changeName": "improve-session-management",
+      "path": "openspec/changes/archive/2026-07-18-improve-session-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "app-settings",
+        "chat-experience",
+        "frontend-runtime-architecture",
+        "main-layout-ui",
+        "native-runtime-architecture",
+        "session-category-management",
+        "session-export",
+        "session-management",
+        "session-runtime-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-18",
+      "changeName": "optimize-cli-local-environment-management",
+      "path": "openspec/changes/archive/2026-07-18-optimize-cli-local-environment-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-registry",
+        "frontend-runtime-architecture",
+        "native-runtime-architecture",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-18",
+      "changeName": "optimize-cli-management-and-about",
+      "path": "openspec/changes/archive/2026-07-18-optimize-cli-management-and-about/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "settings-cli-management-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-18",
+      "changeName": "optimize-settings-ui-and-runtime-controls",
+      "path": "openspec/changes/archive/2026-07-18-optimize-settings-ui-and-runtime-controls/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "app-settings",
+        "desktop-floating-assistant",
+        "desktop-startup-controls",
+        "main-layout-ui",
+        "native-runtime-architecture",
+        "session-management",
+        "settings-basic-configuration-ui",
+        "settings-center-ui",
+        "settings-data-management",
+        "settings-extension-management-ui",
+        "settings-floating-assistant-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-19",
+      "changeName": "add-scheduled-tasks",
+      "path": "openspec/changes/archive/2026-07-19-add-scheduled-tasks/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui",
+        "scheduled-task-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-19",
+      "changeName": "add-workspace-folder-openers",
+      "path": "openspec/changes/archive/2026-07-19-add-workspace-folder-openers/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "app-settings",
+        "session-workspace-tabs",
+        "settings-basic-configuration-ui",
+        "workspace-folder-openers"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-19",
+      "changeName": "fix-agent-workspace-logs-and-cli-launch",
+      "path": "openspec/changes/archive/2026-07-19-fix-agent-workspace-logs-and-cli-launch/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-terminal-runtime",
+        "main-layout-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-19",
+      "changeName": "fix-session-creation-and-cli-runtime",
+      "path": "openspec/changes/archive/2026-07-19-fix-session-creation-and-cli-runtime/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "cli-parameter-management",
+        "interaction-modes",
+        "main-layout-ui",
+        "session-management",
+        "session-runtime-management",
+        "settings-cli-management-ui",
+        "workspace-folder-openers"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-19",
+      "changeName": "redesign-cross-platform-app-icon",
+      "path": "openspec/changes/archive/2026-07-19-redesign-cross-platform-app-icon/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "cross-platform-app-icon"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-19",
+      "changeName": "refactor-rust-ddd-architecture",
+      "path": "openspec/changes/archive/2026-07-19-refactor-rust-ddd-architecture/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "native-runtime-architecture"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-19",
+      "changeName": "replace-chat-with-agent-terminal-session",
+      "path": "openspec/changes/archive/2026-07-19-replace-chat-with-agent-terminal-session/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-terminal-runtime",
+        "cli-parameter-management",
+        "main-layout-ui",
+        "native-runtime-architecture",
+        "session-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-20",
+      "changeName": "fix-agent-terminal-retention",
+      "path": "openspec/changes/archive/2026-07-20-fix-agent-terminal-retention/",
+      "artifacts": [
+        "proposal",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-terminal-runtime",
+        "native-runtime-architecture"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-20",
+      "changeName": "optimize-session-info-panel",
+      "path": "openspec/changes/archive/2026-07-20-optimize-session-info-panel/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "frontend-runtime-architecture",
+        "main-layout-ui",
+        "usage-statistics"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-20",
+      "changeName": "optimize-session-management-page",
+      "path": "openspec/changes/archive/2026-07-20-optimize-session-management-page/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui",
+        "session-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-21",
+      "changeName": "settings-about-page-layout",
+      "path": "openspec/changes/archive/2026-07-21-settings-about-page-layout/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-22",
+      "changeName": "add-ssh-connection-management",
+      "path": "openspec/changes/archive/2026-07-22-add-ssh-connection-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "session-management",
+        "settings-center-ui",
+        "settings-ssh-connection-ui",
+        "ssh-connection-management",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-22",
+      "changeName": "configure-github-repository",
+      "path": "openspec/changes/archive/2026-07-22-configure-github-repository/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "continuous-integration",
+        "desktop-release-delivery",
+        "repository-governance",
+        "software-supply-chain-security"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-22",
+      "changeName": "enhance-session-resume-and-project-sidebar",
+      "path": "openspec/changes/archive/2026-07-22-enhance-session-resume-and-project-sidebar/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-terminal-runtime",
+        "main-layout-ui",
+        "session-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-22",
+      "changeName": "fix-ssh-connection-management-defects",
+      "path": "openspec/changes/archive/2026-07-22-fix-ssh-connection-management-defects/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "session-management",
+        "settings-ssh-connection-ui",
+        "ssh-connection-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-23",
+      "changeName": "add-loop-engineering-runtime",
+      "path": "openspec/changes/archive/2026-07-23-add-loop-engineering-runtime/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "loop-engineering-runtime",
+        "loop-management-ui",
+        "main-layout-ui",
+        "project-worktree-management",
+        "session-runtime-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-23",
+      "changeName": "add-multi-agent-coordination",
+      "path": "openspec/changes/archive/2026-07-23-add-multi-agent-coordination/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-execution-observability",
+        "multi-agent-coordination"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-23",
+      "changeName": "agent-execution-observability",
+      "path": "openspec/changes/archive/2026-07-23-agent-execution-observability/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-execution-observability",
+        "app-settings",
+        "contract-and-task-foundation",
+        "mcp-client-management",
+        "session-runtime-management",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-23",
+      "changeName": "optimize-frontend-rendering-and-loading",
+      "path": "openspec/changes/archive/2026-07-23-optimize-frontend-rendering-and-loading/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "frontend-runtime-architecture",
+        "main-layout-ui",
+        "session-log-viewer",
+        "session-workspace-tabs",
+        "settings-center-ui",
+        "settings-prompt-hooks-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-24",
+      "changeName": "add-remote-terminal-management",
+      "path": "openspec/changes/archive/2026-07-24-add-remote-terminal-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "remote-terminal-runtime",
+        "session-management",
+        "session-shell",
+        "ssh-connection-management",
+        "terminal-command-management",
+        "terminal-output-search",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-24",
+      "changeName": "enhance-prompt-library-advanced-features",
+      "path": "openspec/changes/archive/2026-07-24-enhance-prompt-library-advanced-features/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "frontend-runtime-architecture",
+        "native-runtime-architecture",
+        "prompt-hook-management",
+        "settings-prompt-hooks-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-24",
+      "changeName": "establish-multilingual-documentation",
+      "path": "openspec/changes/archive/2026-07-24-establish-multilingual-documentation/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "multilingual-readme",
+        "native-developer-documentation",
+        "user-guide-documentation"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-24",
+      "changeName": "optimize-rust-build-and-release",
+      "path": "openspec/changes/archive/2026-07-24-optimize-rust-build-and-release/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "continuous-integration",
+        "native-app-packaging",
+        "native-build-optimization"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-26",
+      "changeName": "fix-embedded-terminal-tui-contrast",
+      "path": "openspec/changes/archive/2026-07-26-fix-embedded-terminal-tui-contrast/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "session-workspace-tabs"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-28",
+      "changeName": "dynamic-llm-model-discovery",
+      "path": "openspec/changes/archive/2026-07-28-dynamic-llm-model-discovery/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "cli-parameter-management",
+        "custom-model-display",
+        "native-model-discovery",
+        "session-chat-configuration"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-28",
+      "changeName": "fix-session-workspace-ui-defects",
+      "path": "openspec/changes/archive/2026-07-28-fix-session-workspace-ui-defects/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "session-workspace-tabs"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-28",
+      "changeName": "fix-settings-hydration-flash",
+      "path": "openspec/changes/archive/2026-07-28-fix-settings-hydration-flash/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "app-settings"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-31",
+      "changeName": "add-reported-usage-ingestion",
+      "path": "openspec/changes/archive/2026-07-31-add-reported-usage-ingestion/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "usage-statistics"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-31",
+      "changeName": "add-terminal-usage-tracking",
+      "path": "openspec/changes/archive/2026-07-31-add-terminal-usage-tracking/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "usage-statistics"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-31",
+      "changeName": "establish-test-coverage-and-integration-gates",
+      "path": "openspec/changes/archive/2026-07-31-establish-test-coverage-and-integration-gates/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "continuous-integration",
+        "frontend-runtime-architecture",
+        "native-runtime-architecture"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-31",
+      "changeName": "fix-cli-terminal-session-resume-capture",
+      "path": "openspec/changes/archive/2026-07-31-fix-cli-terminal-session-resume-capture/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-terminal-runtime"
+      ]
+    },
+    {
+      "archivedOn": "2026-07-31",
+      "changeName": "pool-native-sqlite-connections",
+      "path": "openspec/changes/archive/2026-07-31-pool-native-sqlite-connections/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "native-runtime-architecture"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-01",
+      "changeName": "add-agent-chat-configuration",
+      "path": "openspec/changes/archive/2026-08-01-add-agent-chat-configuration/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-chat-configuration"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-01",
+      "changeName": "add-agent-context-compaction",
+      "path": "openspec/changes/archive/2026-08-01-add-agent-context-compaction/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-context-compaction"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-01",
+      "changeName": "add-agent-cross-session-memory",
+      "path": "openspec/changes/archive/2026-08-01-add-agent-cross-session-memory/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-cross-session-memory"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-01",
+      "changeName": "add-agent-lifecycle-management",
+      "path": "openspec/changes/archive/2026-08-01-add-agent-lifecycle-management/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-lifecycle-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-01",
+      "changeName": "add-agent-mcp-tools",
+      "path": "openspec/changes/archive/2026-08-01-add-agent-mcp-tools/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "agent-mcp-tools"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-01",
+      "changeName": "add-agent-skill-support",
+      "path": "openspec/changes/archive/2026-08-01-add-agent-skill-support/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-skill-injection"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-01",
+      "changeName": "add-agent-tool-execution",
+      "path": "openspec/changes/archive/2026-08-01-add-agent-tool-execution/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-execution"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-01",
+      "changeName": "add-agent-tool-trust",
+      "path": "openspec/changes/archive/2026-08-01-add-agent-tool-trust/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-trust"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-01",
+      "changeName": "add-custom-agent-registration",
+      "path": "openspec/changes/archive/2026-08-01-add-custom-agent-registration/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-registry",
+        "api-agent-runtime",
+        "chat-experience",
+        "interaction-modes"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-01",
+      "changeName": "add-loop-api-agent-support",
+      "path": "openspec/changes/archive/2026-08-01-add-loop-api-agent-support/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "loop-engineering-runtime"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-01",
+      "changeName": "fix-terminal-usage-integrity",
+      "path": "openspec/changes/archive/2026-08-01-fix-terminal-usage-integrity/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-execution-observability",
+        "agent-terminal-runtime",
+        "usage-statistics"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-02",
+      "changeName": "add-cli-agent-global-config-switching",
+      "path": "openspec/changes/archive/2026-08-02-add-cli-agent-global-config-switching/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-switching",
+        "cli-agent-config-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-02",
+      "changeName": "add-common-application-locales",
+      "path": "openspec/changes/archive/2026-08-02-add-common-application-locales/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "app-settings",
+        "application-localization",
+        "desktop-background-lifecycle",
+        "settings-basic-configuration-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-02",
+      "changeName": "harden-skill-management-reliability",
+      "path": "openspec/changes/archive/2026-08-02-harden-skill-management-reliability/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "agent-lifecycle-management",
+        "agent-skill-injection",
+        "settings-skill-management-ui",
+        "skill-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-02",
+      "changeName": "optimize-runtime-performance-foundation",
+      "path": "openspec/changes/archive/2026-08-02-optimize-runtime-performance-foundation/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "agent-terminal-runtime",
+        "runtime-performance-governance",
+        "session-management",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-02",
+      "changeName": "recover-webview-white-screen",
+      "path": "openspec/changes/archive/2026-08-02-recover-webview-white-screen/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "desktop-webview-reliability"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-02",
+      "changeName": "refine-basic-settings-information-architecture",
+      "path": "openspec/changes/archive/2026-08-02-refine-basic-settings-information-architecture/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "settings-basic-configuration-ui",
+        "settings-floating-assistant-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-03",
+      "changeName": "harden-mcp-runtime-reliability",
+      "path": "openspec/changes/archive/2026-08-03-harden-mcp-runtime-reliability/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "agent-mcp-tools",
+        "mcp-client-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-03",
+      "changeName": "harden-skill-mount-root-links",
+      "path": "openspec/changes/archive/2026-08-03-harden-skill-mount-root-links/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "settings-skill-management-ui",
+        "skill-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-03",
+      "changeName": "optimize-skill-management-ui",
+      "path": "openspec/changes/archive/2026-08-03-optimize-skill-management-ui/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui",
+        "settings-skill-management-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-03",
+      "changeName": "refine-skill-agent-selection-ui",
+      "path": "openspec/changes/archive/2026-08-03-refine-skill-agent-selection-ui/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "settings-skill-management-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-04",
+      "changeName": "add-onepiece-native-agent",
+      "path": "openspec/changes/archive/2026-08-04-add-onepiece-native-agent/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "agent-lifecycle-management",
+        "agent-skill-injection",
+        "api-agent-runtime",
+        "onepiece-native-agent",
+        "session-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-04",
+      "changeName": "enhance-chat-rich-media",
+      "path": "openspec/changes/archive/2026-08-04-enhance-chat-rich-media/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-04",
+      "changeName": "harden-im-runtime-reliability",
+      "path": "openspec/changes/archive/2026-08-04-harden-im-runtime-reliability/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "frontend-runtime-architecture",
+        "im-connector-management",
+        "native-runtime-architecture",
+        "session-runtime-management",
+        "settings-im-management-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-04",
+      "changeName": "maximize-main-window-on-startup",
+      "path": "openspec/changes/archive/2026-08-04-maximize-main-window-on-startup/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "desktop-background-lifecycle"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-04",
+      "changeName": "remove-agent-management-page",
+      "path": "openspec/changes/archive/2026-08-04-remove-agent-management-page/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-switching",
+        "cli-agent-config-management",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-05",
+      "changeName": "add-permissions-core",
+      "path": "openspec/changes/archive/2026-08-05-add-permissions-core/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-execution",
+        "agent-tool-trust",
+        "permissions-approval",
+        "permissions-core"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-05",
+      "changeName": "add-permissions-settings-ui",
+      "path": "openspec/changes/archive/2026-08-05-add-permissions-settings-ui/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "permissions-approval",
+        "permissions-core"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-05",
+      "changeName": "polish-workspace-visual-consistency",
+      "path": "openspec/changes/archive/2026-08-05-polish-workspace-visual-consistency/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-terminal-runtime",
+        "main-layout-ui",
+        "notification-system",
+        "visual-design-system"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-06",
+      "changeName": "add-claude-code-permission-callback",
+      "path": "openspec/changes/archive/2026-08-06-add-claude-code-permission-callback/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "claude-code-permission-hook",
+        "cli-agent-config-management",
+        "permissions-approval",
+        "permissions-core"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-06",
+      "changeName": "add-cli-agent-permission-launch-flags",
+      "path": "openspec/changes/archive/2026-08-06-add-cli-agent-permission-launch-flags/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-terminal-runtime",
+        "cli-agent-permission-launch-flags",
+        "cli-parameter-management",
+        "permissions-approval"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-06",
+      "changeName": "add-cli-custom-instructions-injection",
+      "path": "openspec/changes/archive/2026-08-06-add-cli-custom-instructions-injection/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "custom-instructions",
+        "native-runtime-architecture"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-06",
+      "changeName": "add-cli-memory-support",
+      "path": "openspec/changes/archive/2026-08-06-add-cli-memory-support/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-cross-session-memory",
+        "native-runtime-architecture"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-06",
+      "changeName": "add-onepiece-search-and-edit-tools",
+      "path": "openspec/changes/archive/2026-08-06-add-onepiece-search-and-edit-tools/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-chat-configuration",
+        "agent-context-compaction",
+        "agent-tool-execution",
+        "agent-tool-trust",
+        "onepiece-native-agent"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-06",
+      "changeName": "add-personalization-settings",
+      "path": "openspec/changes/archive/2026-08-06-add-personalization-settings/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-cross-session-memory",
+        "agent-skill-injection",
+        "app-settings",
+        "custom-instructions",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-06",
+      "changeName": "remove-multi-agent-coordination",
+      "path": "openspec/changes/archive/2026-08-06-remove-multi-agent-coordination/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-execution-observability",
+        "multi-agent-coordination",
+        "multilingual-readme",
+        "user-guide-documentation"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-07",
+      "changeName": "add-multi-agent-group-chat-session",
+      "path": "openspec/changes/archive/2026-08-07-add-multi-agent-group-chat-session/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "expert-role-management",
+        "multi-agent-group-chat",
+        "session-management",
+        "session-workspace-tabs",
+        "settings-center-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-07",
+      "changeName": "add-retrieval-vector-search",
+      "path": "openspec/changes/archive/2026-08-07-add-retrieval-vector-search/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-cross-session-memory",
+        "retrieval-vector-search"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-07",
+      "changeName": "bound-short-query-message-search",
+      "path": "openspec/changes/archive/2026-08-07-bound-short-query-message-search/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "session-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-07",
+      "changeName": "contain-timed-out-process-trees",
+      "path": "openspec/changes/archive/2026-08-07-contain-timed-out-process-trees/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "native-runtime-architecture"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-07",
+      "changeName": "surface-cli-error-results",
+      "path": "openspec/changes/archive/2026-08-07-surface-cli-error-results/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "session-runtime-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-08",
+      "changeName": "add-plan-execution-foundation",
+      "path": "openspec/changes/archive/2026-08-08-add-plan-execution-foundation/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "agent-execution-observability",
+        "frontend-runtime-architecture",
+        "onepiece-native-agent",
+        "plan-execution-runtime",
+        "plan-management",
+        "project-worktree-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-08",
+      "changeName": "workspace-code-indexing-foundation",
+      "path": "openspec/changes/archive/2026-08-08-workspace-code-indexing-foundation/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "retrieval-vector-search",
+        "workspace-code-indexing"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-09",
+      "changeName": "add-antigravity-cli",
+      "path": "openspec/changes/archive/2026-08-09-add-antigravity-cli/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-cross-session-memory",
+        "agent-terminal-runtime",
+        "chat-experience",
+        "cli-agent-config-management",
+        "cli-agent-permission-launch-flags",
+        "cli-parameter-management",
+        "main-layout-ui",
+        "native-model-discovery",
+        "native-runtime-architecture",
+        "permissions-approval",
+        "prompt-hook-management",
+        "settings-cli-management-ui",
+        "skill-management",
+        "usage-statistics"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-09",
+      "changeName": "add-gemini-cli-terminal-usage-tracking",
+      "path": "openspec/changes/archive/2026-08-09-add-gemini-cli-terminal-usage-tracking/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "usage-statistics"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-09",
+      "changeName": "add-local-code-index-mode",
+      "path": "openspec/changes/archive/2026-08-09-add-local-code-index-mode/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "workspace-code-indexing"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-09",
+      "changeName": "deduplicate-skill-spec-requirements",
+      "path": "openspec/changes/archive/2026-08-09-deduplicate-skill-spec-requirements/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": []
+    },
+    {
+      "archivedOn": "2026-08-09",
+      "changeName": "harden-runtime-concurrency-and-query-efficiency",
+      "path": "openspec/changes/archive/2026-08-09-harden-runtime-concurrency-and-query-efficiency/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "frontend-runtime-architecture",
+        "native-runtime-architecture",
+        "runtime-performance-governance"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-09",
+      "changeName": "introduce-agent-provider-contract",
+      "path": "openspec/changes/archive/2026-08-09-introduce-agent-provider-contract/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-provider-runtime"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-09",
+      "changeName": "publish-github-preview-release",
+      "path": "openspec/changes/archive/2026-08-09-publish-github-preview-release/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "desktop-release-delivery",
+        "multilingual-readme",
+        "native-app-packaging"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-09",
+      "changeName": "reconcile-builtin-skill-seeding",
+      "path": "openspec/changes/archive/2026-08-09-reconcile-builtin-skill-seeding/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "skill-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-09",
+      "changeName": "refuse-missing-permission-hook-binary",
+      "path": "openspec/changes/archive/2026-08-09-refuse-missing-permission-hook-binary/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "claude-code-permission-hook"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-09",
+      "changeName": "scope-readme-guides-per-language",
+      "path": "openspec/changes/archive/2026-08-09-scope-readme-guides-per-language/",
+      "artifacts": [
+        "proposal",
+        "tasks"
+      ],
+      "capabilities": [
+        "multilingual-readme"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-09",
+      "changeName": "suppress-probe-console-windows",
+      "path": "openspec/changes/archive/2026-08-09-suppress-probe-console-windows/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "native-runtime-architecture"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-10",
+      "changeName": "add-session-recovery-evidence-foundation",
+      "path": "openspec/changes/archive/2026-08-10-add-session-recovery-evidence-foundation/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "loop-engineering-runtime",
+        "native-runtime-architecture",
+        "plan-execution-runtime",
+        "session-management",
+        "session-recovery",
+        "session-runtime-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-10",
+      "changeName": "establish-effective-skill-runtime",
+      "path": "openspec/changes/archive/2026-08-10-establish-effective-skill-runtime/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-chat-configuration",
+        "agent-skill-injection",
+        "agent-tool-execution",
+        "effective-skill-runtime",
+        "settings-skill-management-ui",
+        "skill-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-10",
+      "changeName": "refine-effective-skill-management-ui",
+      "path": "openspec/changes/archive/2026-08-10-refine-effective-skill-management-ui/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "settings-skill-management-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-11",
+      "changeName": "add-lsp-code-intelligence-foundation",
+      "path": "openspec/changes/archive/2026-08-11-add-lsp-code-intelligence-foundation/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-chat-configuration",
+        "agent-tool-execution",
+        "lsp-code-intelligence",
+        "lsp-server-management",
+        "settings-center-ui",
+        "unified-log-management",
+        "workspace-code-indexing"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-11",
+      "changeName": "complete-multi-agent-session-presence",
+      "path": "openspec/changes/archive/2026-08-11-complete-multi-agent-session-presence/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "main-layout-ui",
+        "multi-agent-group-chat",
+        "session-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-12",
+      "changeName": "add-skill-overlay-governance",
+      "path": "openspec/changes/archive/2026-08-12-add-skill-overlay-governance/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-skill-injection",
+        "settings-skill-management-ui",
+        "skill-management",
+        "skill-overlay-governance"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-12",
+      "changeName": "compact-chat-tool-activity",
+      "path": "openspec/changes/archive/2026-08-12-compact-chat-tool-activity/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-12",
+      "changeName": "fix-onepiece-tool-permission-mapping",
+      "path": "openspec/changes/archive/2026-08-12-fix-onepiece-tool-permission-mapping/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": []
+    },
+    {
+      "archivedOn": "2026-08-12",
+      "changeName": "optimize-session-switching-performance",
+      "path": "openspec/changes/archive/2026-08-12-optimize-session-switching-performance/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-12",
+      "changeName": "polish-settings-and-agent-integrations",
+      "path": "openspec/changes/archive/2026-08-12-polish-settings-and-agent-integrations/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "cli-agent-config-management",
+        "cli-parameter-management",
+        "im-connector-management",
+        "main-layout-ui",
+        "scheduled-task-management",
+        "settings-center-ui",
+        "settings-cli-management-ui",
+        "visual-design-system"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-12",
+      "changeName": "remove-plan-execution",
+      "path": "openspec/changes/archive/2026-08-12-remove-plan-execution/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-execution-observability",
+        "frontend-runtime-architecture",
+        "onepiece-native-agent",
+        "plan-execution-runtime",
+        "plan-management",
+        "project-worktree-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-12",
+      "changeName": "standardize-cli-ui-order",
+      "path": "openspec/changes/archive/2026-08-12-standardize-cli-ui-order/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-ui-ordering",
+        "session-management",
+        "settings-cli-management-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-12",
+      "changeName": "unify-agent-session-execution-policy",
+      "path": "openspec/changes/archive/2026-08-12-unify-agent-session-execution-policy/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "cli-agent-permission-launch-flags",
+        "cli-parameter-management",
+        "session-chat-configuration",
+        "session-execution-policy"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-13",
+      "changeName": "complete-onepiece-plan-agent-loop",
+      "path": "openspec/changes/archive/2026-08-13-complete-onepiece-plan-agent-loop/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-chat-configuration",
+        "agent-execution-observability",
+        "frontend-runtime-architecture",
+        "onepiece-native-agent",
+        "plan-execution-runtime",
+        "plan-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-13",
+      "changeName": "establish-fine-grained-token-accounting",
+      "path": "openspec/changes/archive/2026-08-13-establish-fine-grained-token-accounting/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "agent-terminal-runtime",
+        "api-agent-runtime",
+        "onepiece-native-agent",
+        "settings-usage-statistics-ui",
+        "token-accounting",
+        "usage-statistics"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-13",
+      "changeName": "optimize-im-session-binding",
+      "path": "openspec/changes/archive/2026-08-13-optimize-im-session-binding/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "im-connector-management",
+        "im-session-binding-ui",
+        "settings-im-management-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "add-background-shell-execution",
+      "path": "openspec/changes/archive/2026-08-14-add-background-shell-execution/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-execution"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "add-file-reference-line-ranges",
+      "path": "openspec/changes/archive/2026-08-14-add-file-reference-line-ranges/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "add-onepiece-context-evidence-and-controls-ui",
+      "path": "openspec/changes/archive/2026-08-14-add-onepiece-context-evidence-and-controls-ui/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-context-compaction-control",
+        "agent-context-evidence-projection",
+        "app-settings",
+        "chat-experience",
+        "settings-cli-management-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "add-onepiece-context-measurement-and-classification",
+      "path": "openspec/changes/archive/2026-08-14-add-onepiece-context-measurement-and-classification/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-context-compaction",
+        "agent-context-measurement"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "add-onepiece-context-optimizer",
+      "path": "openspec/changes/archive/2026-08-14-add-onepiece-context-optimizer/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-context-compaction",
+        "agent-context-optimization"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "add-onepiece-context-quality-and-policy-evaluation",
+      "path": "openspec/changes/archive/2026-08-14-add-onepiece-context-quality-and-policy-evaluation/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "agent-context-evidence-projection",
+        "agent-context-quality-evaluation",
+        "app-settings",
+        "frontend-runtime-architecture",
+        "settings-cli-management-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "add-onepiece-context-trigger-and-suppression",
+      "path": "openspec/changes/archive/2026-08-14-add-onepiece-context-trigger-and-suppression/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-context-compaction",
+        "agent-context-compaction-control",
+        "agent-context-measurement"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "add-skill-evolution-evidence-pipeline",
+      "path": "openspec/changes/archive/2026-08-14-add-skill-evolution-evidence-pipeline/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-execution-observability",
+        "chat-experience",
+        "settings-skill-management-ui",
+        "skill-evolution-evidence",
+        "skill-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "add-unified-todo-board",
+      "path": "openspec/changes/archive/2026-08-14-add-unified-todo-board/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "main-layout-ui",
+        "plan-management",
+        "scheduled-task-management",
+        "session-management",
+        "unified-todo-board"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "add-utility-skill-delegation-runtime",
+      "path": "openspec/changes/archive/2026-08-14-add-utility-skill-delegation-runtime/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "effective-skill-runtime",
+        "settings-skill-management-ui",
+        "skill-management",
+        "utility-skill-delegation-runtime"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "address-workspace-destinations-by-route",
+      "path": "openspec/changes/archive/2026-08-14-address-workspace-destinations-by-route/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "frontend-runtime-architecture",
+        "main-layout-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "complete-onepiece-builtin-tool-system",
+      "path": "openspec/changes/archive/2026-08-14-complete-onepiece-builtin-tool-system/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "agent-chat-configuration",
+        "agent-tool-execution",
+        "local-extension-management",
+        "onepiece-artifact-publishing",
+        "onepiece-browser-automation",
+        "onepiece-cli-delegation",
+        "onepiece-code-execution",
+        "onepiece-native-agent",
+        "onepiece-ocr-tool",
+        "onepiece-tool-governance",
+        "onepiece-web-research"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "expand-file-mention-candidate-coverage",
+      "path": "openspec/changes/archive/2026-08-14-expand-file-mention-candidate-coverage/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-14",
+      "changeName": "harden-workspace-dialogs-and-empty-states",
+      "path": "openspec/changes/archive/2026-08-14-harden-workspace-dialogs-and-empty-states/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "loop-management-ui",
+        "main-layout-ui",
+        "visual-design-system"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "add-agent-image-input",
+      "path": "openspec/changes/archive/2026-08-15-add-agent-image-input/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-image-input",
+        "agent-provider-runtime"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "add-agent-notebook-tool",
+      "path": "openspec/changes/archive/2026-08-15-add-agent-notebook-tool/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-notebook-editing"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "add-agent-plan-exit-request",
+      "path": "openspec/changes/archive/2026-08-15-add-agent-plan-exit-request/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-chat-configuration",
+        "agent-plan-exit-request"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "add-agent-task-list",
+      "path": "openspec/changes/archive/2026-08-15-add-agent-task-list/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-task-list",
+        "agent-tool-execution"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "add-agent-user-question",
+      "path": "openspec/changes/archive/2026-08-15-add-agent-user-question/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-execution",
+        "agent-user-question"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "add-file-reference-drag-and-paste",
+      "path": "openspec/changes/archive/2026-08-15-add-file-reference-drag-and-paste/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "add-file-reference-preview-picker",
+      "path": "openspec/changes/archive/2026-08-15-add-file-reference-preview-picker/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "add-goal-system",
+      "path": "openspec/changes/archive/2026-08-15-add-goal-system/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "goal-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "add-ocr-rendered-page-return",
+      "path": "openspec/changes/archive/2026-08-15-add-ocr-rendered-page-return/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-image-input"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "add-onepiece-subagents",
+      "path": "openspec/changes/archive/2026-08-15-add-onepiece-subagents/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-execution",
+        "onepiece-subagents"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "add-onepiece-visual-tool-returns",
+      "path": "openspec/changes/archive/2026-08-15-add-onepiece-visual-tool-returns/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-image-input"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-15",
+      "changeName": "migrate-agent-memory-to-file-store",
+      "path": "openspec/changes/archive/2026-08-15-migrate-agent-memory-to-file-store/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-cross-session-memory",
+        "retrieval-vector-search"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-16",
+      "changeName": "add-agent-code-review-center",
+      "path": "openspec/changes/archive/2026-08-16-add-agent-code-review-center/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-code-review",
+        "frontend-runtime-architecture",
+        "native-runtime-architecture",
+        "session-project-inspection",
+        "session-workspace-tabs",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-16",
+      "changeName": "add-agent-evaluation-platform",
+      "path": "openspec/changes/archive/2026-08-16-add-agent-evaluation-platform/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-evaluation"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-16",
+      "changeName": "add-cross-platform-desktop-automation",
+      "path": "openspec/changes/archive/2026-08-16-add-cross-platform-desktop-automation/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "continuous-integration",
+        "desktop-runtime-verification"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-16",
+      "changeName": "add-onepiece-slash-commands",
+      "path": "openspec/changes/archive/2026-08-16-add-onepiece-slash-commands/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "chat-experience",
+        "slash-command-runtime"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-16",
+      "changeName": "add-signed-release-auto-update",
+      "path": "openspec/changes/archive/2026-08-16-add-signed-release-auto-update/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "desktop-release-delivery",
+        "signed-desktop-auto-update"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-16",
+      "changeName": "add-two-tier-memory-recall",
+      "path": "openspec/changes/archive/2026-08-16-add-two-tier-memory-recall/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-cross-session-memory",
+        "retrieval-vector-search"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-16",
+      "changeName": "enforce-architecture-fitness-functions",
+      "path": "openspec/changes/archive/2026-08-16-enforce-architecture-fitness-functions/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "continuous-integration",
+        "frontend-runtime-architecture",
+        "native-runtime-architecture",
+        "repository-governance"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-16",
+      "changeName": "fix-direct-connection-os-proxy-inheritance",
+      "path": "openspec/changes/archive/2026-08-16-fix-direct-connection-os-proxy-inheritance/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "app-settings"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-16",
+      "changeName": "unify-agent-context-engine",
+      "path": "openspec/changes/archive/2026-08-16-unify-agent-context-engine/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-context-engine",
+        "agent-context-evidence-projection",
+        "agent-context-measurement",
+        "agent-cross-session-memory",
+        "lsp-code-intelligence",
+        "onepiece-native-agent",
+        "retrieval-vector-search",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-16",
+      "changeName": "unify-agent-run-state-machine",
+      "path": "openspec/changes/archive/2026-08-16-unify-agent-run-state-machine/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-execution-observability",
+        "agent-run-state-management",
+        "agent-user-question",
+        "goal-management",
+        "loop-engineering-runtime",
+        "multi-agent-group-chat",
+        "permissions-approval",
+        "plan-execution-runtime",
+        "session-recovery",
+        "session-runtime-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-17",
+      "changeName": "add-agent-mission-control",
+      "path": "openspec/changes/archive/2026-08-17-add-agent-mission-control/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-mission-control",
+        "agent-run-state-management",
+        "main-layout-ui"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-17",
+      "changeName": "add-sandboxed-skill-tool-runtime",
+      "path": "openspec/changes/archive/2026-08-17-add-sandboxed-skill-tool-runtime/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-tool-execution",
+        "permissions-approval",
+        "permissions-core",
+        "settings-skill-management-ui",
+        "skill-management",
+        "skill-tool-runtime"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-17",
+      "changeName": "expand-runtime-performance-budgets",
+      "path": "openspec/changes/archive/2026-08-17-expand-runtime-performance-budgets/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-context-engine",
+        "agent-context-measurement",
+        "agent-execution-observability",
+        "agent-mission-control",
+        "agent-run-state-management",
+        "lsp-code-intelligence",
+        "remote-terminal-runtime",
+        "runtime-performance-governance"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-17",
+      "changeName": "extend-provider-runtime-plugin-sdk",
+      "path": "openspec/changes/archive/2026-08-17-extend-provider-runtime-plugin-sdk/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "agent-provider-runtime",
+        "provider-plugin-sdk"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-18",
+      "changeName": "add-agent-runner-abstraction",
+      "path": "openspec/changes/archive/2026-08-18-add-agent-runner-abstraction/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "agent-mission-control",
+        "agent-provider-runtime",
+        "agent-run-state-management",
+        "agent-runner-runtime",
+        "permissions-core",
+        "remote-terminal-runtime",
+        "runtime-performance-governance",
+        "unified-log-management"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-18",
+      "changeName": "add-hybrid-local-model-runtime",
+      "path": "openspec/changes/archive/2026-08-18-add-hybrid-local-model-runtime/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks",
+        "verification"
+      ],
+      "capabilities": [
+        "agent-context-engine",
+        "agent-context-measurement",
+        "api-agent-runtime",
+        "hybrid-local-model-runtime",
+        "onepiece-native-agent"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-18",
+      "changeName": "extract-api-adapter-inline-tests",
+      "path": "openspec/changes/archive/2026-08-18-extract-api-adapter-inline-tests/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": []
+    },
+    {
+      "archivedOn": "2026-08-18",
+      "changeName": "freeze-large-file-line-budgets",
+      "path": "openspec/changes/archive/2026-08-18-freeze-large-file-line-budgets/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "repository-governance"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-18",
+      "changeName": "split-database-migrations",
+      "path": "openspec/changes/archive/2026-08-18-split-database-migrations/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": []
+    },
+    {
+      "archivedOn": "2026-08-18",
+      "changeName": "split-web-agent-client",
+      "path": "openspec/changes/archive/2026-08-18-split-web-agent-client/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": []
+    },
+    {
+      "archivedOn": "2026-08-19",
+      "changeName": "decompose-api-tool-use-loop",
+      "path": "openspec/changes/archive/2026-08-19-decompose-api-tool-use-loop/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": []
+    },
+    {
+      "archivedOn": "2026-08-19",
+      "changeName": "extract-web-client-chat-state",
+      "path": "openspec/changes/archive/2026-08-19-extract-web-client-chat-state/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": []
+    },
+    {
+      "archivedOn": "2026-08-19",
+      "changeName": "freeze-panic-shortcuts-in-production-code",
+      "path": "openspec/changes/archive/2026-08-19-freeze-panic-shortcuts-in-production-code/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "repository-governance"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-19",
+      "changeName": "prune-unused-dependencies",
+      "path": "openspec/changes/archive/2026-08-19-prune-unused-dependencies/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": []
+    },
+    {
+      "archivedOn": "2026-08-19",
+      "changeName": "relocate-heavyweight-inline-tests",
+      "path": "openspec/changes/archive/2026-08-19-relocate-heavyweight-inline-tests/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": []
+    },
+    {
+      "archivedOn": "2026-08-19",
+      "changeName": "retire-panic-shortcut-whitelist",
+      "path": "openspec/changes/archive/2026-08-19-retire-panic-shortcut-whitelist/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "repository-governance"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-19",
+      "changeName": "split-api-adapter-modules",
+      "path": "openspec/changes/archive/2026-08-19-split-api-adapter-modules/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": []
+    },
+    {
+      "archivedOn": "2026-08-20",
+      "changeName": "add-permission-hook-recovery",
+      "path": "openspec/changes/archive/2026-08-20-add-permission-hook-recovery/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "claude-code-permission-hook"
+      ]
+    },
+    {
+      "archivedOn": "2026-08-20",
+      "changeName": "pin-git-message-locale",
+      "path": "openspec/changes/archive/2026-08-20-pin-git-message-locale/",
+      "artifacts": [
+        "proposal",
+        "design",
+        "tasks"
+      ],
+      "capabilities": [
+        "session-project-inspection"
+      ]
+    }
+  ]
 }

--- a/openspec/specs/claude-code-permission-hook/spec.md
+++ b/openspec/specs/claude-code-permission-hook/spec.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 TBD - created by archiving change add-claude-code-permission-callback. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: PreToolUse requests resolve through the existing decision pipeline
 The system SHALL translate every `PreToolUse` request the hook wrapper forwards into an `Action`/`Resource` pair and resolve it through the same `evaluate()`/`ApprovalBroker` pipeline used for native API agents, without a separate decision engine.
 
@@ -113,3 +115,61 @@ Every supported Tauri package SHALL include the permission-hook wrapper as a tar
 #### Scenario: An installation is incomplete or damaged
 - **WHEN** the resolved packaged wrapper is absent
 - **THEN** enabling hook management SHALL fail without modifying Claude Code's global settings
+
+### Requirement: Wrapper provides a standalone uninstall escape hatch
+
+The hook wrapper SHALL support a `--uninstall` invocation that removes only VaneHub-owned `PreToolUse` entries — identified by the wrapper binary's name appearing in an entry's hook command — from Claude Code's global settings file, SHALL preserve every other key and every non-owned hook entry, SHALL work without any running VaneHub instance or discovery data, and SHALL NOT modify the file when it cannot be parsed.
+
+#### Scenario: Owned entries are removed and everything else survives
+
+- **WHEN** `--uninstall` runs against a settings file containing VaneHub-owned `PreToolUse` entries alongside other keys and non-owned hook entries
+- **THEN** the owned entries SHALL be removed
+- **AND** every other key and non-owned hook entry SHALL be preserved
+- **AND** the process SHALL exit successfully
+
+#### Scenario: Nothing to remove is success, not failure
+
+- **WHEN** `--uninstall` runs and the settings file is absent or contains no VaneHub-owned entries
+- **THEN** the process SHALL exit successfully without modifying the file
+
+#### Scenario: An unparseable settings file is left untouched
+
+- **WHEN** `--uninstall` runs against a settings file that is not valid JSON
+- **THEN** the file SHALL NOT be modified
+- **AND** the process SHALL exit with a nonzero status and an error message
+
+### Requirement: Offline denial names its recovery paths
+
+The hook wrapper SHALL, when denying a tool call because the loopback server cannot be reached, produce a deny reason that distinguishes the absence of discovery data from a present-but-unreachable instance, and SHALL name both recovery actions — starting VaneHub, and running the wrapper's `--uninstall` escape hatch — in each variant.
+
+#### Scenario: Discovery data exists but the instance is unreachable
+
+- **WHEN** discovery data is present and the connection to the loopback server fails
+- **THEN** the deny reason SHALL state that the VaneHub instance is not reachable
+- **AND** SHALL name both recovery actions
+
+#### Scenario: No discovery data exists
+
+- **WHEN** no discovery data can be read at all
+- **THEN** the deny reason SHALL state that no VaneHub instance has registered on this machine
+- **AND** SHALL name both recovery actions
+
+### Requirement: Hook registration reconverges at desktop startup
+
+The desktop application SHALL, at startup, re-project the permission-hook entries into Claude Code's global settings when and only when the `claude-code` principal has a previously assigned template row, so that the entries name the current wrapper binary path after an application update. A reconvergence failure SHALL NOT block the rest of permissions bootstrap.
+
+#### Scenario: Hook management was previously enabled
+
+- **WHEN** the desktop application starts and the `claude-code` principal has an assigned template row
+- **THEN** the hook entries SHALL be re-projected naming the currently resolved wrapper path
+
+#### Scenario: Hook management was never enabled
+
+- **WHEN** the desktop application starts and the `claude-code` principal has no assigned template row
+- **THEN** Claude Code's global settings SHALL NOT be modified
+
+#### Scenario: Reconvergence fails
+
+- **WHEN** the startup re-projection fails for any reason
+- **THEN** permissions bootstrap SHALL continue
+- **AND** CLI sessions SHALL remain governed by the existing offline fallback behavior

--- a/openspec/specs/session-project-inspection/spec.md
+++ b/openspec/specs/session-project-inspection/spec.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 Defines confined, bounded, read-only inspection of session project files, documents, Git status, and structured diffs.
+
 ## Requirements
+
 ### Requirement: Session-root access confinement
 Project inspection operations SHALL resolve their root from the registered session and MUST reject access outside the canonical session root.
 
@@ -112,3 +114,23 @@ The workspace service SHALL extend its confined structured Git inspection with s
 #### Scenario: Refuse unsafe mutation
 - **WHEN** path confinement, file type, size, fingerprint, or exact patch application validation fails
 - **THEN** `workspaces` SHALL fail closed without partial writes
+
+### Requirement: Git inspection outcomes are locale-independent
+
+The native runtime SHALL execute Git inspection commands with a pinned message locale so that outcome classification — non-Git detection and untracked-path detection in particular — does not depend on the host system's display language. User-facing presentation of the classified outcome SHALL remain localized as specified elsewhere in this capability.
+
+#### Scenario: Non-Git directory on a non-English host
+
+- **WHEN** the selected session root is not a Git repository and the host locale is not English
+- **THEN** the runtime SHALL classify it as the non-Git case
+- **AND** Changes SHALL show the localized non-Git empty state rather than a raw command failure
+
+#### Scenario: Untracked path on a non-English host
+
+- **WHEN** an untracked path is probed on a host whose locale is not English
+- **THEN** the runtime SHALL classify it as untracked rather than as a Git command failure
+
+#### Scenario: Caller-supplied environment still applies
+
+- **WHEN** a Git invocation is made with explicit caller-supplied environment variables
+- **THEN** those variables SHALL take precedence over the pinned locale default for that invocation

--- a/src-tauri/src/bootstrap/permissions.rs
+++ b/src-tauri/src/bootstrap/permissions.rs
@@ -66,6 +66,13 @@ pub(crate) fn assemble_permissions_api(
     // rest of permissions bootstrap.
     let _ = start_hook_bridge_server(permissions.clone(), hook_waits);
 
+    // Same best-effort stance: when hook management was previously enabled, refresh the global
+    // settings entry so it names this build's wrapper path instead of a pre-update location
+    // (`add-permission-hook-recovery`'s startup reconvergence). A failure (for example a dev
+    // build without the wrapper binary on disk) leaves CLI sessions in the same risk-tiered
+    // offline fallback they were already in, and must not fail permissions bootstrap.
+    let _ = permissions.reconverge_claude_code_hook();
+
     permissions
 }
 

--- a/src-tauri/src/contexts/permissions/api.rs
+++ b/src-tauri/src/contexts/permissions/api.rs
@@ -82,6 +82,23 @@ impl PermissionsApi {
         Ok(principal)
     }
 
+    /// Re-projects the permission-hook entries at desktop startup, iff hook management was
+    /// previously enabled. The only durable representation of "enabled" is a real
+    /// (non-synthesized) `claude-code` principal row — `assign_template` is what creates it at
+    /// the moment it installs the hook — so that row's existence is the trigger. Re-running
+    /// `install()` refreshes the wrapper path the global settings entry names, which otherwise
+    /// keeps pointing at a pre-update install location forever
+    /// (`add-permission-hook-recovery`'s "Hook registration reconverges at desktop startup").
+    /// Returns whether a re-projection was attempted; the caller treats failure as best-effort.
+    pub(crate) fn reconverge_claude_code_hook(&self) -> Result<bool, PermissionsApplicationError> {
+        let (_, assigned) = self.find_principal(CLAUDE_CODE_AGENT_ID)?;
+        if !assigned {
+            return Ok(false);
+        }
+        self.claude_code_hook.install()?;
+        Ok(true)
+    }
+
     /// Reports an agent's current policy template — synthesizing the effective default when no
     /// principal row exists yet — without ever creating one as a side effect of reading
     /// (`add-permissions-settings-ui`'s agent-policy list). The `bool` is whether that template
@@ -191,10 +208,26 @@ impl PermissionsApi {
 
 #[cfg(test)]
 pub(crate) fn test_permissions_api(default_template: PolicyTemplateName) -> PermissionsApi {
-    use super::application::{
-        DefaultTemplatePort, PendingApprovalEventPort, PermissionsApplicationError,
-    };
-    use super::domain::ApprovalRequest;
+    struct NoopHook;
+    impl ClaudeCodeHookPort for NoopHook {
+        fn install(&self) -> Result<(), PermissionsApplicationError> {
+            Ok(())
+        }
+
+        fn remove(&self) -> Result<(), PermissionsApplicationError> {
+            Ok(())
+        }
+    }
+
+    test_permissions_api_with_hook(default_template, Arc::new(NoopHook))
+}
+
+#[cfg(test)]
+pub(crate) fn test_permissions_api_with_hook(
+    default_template: PolicyTemplateName,
+    claude_code_hook: Arc<dyn ClaudeCodeHookPort>,
+) -> PermissionsApi {
+    use super::application::{DefaultTemplatePort, PendingApprovalEventPort};
     use super::infrastructure::{
         PermissionsSystemClock, PermissionsUuidIdGenerator, SqliteAuditRepository,
         SqliteGrantRepository, SqlitePrincipalRepository,
@@ -212,17 +245,6 @@ pub(crate) fn test_permissions_api(default_template: PolicyTemplateName) -> Perm
     struct NoopEvents;
     impl PendingApprovalEventPort for NoopEvents {
         fn publish(&self, _request: &ApprovalRequest) -> Result<(), PermissionsApplicationError> {
-            Ok(())
-        }
-    }
-
-    struct NoopHook;
-    impl ClaudeCodeHookPort for NoopHook {
-        fn install(&self) -> Result<(), PermissionsApplicationError> {
-            Ok(())
-        }
-
-        fn remove(&self) -> Result<(), PermissionsApplicationError> {
             Ok(())
         }
     }
@@ -255,6 +277,75 @@ pub(crate) fn test_permissions_api(default_template: PolicyTemplateName) -> Perm
         evaluation,
         approvals,
         Arc::new(HookWaitRegistry::new()),
-        Arc::new(NoopHook),
+        claude_code_hook,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    #[derive(Default)]
+    struct RecordingHook {
+        installs: AtomicUsize,
+        fail: AtomicBool,
+    }
+
+    impl ClaudeCodeHookPort for RecordingHook {
+        fn install(&self) -> Result<(), PermissionsApplicationError> {
+            self.installs.fetch_add(1, Ordering::SeqCst);
+            if self.fail.load(Ordering::SeqCst) {
+                return Err(PermissionsApplicationError::infrastructure(
+                    "cli_config",
+                    "install failed".to_string(),
+                ));
+            }
+            Ok(())
+        }
+
+        fn remove(&self) -> Result<(), PermissionsApplicationError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn reconverge_does_nothing_without_an_assigned_claude_code_row() {
+        let hook = Arc::new(RecordingHook::default());
+        let api = test_permissions_api_with_hook(PolicyTemplateName::Standard, hook.clone());
+
+        let attempted = api
+            .reconverge_claude_code_hook()
+            .expect("reconverge should succeed");
+
+        assert!(!attempted);
+        assert_eq!(hook.installs.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn reconverge_reinstalls_when_hook_management_was_previously_enabled() {
+        let hook = Arc::new(RecordingHook::default());
+        let api = test_permissions_api_with_hook(PolicyTemplateName::Standard, hook.clone());
+        api.assign_template(CLAUDE_CODE_AGENT_ID, PolicyTemplateName::Readonly)
+            .expect("assign should succeed");
+        assert_eq!(hook.installs.load(Ordering::SeqCst), 1);
+
+        let attempted = api
+            .reconverge_claude_code_hook()
+            .expect("reconverge should succeed");
+
+        assert!(attempted);
+        assert_eq!(hook.installs.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn reconverge_surfaces_an_install_failure_to_the_best_effort_caller() {
+        let hook = Arc::new(RecordingHook::default());
+        let api = test_permissions_api_with_hook(PolicyTemplateName::Standard, hook.clone());
+        api.assign_template(CLAUDE_CODE_AGENT_ID, PolicyTemplateName::Readonly)
+            .expect("assign should succeed");
+
+        hook.fail.store(true, Ordering::SeqCst);
+        assert!(api.reconverge_claude_code_hook().is_err());
+    }
 }

--- a/src-tauri/src/platform/git/mod.rs
+++ b/src-tauri/src/platform/git/mod.rs
@@ -24,10 +24,7 @@ impl GitAdapter {
         args: &[String],
         timeout: Duration,
     ) -> Result<GitOutput, ProcessError> {
-        let request = ProcessRequest::new("git")
-            .args(args.iter().cloned())
-            .current_dir(root)
-            .timeout(timeout);
+        let request = base_request(root, args, timeout);
         let output = self.process.execute(&request)?;
         Ok(GitOutput {
             status: output.status,
@@ -44,10 +41,7 @@ impl GitAdapter {
         environment: &BTreeMap<String, String>,
         timeout: Duration,
     ) -> Result<GitOutput, ProcessError> {
-        let mut request = ProcessRequest::new("git")
-            .args(args.iter().cloned())
-            .current_dir(root)
-            .timeout(timeout);
+        let mut request = base_request(root, args, timeout);
         for (key, value) in environment {
             request = request.env(key, value);
         }
@@ -75,6 +69,19 @@ impl GitAdapter {
     }
 }
 
+/// `LC_ALL=C` pins git's message language: callers classify outcomes by matching output text
+/// ("not a git repository", "did not match any files"), and on a zh_CN host git otherwise
+/// localizes those messages, silently breaking every such match
+/// (`session-project-inspection`'s "Git inspection outcomes are locale-independent"). Applied
+/// before caller-supplied environment so an explicit override still wins.
+fn base_request(root: &Path, args: &[String], timeout: Duration) -> ProcessRequest {
+    ProcessRequest::new("git")
+        .args(args.iter().cloned())
+        .current_dir(root)
+        .env("LC_ALL", "C")
+        .timeout(timeout)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -95,6 +102,76 @@ mod tests {
         assert!(diagnostic.contains("token=[REDACTED]"));
         assert!(!diagnostic.contains("private-user"));
         assert!(!diagnostic.contains("git-secret"));
+    }
+
+    fn temp_non_git_dir(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "vanehub-git-locale-test-{}-{name}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn execute_yields_english_classifiable_messages_regardless_of_host_locale() {
+        let dir = temp_non_git_dir("execute");
+        let output = GitAdapter::default()
+            .execute(&dir, &["status".to_string()], Duration::from_secs(10))
+            .expect("git should run");
+        let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+        assert!(!output.status.success());
+        assert!(
+            stderr.contains("not a git repository"),
+            "expected the English classification marker, got: {stderr}"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn pinned_locale_beats_a_non_english_caller_language_environment() {
+        let dir = temp_non_git_dir("with-env");
+        // LANG/LC_MESSAGES/LANGUAGE sit below LC_ALL in libc's precedence, so the pinned
+        // LC_ALL=C must win over all of them.
+        let environment: BTreeMap<String, String> = [
+            ("LANG", "zh_CN.UTF-8"),
+            ("LC_MESSAGES", "zh_CN.UTF-8"),
+            ("LANGUAGE", "zh_CN"),
+        ]
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect();
+        let output = GitAdapter::default()
+            .execute_with_environment(
+                &dir,
+                &["status".to_string()],
+                &environment,
+                Duration::from_secs(10),
+            )
+            .expect("git should run");
+        let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+        assert!(!output.status.success());
+        assert!(
+            stderr.contains("not a git repository"),
+            "expected the English classification marker, got: {stderr}"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn an_explicit_caller_lc_all_overrides_the_pinned_default() {
+        let request = base_request(
+            Path::new("."),
+            &["status".to_string()],
+            Duration::from_secs(1),
+        )
+        .env("LC_ALL", "zh_CN.UTF-8");
+        let command = request.command().expect("command should build");
+        let lc_all = command
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new("LC_ALL"))
+            .and_then(|(_, value)| value.map(std::ffi::OsStr::to_os_string));
+        assert_eq!(lc_all.as_deref(), Some(std::ffi::OsStr::new("zh_CN.UTF-8")));
     }
 
     #[cfg(windows)]

--- a/src-tauri/src/platform/process/mod.rs
+++ b/src-tauri/src/platform/process/mod.rs
@@ -140,9 +140,6 @@ impl ProcessRequest {
         self
     }
 
-    // Unused builder surface: every current caller inherits the parent environment. Kept
-    // as the counterpart to `environment`, which `command()` still applies.
-    #[allow(dead_code)]
     pub(crate) fn env(mut self, key: impl Into<OsString>, value: impl Into<OsString>) -> Self {
         self.environment.insert(key.into(), value.into());
         self


### PR DESCRIPTION
## Summary

Two OpenSpec changes, both archived with specs synced (`add-permission-hook-recovery`, `pin-git-message-locale`).

### 1. Permission-hook recovery paths (`feat`)

The PreToolUse hook deliberately lives in Claude Code's *global* settings so governance outlives the VaneHub process (fail-closed by design). But when the installing VaneHub instance dies — crash, killed dev build — every Claude Code session on the machine degrades to the read-only offline allowlist, and the only recovery was hand-editing `~/.claude/settings.json` (Claude cannot self-recover: the Edit tool is denied by the very hook being removed). This keeps the fail-closed semantics and fixes the recovery cost:

- **`vanehub-permission-hook --uninstall`**: standalone escape hatch that removes only VaneHub-owned PreToolUse entries (marker-matched, mirroring `live_config`'s `is_vanehub_owned`), preserves everything else, writes via same-directory temp file + rename, refuses to touch an unparseable settings file, and works with no VaneHub running.
- **Actionable offline deny reasons**: "discovery present but instance unreachable" and "never registered" now produce distinct messages, each naming both recovery actions (start VaneHub / run `--uninstall`).
- **Startup reconvergence**: when the `claude-code` principal has an assigned template row, desktop startup re-projects the hook entries so the wrapper path is refreshed after an app update; best-effort, never blocks bootstrap.

### 2. Locale-independent git output classification (`fix`)

`session_queries` classifies git outcomes by matching English stderr text, but `GitAdapter` inherited the host environment — on zh_CN hosts git localizes "not a git repository", so non-git folders surfaced as raw "Git status failed." errors and the git fixtures unit test always failed. `GitAdapter` now pins `LC_ALL=C` on every git invocation (caller-supplied environment still overrides), with regression tests for a hostile zh_CN environment and override precedence.

## Verification

- `cargo fmt --check` / `cargo check --workspace` / `cargo clippy --workspace --all-targets -- -D warnings` / `npm run native:panic:check`: pass
- `cargo test --workspace`: 3602 passed, 0 failed, no skips (includes the previously locale-broken `git_fixtures_cover_non_git_and_common_worktree_states` on a zh_CN machine)
- End-to-end smoke of the built wrapper against an isolated fake HOME: both deny variants, offline Read allow, uninstall remove/preserve/idempotent, bad-flag exit code
- `openspec validate --strict` for both changes and `--specs --strict` (138 items): pass; archive index regenerated via `Update-OpenSpecArchiveIndex.ps1`

No frontend changes, no Tauri command signature changes, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TEehh3gB9wCysT6kWAB8E