### PR TITLE
Include Linux ARM64 updater metadata

### DIFF
--- a/scripts/generate-updater-manifest.mjs
+++ b/scripts/generate-updater-manifest.mjs
@@ -13,9 +13,10 @@ for (const signaturePath of signatures) {
   const artifactPath = signaturePath.slice(0, -4);
   const name = basename(artifactPath).replaceAll(" ", ".");
   const lower = name.toLowerCase();
-  const platform = lower.includes("macos-arm64") || lower.includes("aarch64") ? "darwin-aarch64"
+  const platform = lower.includes("macos-arm64") || lower.includes("aarch64-macos") ? "darwin-aarch64"
     : lower.includes("macos-x64") ? "darwin-x86_64"
-      : lower.includes("linux-x64") || lower.endsWith(".appimage") || lower.endsWith(".deb") ? "linux-x86_64"
+      : lower.includes("linux-arm64") || lower.includes("aarch64-linux") ? "linux-aarch64"
+        : lower.includes("linux-x64") || lower.endsWith(".appimage") || lower.endsWith(".deb") ? "linux-x86_64"
         : lower.includes("windows-x64") || lower.endsWith(".exe") ? "windows-x86_64"
           : lower.endsWith(".dmg") ? "darwin-x86_64" : null;
   if (!platform || platforms[platform]) continue;
@@ -23,7 +24,7 @@ for (const signaturePath of signatures) {
   if (signature.length < 40) throw new Error(`invalid signature for ${name}`);
   platforms[platform] = { signature, url: `https://github.com/${repository}/releases/download/${tag}/${encodeURIComponent(name)}` };
 }
-const requiredPlatforms = ["darwin-aarch64", "darwin-x86_64", "linux-x86_64", "windows-x86_64"];
+const requiredPlatforms = ["darwin-aarch64", "darwin-x86_64", "linux-x86_64", "linux-aarch64", "windows-x86_64"];
 const missingPlatforms = requiredPlatforms.filter((platform) => !platforms[platform]);
 if (missingPlatforms.length > 0) throw new Error(`missing signed updater artifacts: ${missingPlatforms.join(", ")}`);
 await writeFile(outputPath, `${JSON.stringify({ version, notes: `VaneHub AI ${tag}`, pub_date: new Date().toISOString(), platforms }, null, 2)}\n`);

--- a/scripts/generate-updater-manifest.unit.mjs
+++ b/scripts/generate-updater-manifest.unit.mjs
@@ -10,6 +10,7 @@ await writeFile(join(directory, "VaneHub.AI_1.2.0_x64-setup.exe.sig"), "signed-f
 await writeFile(join(directory, "VaneHub.AI-macos-arm64.app.tar.gz.sig"), "arm-signature-".repeat(5));
 await writeFile(join(directory, "VaneHub.AI-macos-x64.app.tar.gz.sig"), "mac-signature-".repeat(5));
 await writeFile(join(directory, "VaneHub.AI-linux-x64.AppImage.sig"), "linux-signature-".repeat(5));
+await writeFile(join(directory, "VaneHub.AI_aarch64-linux-arm64.AppImage.sig"), "linux-arm-signature-".repeat(5));
 const output = join(directory, "latest.json");
 const generator = fileURLToPath(new URL("./generate-updater-manifest.mjs", import.meta.url));
 const result = spawnSync(process.execPath, [generator, directory, "v1.2.0", "owner/repo", output]);
@@ -18,6 +19,7 @@ const manifest = JSON.parse(await readFile(output, "utf8"));
 assert.equal(manifest.version, "1.2.0");
 assert.match(manifest.platforms["windows-x86_64"].url, /^https:\/\//);
 assert.match(manifest.platforms["darwin-aarch64"].url, /macos-arm64/);
+assert.match(manifest.platforms["linux-aarch64"].url, /linux-arm64/);
 await writeFile(join(directory, "bad.exe.sig"), "tampered");
 const invalid = spawnSync(process.execPath, [generator, directory, "invalid", "owner/repo", output]);
 assert.notEqual(invalid.status, 0);


### PR DESCRIPTION
The v1.0.0 release includes Linux ARM64 packages and signatures, but latest.json omitted the linux-aarch64 updater platform. Add explicit Linux ARM64 detection and require/cover it in the manifest unit test. Validation: node --test scripts/generate-updater-manifest.unit.mjs scripts/release-policy.node-test.mjs.