### PR TITLE
Enable updater-only stable release phase

### DIFF
--- a/.github/STABLE_RELEASE_NOTES.md
+++ b/.github/STABLE_RELEASE_NOTES.md
@@ -14,9 +14,9 @@ VaneHub AI 1.0.0 is the first stable desktop release of the unified workspace fo
 
 | Platform | Architecture | Assets |
 | --- | --- | --- |
-| Windows | x64 | Signed per-user `.exe` installer (NSIS) |
-| macOS | Apple Silicon | Signed and notarized `aarch64` `.dmg` |
-| macOS | Intel | Signed and notarized `x64` `.dmg` |
+| Windows | x64 | x64 `.exe` installer (NSIS), updater-signed; Authenticode deferred |
+| macOS | Apple Silicon | `aarch64` `.dmg`, updater-signed; code signing/notarization deferred |
+| macOS | Intel | `x64` `.dmg`, updater-signed; code signing/notarization deferred |
 | Linux | x64 | `.deb` and AppImage |
 | Linux | ARM64 | `.deb` and AppImage |
 
@@ -24,7 +24,7 @@ No Windows ARM64, `.msi`, or `.rpm` package is included in this release. Linux A
 
 ## Verify your download
 
-Stable publication is blocked unless the workflow verifies the Windows publisher and trusted timestamp and verifies macOS Developer ID signing, notarization, and stapled tickets. Linux packages do not use operating-system code signing; their evidence is integrity and provenance only.
+This phase verifies the Tauri updater signature, package checksums, SBOM, and GitHub provenance. Windows packages are not Authenticode signed, and macOS packages are not Developer ID signed or notarized yet. Linux packages do not use operating-system code signing; their evidence is integrity and provenance only.
 
 Every downloadable package is covered by `SHA256SUMS`, an SPDX SBOM, and GitHub build-provenance and SBOM attestations. Download `SHA256SUMS` beside the package and run:
 
@@ -45,6 +45,7 @@ Stable installations use signed updater artifacts and the stable update channel.
 ## Known limitations
 
 - Native CLI detection, process launch, local storage, desktop integration, and installation require the Tauri desktop application; browser mode uses deterministic Web/mock behavior.
+- Windows SmartScreen and macOS Gatekeeper may warn because operating-system signing and notarization are deferred to a later release phase.
 - Agent vendor authentication still occurs through each vendor's CLI or account flow; VaneHub AI does not broker subscription sign-in.
 - Package availability is limited to the platform and architecture matrix above.
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -165,12 +165,10 @@ jobs:
           fi
           if [[ "${GITHUB_REF_NAME}" != *-* ]]; then
             if [[ "${RUNNER_OS}" == "Windows" && -z "${WINDOWS_CERTIFICATE}" ]]; then
-              echo "::error::stable Windows releases require signing credentials" >&2
-              exit 1
+              echo "Windows Authenticode credentials are not configured; publishing an explicitly unsigned Windows package for updater-only phase 1."
             fi
             if [[ "${RUNNER_OS}" == "macOS" && ( -z "${APPLE_CERTIFICATE}" || -z "${APPLE_ID}" || -z "${APPLE_TEAM_ID}" ) ]]; then
-              echo "::error::stable macOS releases require signing and notarization credentials" >&2
-              exit 1
+              echo "Apple signing/notarization credentials are not configured; publishing an explicitly unsigned and un-notarized macOS package for updater-only phase 1."
             fi
           fi
 
@@ -412,8 +410,9 @@ jobs:
               --latest=false
           fi
 
-          # This mutable channel release is updated only after every package, signature,
-          # notarization, checksum, SBOM, attestation, and versioned-release step succeeds.
+          # This mutable channel release is updated only after every package, updater signature,
+          # checksum, SBOM, attestation, and versioned-release step succeeds. Operating-system
+          # signing is optional during updater-only phase 1 and is disclosed in the release notes.
           cp "${manifest}" "${RUNNER_TEMP}/latest.json"
           gh release upload "${channel_tag}" "${RUNNER_TEMP}/latest.json" \
             --repo "${GITHUB_REPOSITORY}" \

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -12,7 +12,7 @@ The `Package Desktop Apps` workflow uses an unprivileged `build-preview` environ
 6. Merge the reviewed version change to `main`.
 7. Create and push an annotated `v<version>` tag from that exact `main` commit.
 8. Approve the `release` environment deployment if environment reviewers are configured.
-9. Verify packages, signatures, notarization, `SHA256SUMS`, the SPDX SBOM, GitHub artifact attestations, release notes, and channel metadata.
+9. Verify packages, updater signatures, `SHA256SUMS`, the SPDX SBOM, GitHub artifact attestations, release notes, and channel metadata. Operating-system signing is a later phase until its credentials are provisioned.
 
 The publish job cannot run until all Windows, macOS, and Linux jobs finish successfully. It uses short-lived GitHub OIDC identity for attestations and does not require a stored GitHub token.
 
@@ -109,7 +109,7 @@ The expected inventory is the eleven names in the table above. A missing name ma
 
 Windows evidence follows `artifact -> Get-AuthenticodeSignature -> expected publisher subject -> timestamp certificate`. A `Valid` status alone is insufficient: the workflow rejects an unexpected publisher or missing timestamp.
 
-macOS evidence follows `build -> codesign --verify --deep --strict -> notarize -> staple -> stapler validate -> spctl --assess -> publish` for both x64 and arm64 matrix entries. A notarization or staple failure prevents stable publication.
+When Apple credentials are provisioned, macOS evidence follows `build -> codesign --verify --deep --strict -> notarize -> staple -> stapler validate -> spctl --assess -> publish` for both x64 and arm64 matrix entries. During updater-only phase 1, macOS packages are explicitly unsigned and un-notarized.
 
 Linux packages retain SHA-256, SPDX SBOM, and GitHub provenance/SBOM attestations. These prove integrity and provenance; they are not operating-system code signing.
 
@@ -123,6 +123,6 @@ After publication, inspect the `Package Desktop Apps` run and the versioned GitH
 
 The environment should allow deployment only from protected `v*` tags. Add a human reviewer when a second trusted maintainer is available. A required self-review is intentionally not configured because it would make a single-maintainer repository impossible to release.
 
-Until valid platform credentials are configured, manual rehearsal and preview packages may be unsigned. Stable publication fails closed. Release notes must say so clearly; the checksums, SBOM, and GitHub attestations establish integrity but do not replace operating-system code signing or Apple notarization.
+During updater-only phase 1, stable publication requires the updater signing key but permits explicitly disclosed unsigned Windows and un-notarized macOS packages. The checksums, SBOM, and GitHub attestations establish integrity but do not replace operating-system code signing or Apple notarization. A later phase will restore platform-signing gates after the corresponding credentials and provider are configured.
 
 A bare disclosure is not enough for a public download. An unsigned build must also publish the steps a downloader needs to get past the protection each platform raises: macOS reports an un-notarized application as damaged until its quarantine attribute is cleared, and Windows SmartScreen blocks an unsigned installer behind a secondary confirmation. `.github/PREVIEW_RELEASE_NOTES.md` carries both, and must be updated whenever the signing situation changes.

--- a/scripts/release-policy.node-test.mjs
+++ b/scripts/release-policy.node-test.mjs
@@ -16,17 +16,17 @@ test("stable and preview tags select their reviewed release notes", () => {
   assert.ok(workflow.includes('if [[ "${GITHUB_REF_NAME}" == *-* ]]'));
 });
 
-test("stable publication fails closed without updater and platform signing credentials", () => {
+test("stable updater-only phase fails closed without the updater signing key", () => {
   assert.ok(workflow.includes('if [[ -z "${TAURI_SIGNING_PRIVATE_KEY}" ]]'));
   assert.ok(workflow.includes('if [[ "${GITHUB_REF_NAME}" != *-* ]]'));
   assert.ok(
     workflow.includes(
-      'if [[ "${RUNNER_OS}" == "Windows" && -z "${WINDOWS_CERTIFICATE}" ]]',
+      "publishing an explicitly unsigned Windows package for updater-only phase 1",
     ),
   );
   assert.ok(
     workflow.includes(
-      'if [[ "${RUNNER_OS}" == "macOS" && ( -z "${APPLE_CERTIFICATE}" || -z "${APPLE_ID}" || -z "${APPLE_TEAM_ID}" ) ]]',
+      "publishing an explicitly unsigned and un-notarized macOS package for updater-only phase 1",
     ),
   );
 });
@@ -68,7 +68,7 @@ test("stable notes distinguish platform signing from Linux integrity evidence", 
   for (const heading of ["## Downloads", "## Verify your download", "## Updates", "## Known limitations", "## Reporting problems"]) {
     assert.ok(stableNotes.includes(heading), `Missing stable release section: ${heading}`);
   }
-  assert.match(stableNotes, /Windows publisher and trusted timestamp/);
-  assert.match(stableNotes, /macOS Developer ID signing, notarization, and stapled tickets/);
+  assert.match(stableNotes, /Windows packages are not Authenticode signed/);
+  assert.match(stableNotes, /macOS packages are not Developer ID signed or notarized/);
   assert.match(stableNotes, /Linux packages do not use operating-system code signing/);
 });

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,7 @@
   "plugins": {
     "updater": {
       "endpoints": ["https://github.com/cdavid817/vanehub-ai/releases/download/update-stable/latest.json"],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEU4NDlGMzI5MzgwRjNCQkUKUldTK093ODRLZk5KNlB5TVpQanNaVW92eWNvK3llR2ZkOU1KdnZLMzFkT1VYQnhsRjlhekVxc1IK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDNFQzk2Q0U2NzMyMDdFQTkKUldTcGZpQno1bXpKUGd5ZjFrSkk2Z1YwbDkwWVdpbmIwS2JuWUlMajk0bktWRmY1aWQ3M3FzNU4K"
     }
   }
 }


### PR DESCRIPTION
## Summary
- rotate the embedded Tauri updater public key to match the newly provisioned release secret
- enable the first stable publication phase with updater-signed artifacts
- permit explicitly disclosed unsigned Windows and un-notarized macOS packages until platform credentials are provisioned
- retain five-target packaging, checksums, SBOM, attestations, and stable updater metadata

## Validation
- npm run release:unit:test
- npm run docs:check
- npm run build
- cargo check (src-tauri)

The release environment now contains TAURI_SIGNING_PRIVATE_KEY and TAURI_SIGNING_PRIVATE_KEY_PASSWORD. Windows and Apple signing secrets remain intentionally unconfigured for this phase.