### PR TITLE
chore(release): prepare v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7326,7 +7326,7 @@ dependencies = [
 
 [[package]]
 name = "vanehub-ai"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/openspec/changes/prepare-first-stable-release/tasks.md
+++ b/openspec/changes/prepare-first-stable-release/tasks.md
@@ -15,6 +15,7 @@
 - [x] 3.1 Validate `prepare-first-stable-release` strictly and validate all main specifications strictly.
 - [x] 3.2 Run all mandatory frontend, coverage-policy, version, contract, build, Rust format, clippy, test, and check commands from `AGENTS.md`.
 - [x] 3.3 Run the UI and native desktop verification commands required for desktop release behavior and record Windows as `PASSED`, `FAILED`, `BLOCKED`, or `NOT RUN`.
+- [x] 3.4 Keep release-version fixtures and the workspace lockfile synchronized so CI documentation builds remain read-only.
 
 ## 4. GitHub Release Readiness
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vanehub-ai",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vanehub-ai",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.3.3",
         "@tanstack/react-query": "^5.101.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanehub-ai",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanehub-ai"
-version = "1.0.0"
+version = "1.1.0"
 description = "Unified AI coding agent management"
 authors = ["vanehub-ai"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VaneHub AI",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "ai.vanehub.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/services/about-service.test.ts
+++ b/src/services/about-service.test.ts
@@ -13,9 +13,9 @@ describe("about-service", () => {
       new Response(
         JSON.stringify({
           body: "Release notes",
-          html_url: "https://github.com/cdavid817/vanehub-ai/releases/tag/v1.1.0",
-          name: "VaneHub AI v1.1.0",
-          tag_name: "v1.1.0",
+          html_url: "https://github.com/cdavid817/vanehub-ai/releases/tag/v1.1.1",
+          name: "VaneHub AI v1.1.1",
+          tag_name: "v1.1.1",
         }),
         { status: 200 },
       );
@@ -23,7 +23,7 @@ describe("about-service", () => {
     const result = await checkAboutUpdates(fetchImpl);
 
     expect(result.updateAvailable).toBe(true);
-    expect(result.latestVersion).toBe("1.1.0");
+    expect(result.latestVersion).toBe("1.1.1");
     expect(result.releaseNotes).toBe("Release notes");
   });
 


### PR DESCRIPTION
## Summary
- synchronize the npm, Cargo, Tauri, and lockfile version declarations for v1.1.0
- prepare the second stable GitHub release after v1.0.0

## Validation
- npm run version:check
- npm run version:unit:test
- npm run release:unit:test

The v1.1.0 tag should be created after this PR is merged; it triggers the protected multi-platform release workflow.