### PR TITLE
Include Linux ARM64 updater metadata

### DIFF
--- a/.github/STABLE_RELEASE_NOTES.md
+++ b/.github/STABLE_RELEASE_NOTES.md
@@ -14,9 +14,9 @@ VaneHub AI 1.0.0 is the first stable desktop release of the unified workspace fo
 
 | Platform | Architecture | Assets |
 | --- | --- | --- |
-| Windows | x64 | Signed per-user `.exe` installer (NSIS) |
-| macOS | Apple Silicon | Signed and notarized `aarch64` `.dmg` |
-| macOS | Intel | Signed and notarized `x64` `.dmg` |
+| Windows | x64 | x64 `.exe` installer (NSIS), updater-signed; Authenticode deferred |
+| macOS | Apple Silicon | `aarch64` `.dmg`, updater-signed; code signing/notarization deferred |
+| macOS | Intel | `x64` `.dmg`, updater-signed; code signing/notarization deferred |
 | Linux | x64 | `.deb` and AppImage |
 | Linux | ARM64 | `.deb` and AppImage |
 
@@ -24,7 +24,7 @@ No Windows ARM64, `.msi`, or `.rpm` package is included in this release. Linux A
 
 ## Verify your download
 
-Stable publication is blocked unless the workflow verifies the Windows publisher and trusted timestamp and verifies macOS Developer ID signing, notarization, and stapled tickets. Linux packages do not use operating-system code signing; their evidence is integrity and provenance only.
+This phase verifies the Tauri updater signature, package checksums, SBOM, and GitHub provenance. Windows packages are not Authenticode signed, and macOS packages are not Developer ID signed or notarized yet. Linux packages do not use operating-system code signing; their evidence is integrity and provenance only.
 
 Every downloadable package is covered by `SHA256SUMS`, an SPDX SBOM, and GitHub build-provenance and SBOM attestations. Download `SHA256SUMS` beside the package and run:
 
@@ -45,6 +45,7 @@ Stable installations use signed updater artifacts and the stable update channel.
 ## Known limitations
 
 - Native CLI detection, process launch, local storage, desktop integration, and installation require the Tauri desktop application; browser mode uses deterministic Web/mock behavior.
+- Windows SmartScreen and macOS Gatekeeper may warn because operating-system signing and notarization are deferred to a later release phase.
 - Agent vendor authentication still occurs through each vendor's CLI or account flow; VaneHub AI does not broker subscription sign-in.
 - Package availability is limited to the platform and architecture matrix above.
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -369,7 +369,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          mapfile -d '' assets < <(find release-assets -type f -print0)
+          assets=()
+          while IFS= read -r -d '' file; do
+            assets+=("${file}")
+          done < <(find release-assets/packages -type f -print0)
+          channel_manifest="latest.json"
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then channel_manifest="preview.json"; fi
+          assets+=(
+            "release-assets/SHA256SUMS"
+            "release-assets/vanehub-ai-sbom.spdx.json"
+            "release-assets/${channel_manifest}"
+          )
 
           args=(
             --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -165,12 +165,10 @@ jobs:
           fi
           if [[ "${GITHUB_REF_NAME}" != *-* ]]; then
             if [[ "${RUNNER_OS}" == "Windows" && -z "${WINDOWS_CERTIFICATE}" ]]; then
-              echo "::error::stable Windows releases require signing credentials" >&2
-              exit 1
+              echo "Windows Authenticode credentials are not configured; publishing an explicitly unsigned Windows package for updater-only phase 1."
             fi
             if [[ "${RUNNER_OS}" == "macOS" && ( -z "${APPLE_CERTIFICATE}" || -z "${APPLE_ID}" || -z "${APPLE_TEAM_ID}" ) ]]; then
-              echo "::error::stable macOS releases require signing and notarization credentials" >&2
-              exit 1
+              echo "Apple signing/notarization credentials are not configured; publishing an explicitly unsigned and un-notarized macOS package for updater-only phase 1."
             fi
           fi
 
@@ -412,8 +410,9 @@ jobs:
               --latest=false
           fi
 
-          # This mutable channel release is updated only after every package, signature,
-          # notarization, checksum, SBOM, attestation, and versioned-release step succeeds.
+          # This mutable channel release is updated only after every package, updater signature,
+          # checksum, SBOM, attestation, and versioned-release step succeeds. Operating-system
+          # signing is optional during updater-only phase 1 and is disclosed in the release notes.
           cp "${manifest}" "${RUNNER_TEMP}/latest.json"
           gh release upload "${channel_tag}" "${RUNNER_TEMP}/latest.json" \
             --repo "${GITHUB_REPOSITORY}" \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -332,7 +332,10 @@ jobs:
             digest="$(sha256sum "${file}" | cut -d' ' -f1)"
             asset="$(basename "${file}" | tr ' ' '.')"
             printf '%s  %s\n' "${digest}" "${asset}" >> release-assets/SHA256SUMS
-          done < <(find release-assets -type f ! -name SHA256SUMS -print0 | sort -z)
+          done < <(find release-assets/packages -type f -print0 | sort -z)
+
+          digest="$(sha256sum release-assets/vanehub-ai-sbom.spdx.json | cut -d' ' -f1)"
+          printf '%s  %s\n' "${digest}" "vanehub-ai-sbom.spdx.json" >> release-assets/SHA256SUMS
 
           echo "Published checksum manifest:"
           cat release-assets/SHA256SUMS

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -12,7 +12,7 @@ The `Package Desktop Apps` workflow uses an unprivileged `build-preview` environ
 6. Merge the reviewed version change to `main`.
 7. Create and push an annotated `v<version>` tag from that exact `main` commit.
 8. Approve the `release` environment deployment if environment reviewers are configured.
-9. Verify packages, signatures, notarization, `SHA256SUMS`, the SPDX SBOM, GitHub artifact attestations, release notes, and channel metadata.
+9. Verify packages, updater signatures, `SHA256SUMS`, the SPDX SBOM, GitHub artifact attestations, release notes, and channel metadata. Operating-system signing is a later phase until its credentials are provisioned.
 
 The publish job cannot run until all Windows, macOS, and Linux jobs finish successfully. It uses short-lived GitHub OIDC identity for attestations and does not require a stored GitHub token.
 
@@ -109,7 +109,7 @@ The expected inventory is the eleven names in the table above. A missing name ma
 
 Windows evidence follows `artifact -> Get-AuthenticodeSignature -> expected publisher subject -> timestamp certificate`. A `Valid` status alone is insufficient: the workflow rejects an unexpected publisher or missing timestamp.
 
-macOS evidence follows `build -> codesign --verify --deep --strict -> notarize -> staple -> stapler validate -> spctl --assess -> publish` for both x64 and arm64 matrix entries. A notarization or staple failure prevents stable publication.
+When Apple credentials are provisioned, macOS evidence follows `build -> codesign --verify --deep --strict -> notarize -> staple -> stapler validate -> spctl --assess -> publish` for both x64 and arm64 matrix entries. During updater-only phase 1, macOS packages are explicitly unsigned and un-notarized.
 
 Linux packages retain SHA-256, SPDX SBOM, and GitHub provenance/SBOM attestations. These prove integrity and provenance; they are not operating-system code signing.
 
@@ -123,6 +123,6 @@ After publication, inspect the `Package Desktop Apps` run and the versioned GitH
 
 The environment should allow deployment only from protected `v*` tags. Add a human reviewer when a second trusted maintainer is available. A required self-review is intentionally not configured because it would make a single-maintainer repository impossible to release.
 
-Until valid platform credentials are configured, manual rehearsal and preview packages may be unsigned. Stable publication fails closed. Release notes must say so clearly; the checksums, SBOM, and GitHub attestations establish integrity but do not replace operating-system code signing or Apple notarization.
+During updater-only phase 1, stable publication requires the updater signing key but permits explicitly disclosed unsigned Windows and un-notarized macOS packages. The checksums, SBOM, and GitHub attestations establish integrity but do not replace operating-system code signing or Apple notarization. A later phase will restore platform-signing gates after the corresponding credentials and provider are configured.
 
 A bare disclosure is not enough for a public download. An unsigned build must also publish the steps a downloader needs to get past the protection each platform raises: macOS reports an un-notarized application as damaged until its quarantine attribute is cleared, and Windows SmartScreen blocks an unsigned installer behind a secondary confirmation. `.github/PREVIEW_RELEASE_NOTES.md` carries both, and must be updated whenever the signing situation changes.

--- a/scripts/generate-updater-manifest.mjs
+++ b/scripts/generate-updater-manifest.mjs
@@ -13,9 +13,10 @@ for (const signaturePath of signatures) {
   const artifactPath = signaturePath.slice(0, -4);
   const name = basename(artifactPath).replaceAll(" ", ".");
   const lower = name.toLowerCase();
-  const platform = lower.includes("macos-arm64") || lower.includes("aarch64") ? "darwin-aarch64"
+  const platform = lower.includes("macos-arm64") || lower.includes("aarch64-macos") ? "darwin-aarch64"
     : lower.includes("macos-x64") ? "darwin-x86_64"
-      : lower.includes("linux-x64") || lower.endsWith(".appimage") || lower.endsWith(".deb") ? "linux-x86_64"
+      : lower.includes("linux-arm64") || lower.includes("aarch64-linux") ? "linux-aarch64"
+        : lower.includes("linux-x64") || lower.endsWith(".appimage") || lower.endsWith(".deb") ? "linux-x86_64"
         : lower.includes("windows-x64") || lower.endsWith(".exe") ? "windows-x86_64"
           : lower.endsWith(".dmg") ? "darwin-x86_64" : null;
   if (!platform || platforms[platform]) continue;
@@ -23,7 +24,7 @@ for (const signaturePath of signatures) {
   if (signature.length < 40) throw new Error(`invalid signature for ${name}`);
   platforms[platform] = { signature, url: `https://github.com/${repository}/releases/download/${tag}/${encodeURIComponent(name)}` };
 }
-const requiredPlatforms = ["darwin-aarch64", "darwin-x86_64", "linux-x86_64", "windows-x86_64"];
+const requiredPlatforms = ["darwin-aarch64", "darwin-x86_64", "linux-x86_64", "linux-aarch64", "windows-x86_64"];
 const missingPlatforms = requiredPlatforms.filter((platform) => !platforms[platform]);
 if (missingPlatforms.length > 0) throw new Error(`missing signed updater artifacts: ${missingPlatforms.join(", ")}`);
 await writeFile(outputPath, `${JSON.stringify({ version, notes: `VaneHub AI ${tag}`, pub_date: new Date().toISOString(), platforms }, null, 2)}\n`);

--- a/scripts/generate-updater-manifest.unit.mjs
+++ b/scripts/generate-updater-manifest.unit.mjs
@@ -10,6 +10,7 @@ await writeFile(join(directory, "VaneHub.AI_1.2.0_x64-setup.exe.sig"), "signed-f
 await writeFile(join(directory, "VaneHub.AI-macos-arm64.app.tar.gz.sig"), "arm-signature-".repeat(5));
 await writeFile(join(directory, "VaneHub.AI-macos-x64.app.tar.gz.sig"), "mac-signature-".repeat(5));
 await writeFile(join(directory, "VaneHub.AI-linux-x64.AppImage.sig"), "linux-signature-".repeat(5));
+await writeFile(join(directory, "VaneHub.AI_aarch64-linux-arm64.AppImage.sig"), "linux-arm-signature-".repeat(5));
 const output = join(directory, "latest.json");
 const generator = fileURLToPath(new URL("./generate-updater-manifest.mjs", import.meta.url));
 const result = spawnSync(process.execPath, [generator, directory, "v1.2.0", "owner/repo", output]);
@@ -18,6 +19,7 @@ const manifest = JSON.parse(await readFile(output, "utf8"));
 assert.equal(manifest.version, "1.2.0");
 assert.match(manifest.platforms["windows-x86_64"].url, /^https:\/\//);
 assert.match(manifest.platforms["darwin-aarch64"].url, /macos-arm64/);
+assert.match(manifest.platforms["linux-aarch64"].url, /linux-arm64/);
 await writeFile(join(directory, "bad.exe.sig"), "tampered");
 const invalid = spawnSync(process.execPath, [generator, directory, "invalid", "owner/repo", output]);
 assert.notEqual(invalid.status, 0);

--- a/scripts/release-policy.node-test.mjs
+++ b/scripts/release-policy.node-test.mjs
@@ -16,17 +16,17 @@ test("stable and preview tags select their reviewed release notes", () => {
   assert.ok(workflow.includes('if [[ "${GITHUB_REF_NAME}" == *-* ]]'));
 });
 
-test("stable publication fails closed without updater and platform signing credentials", () => {
+test("stable updater-only phase fails closed without the updater signing key", () => {
   assert.ok(workflow.includes('if [[ -z "${TAURI_SIGNING_PRIVATE_KEY}" ]]'));
   assert.ok(workflow.includes('if [[ "${GITHUB_REF_NAME}" != *-* ]]'));
   assert.ok(
     workflow.includes(
-      'if [[ "${RUNNER_OS}" == "Windows" && -z "${WINDOWS_CERTIFICATE}" ]]',
+      "publishing an explicitly unsigned Windows package for updater-only phase 1",
     ),
   );
   assert.ok(
     workflow.includes(
-      'if [[ "${RUNNER_OS}" == "macOS" && ( -z "${APPLE_CERTIFICATE}" || -z "${APPLE_ID}" || -z "${APPLE_TEAM_ID}" ) ]]',
+      "publishing an explicitly unsigned and un-notarized macOS package for updater-only phase 1",
     ),
   );
 });
@@ -68,7 +68,7 @@ test("stable notes distinguish platform signing from Linux integrity evidence", 
   for (const heading of ["## Downloads", "## Verify your download", "## Updates", "## Known limitations", "## Reporting problems"]) {
     assert.ok(stableNotes.includes(heading), `Missing stable release section: ${heading}`);
   }
-  assert.match(stableNotes, /Windows publisher and trusted timestamp/);
-  assert.match(stableNotes, /macOS Developer ID signing, notarization, and stapled tickets/);
+  assert.match(stableNotes, /Windows packages are not Authenticode signed/);
+  assert.match(stableNotes, /macOS packages are not Developer ID signed or notarized/);
   assert.match(stableNotes, /Linux packages do not use operating-system code signing/);
 });

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,7 @@
   "plugins": {
     "updater": {
       "endpoints": ["https://github.com/cdavid817/vanehub-ai/releases/download/update-stable/latest.json"],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEU4NDlGMzI5MzgwRjNCQkUKUldTK093ODRLZk5KNlB5TVpQanNaVW92eWNvK3llR2ZkOU1KdnZLMzFkT1VYQnhsRjlhekVxc1IK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDNFQzk2Q0U2NzMyMDdFQTkKUldTcGZpQno1bXpKUGd5ZjFrSkk2Z1YwbDkwWVdpbmIwS2JuWUlMajk0bktWRmY1aWQ3M3FzNU4K"
     }
   }
 }


### PR DESCRIPTION
The v1.0.0 release includes Linux ARM64 packages and signatures, but the generated latest.json omitted the linux-aarch64 updater platform. Add explicit Linux ARM64 detection and require/cover it in the manifest unit test. Validation: node --test scripts/generate-updater-manifest.unit.mjs scripts/release-policy.node-test.mjs.