### PR TITLE
test(mcp-relay): read the Windows relay DACL structurally instead of comparing its text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,29 @@ jobs:
       - name: Native cargo build
         run: cargo build --manifest-path src-tauri/Cargo.toml
 
+      # The relay privacy contract is a Windows DACL, and this leg is the only place a GitHub
+      # Windows runner executes it. It is targeted rather than a full workspace run because the
+      # question is narrow: what does the ACL actually look like on this host.
+      #
+      # The guard matters as much as the command. A libtest filter that matches nothing exits 0
+      # and reads exactly like a pass -- which is how the original filter for this test, missing
+      # its `tests::` segment, selected zero tests and reported success. So the run is required
+      # to prove a test ran before either outcome is believed.
+      - name: Windows relay DACL contract reading
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          output=$(cargo test --workspace \
+            private_relay_fs::tests::windows_directory_and_file_dacls_allow_only_the_current_user \
+            -- --nocapture 2>&1)
+          status=$?
+          echo "$output"
+          if ! grep -q "running 1 test" <<< "$output"; then
+            echo "::error::the filter selected no test; a zero-match run is not a pass"
+            exit 1
+          fi
+          exit $status
+
       - name: Windows Skill Tool hostile fixtures (declarative-only)
         if: runner.os == 'Windows'
         run: cargo test --manifest-path src-tauri/Cargo.toml skill_tool --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,12 +358,16 @@ jobs:
         shell: bash
         run: |
           output=$(cargo test --workspace \
-            private_relay_fs::tests::windows_directory_and_file_dacls_allow_only_the_current_user \
-            -- --nocapture 2>&1)
+            platform::private_relay_fs::tests::windows_directory_and_file_dacls_allow_only_the_current_user \
+            -- --exact --nocapture 2>&1)
           status=$?
           echo "$output"
-          if ! grep -q "running 1 test" <<< "$output"; then
-            echo "::error::the filter selected no test; a zero-match run is not a pass"
+          # `--exact` with the full path names one test and cannot drag in a neighbour by
+          # prefix. The count guard stays regardless: libtest exits 0 when a filter matches
+          # nothing, so a renamed test would turn this step into a silent pass -- which is how
+          # the earlier filter, missing its `tests::` segment, reported success on zero tests.
+          if ! grep -q "^running 1 test$" <<< "$output"; then
+            echo "::error::expected exactly one executed test; a zero-match run is not a pass"
             exit 1
           fi
           exit $status

--- a/openspec/changes/fix-code-intelligence-bounded-cleanup-flake/.openspec.yaml
+++ b/openspec/changes/fix-code-intelligence-bounded-cleanup-flake/.openspec.yaml
@@ -1,0 +1,11 @@
+schema: spec-driven
+created: 2026-08-24
+# No spec delta: the contract this test asserts -- an initialize timeout forces bounded
+# process-tree cleanup, reports InitializeTimedOut, then ForcedTermination, without
+# cancellation -- is unchanged and stays exactly as written. What is defective is the harness
+# around it, which measures wall clock on a shared machine and calls the result a bound.
+#
+# If investigation shows production cleanup is genuinely unbounded under load, that is a
+# behaviour change with a spec impact, and the proposal is amended rather than this flag being
+# used to carry it through unnoticed.
+skip_specs: true

--- a/openspec/changes/fix-code-intelligence-bounded-cleanup-flake/proposal.md
+++ b/openspec/changes/fix-code-intelligence-bounded-cleanup-flake/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`code_intelligence::infrastructure::server_test_tests::initialize_timeout_forces_bounded_process_tree_cleanup_without_cancellation` fails under load and passes in isolation. That has now happened twice, which is what turns it from an anecdote into a defect worth its own change.
+
+Recorded evidence, all on Windows:
+
+| when | result | context |
+| --- | --- | --- |
+| full workspace run, `npx openspec` running concurrently | FAILED | first observation |
+| 7 isolated re-runs immediately afterwards | 7 PASS | — |
+| full workspace run, 490s against a usual ~343s | FAILED | second observation, alongside `local_runner_windows_spawn_cancel_benchmark` |
+| 3 isolated re-runs immediately afterwards | 3 PASS | — |
+
+Ten passes, two failures, and both failures are on the loaded runs. The test spawns a real `lsp-hang` fixture process and asserts that an initialize timeout of `Duration::from_secs(2)` produces `InitializeTimedOut` followed by a `ForcedTermination` cleanup. A two-second budget measured against real process startup is a budget that a busy machine can miss for reasons that have nothing to do with the code under test.
+
+`local_runner_windows_spawn_cancel_benchmark_records_bounded_cleanup` failed once in the same loaded run and passed 3/3 isolated. It is listed here as a second data point rather than a second defect: one observation is not repeat evidence, and this change should not quietly widen to cover it without one.
+
+The cost of leaving it is not the red build. It is that a suite with a known load-sensitive failure teaches everyone reading it to re-run rather than to look — and the next real regression arrives wearing the same clothes.
+
+## What Changes
+
+* **Establish what the test is actually asserting.** There are two candidates and they need separating before anything is edited: that cleanup is *bounded* (a property), or that cleanup completes *within two seconds of wall clock on this machine* (a measurement). Only the first is a contract.
+* **Reproduce deliberately rather than by waiting.** Run the test under induced load until the failure is observable on demand. A defect that can only be seen by accident cannot be shown to be fixed.
+* **Separate the timeout under test from the harness's patience.** The initialize timeout is the behaviour being verified; how long the test is willing to wait for the resulting cleanup to be observed is a different number, and conflating them is what makes a slow machine look like a broken one.
+* **Keep the assertion about ordering and outcome**, which is the real contract: an initialize timeout must force bounded process-tree cleanup, report `InitializeTimedOut`, and report `ForcedTermination` — without cancellation.
+
+Explicitly forbidden, and named because each would make the symptom disappear without touching the cause: fixed sleeps, test-level retry, `#[ignore]`, `--test-threads=1` as a fix rather than a diagnostic, and simply enlarging the two-second budget until the failures stop.
+
+## Impact
+
+* Affected specs: none expected — this is a test-harness defect, not a behaviour change. If investigation shows the *production* cleanup is genuinely unbounded under load, that becomes a spec-affecting change and this proposal is amended rather than quietly widened.
+* Affected code: `src-tauri/src/contexts/code_intelligence/infrastructure/server_test_tests.rs`, and `server_test.rs` only if the evidence turns out to implicate it.
+* Not blocked by, and does not block, `fix-portable-pty-bounded-termination` or `fix-private-relay-windows-acl-contract`. It is recorded separately precisely so none of the three borrows another's evidence.

--- a/openspec/changes/fix-code-intelligence-bounded-cleanup-flake/tasks.md
+++ b/openspec/changes/fix-code-intelligence-bounded-cleanup-flake/tasks.md
@@ -1,0 +1,56 @@
+# Tasks
+
+## 1. Establish what is being asserted
+
+- [ ] 1.1 Read `initialize_timeout_forces_bounded_process_tree_cleanup_without_cancellation` and separate its two candidate claims: that cleanup is *bounded* (a property, and the contract), versus that cleanup completes within two seconds of wall clock on this machine (a measurement, and not one). Nothing is edited before this is written down.
+- [ ] 1.2 Identify every wall-clock number the test depends on, including the `Duration::from_secs(2)` initialize timeout and any implicit patience in the harness around it.
+- [ ] 1.3 Decide which of those is the behaviour under test and which is the harness waiting. Conflating them is what makes a slow machine look like a broken one.
+
+## 2. Reproduce on demand
+
+- [ ] 2.1 Reproduce the failure under induced load rather than by waiting for a busy run. A defect that can only be observed by accident cannot be shown to have been fixed.
+- [ ] 2.2 Record the reproduction recipe in the change, so a reviewer can see it fail before seeing it pass.
+- [ ] 2.3 Confirm the same recipe leaves the rest of the suite unaffected — if induced load breaks twenty tests, the recipe is measuring the machine, not this test.
+
+## 3. Repair
+
+- [ ] 3.1 Keep the contract assertions exactly as they are: an initialize timeout forces bounded process-tree cleanup, reports `InitializeTimedOut`, then reports `ForcedTermination`, without cancellation.
+- [ ] 3.2 Make the test's own patience independent of the timeout it is verifying.
+- [ ] 3.3 If the evidence implicates production cleanup rather than the harness, stop and amend the proposal: that is a behaviour change with a spec impact, not a test fix, and it must not arrive disguised as one.
+
+## 4. Verification
+
+- [ ] 4.1 The reproduction recipe no longer fails, run repeatedly.
+- [ ] 4.2 `cargo test --workspace` under the same induced load.
+- [ ] 4.3 `cargo test --workspace`: Windows, Linux, macOS.
+- [ ] 4.4 `clippy`, `fmt`, `openspec validate --strict`.
+
+## Forbidden
+
+- [ ] X.1 No fixed sleep.
+- [ ] X.2 No test-level retry.
+- [ ] X.3 No `#[ignore]` and no skip.
+- [ ] X.4 No `--test-threads=1` as a fix. It is a legitimate diagnostic and an illegitimate repair: it hides the interaction rather than removing it.
+- [ ] X.5 No enlarging the two-second budget until the failures stop. That converts an unproven bound into a longer unproven bound.
+- [ ] X.6 No changes to `fix-portable-pty-bounded-termination` or `fix-private-relay-windows-acl-contract` from this change, and none of the three may borrow another's evidence.
+
+## Out of scope
+
+- [ ] Y.1 `local_runner_windows_spawn_cancel_benchmark_records_bounded_cleanup` failed once in the same loaded run and passed 3/3 isolated. One observation is not repeat evidence. It is recorded here as a second data point, and this change does not widen to cover it without one.
+
+## Evidence
+
+| when | result | context |
+| --- | --- | --- |
+| full workspace run, `npx openspec` concurrent | FAILED | first observation |
+| 7 isolated re-runs | 7 PASS | — |
+| full workspace run, 490s against a usual ~343s | FAILED | second observation |
+| 3 isolated re-runs | 3 PASS | — |
+
+Ten passes, two failures, both failures on loaded runs. All on Windows. The test spawns a real `lsp-hang` fixture process and asserts against a two-second initialize timeout.
+
+## Status
+
+- Implementation: **NOT STARTED**
+- Windows / Linux / macOS: **NOT RUN**
+- Archive: **BLOCKED**

--- a/openspec/changes/fix-private-relay-windows-acl-contract/design.md
+++ b/openspec/changes/fix-private-relay-windows-acl-contract/design.md
@@ -1,0 +1,70 @@
+# Design
+
+## What the code does today
+
+Production sets the DACL from an SDDL literal and marks it protected:
+
+```rust
+fn apply_current_user_dacl(path: &Path, token: HANDLE) -> io::Result<()> {
+    let sid = current_user_sid(token)?;
+    apply_sddl(path, &format!("D:P(A;;FA;;;{sid})"))
+}
+```
+
+`apply_sddl` then calls `SetFileSecurityW` with `DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION`.
+
+The check renders the descriptor back to a string and compares:
+
+```rust
+Ok(actual? == expected?)
+```
+
+So the assertion is `"D:PAI(A;;FA;;;S-1-5-21-…)" == "D:P(A;;FA;;;S-1-5-21-…)"` if Windows happens to set `SE_DACL_AUTO_INHERITED` when it stores the descriptor, and `"D:P(A;;0x1f01ff;;;S-1-5-21-…)"` vs `"D:P(A;;FA;;;S-1-5-21-…)"` if the round trip expands the mask abbreviation. Both are string differences that say nothing about access.
+
+They are also only *candidate* explanations. Naming the likeliest cause and fixing that is how you end up fixing the wrong thing convincingly. Phase one exists to replace the candidates with a reading.
+
+## Why the assertion is the defect regardless of the outcome
+
+Even if the ACL turns out to be perfect and only the rendering differs, this test was not verifying the contract. It was verifying that one particular Windows build renders one particular descriptor as one particular string. It passed for the same reason a stopped clock is right — the environment happened to agree — and its failure carries no information, because `assert!(bool)` discards both operands.
+
+The contract in `mcp-client-management` is about *access*: only the current user may reach a directory that is about to hold secrets. That is a statement about owner, principals, masks, inheritance and protection. Checking it as a string is checking a shadow of it.
+
+## What phase one reports, and why each field is on the list
+
+| Field | Why it cannot be dropped |
+| --- | --- |
+| current user SID | The expected principal. Everything else is relative to it. |
+| owner SID | An owner can rewrite the DACL regardless of the DACL. If the owner is not the current user, "only the current user has access" is false no matter what the ACEs say. |
+| DACL present vs NULL | A NULL DACL grants everyone full control. An empty DACL denies everyone. Rendered casually they both look like "no entries"; they are opposites. |
+| protected | Unprotected means the parent's ACEs flow in later, so a directory that is private now may not be after the next inheritance recalculation. |
+| auto-inherited | Distinguishes "we set this" from "Windows recomputed this". |
+| ACE list, in order | Windows evaluates ACEs in order and stops at the first match. A deny after an allow does not deny. Order is the guarantee, not an artefact. |
+| allow/deny per ACE | Obvious, and cheap to state. |
+| explicit/inherited per ACE | An inherited allow is evidence that protection failed, even if the principal looks acceptable. |
+| SID per ACE | Names are locale-dependent, renameable, and ambiguous across domains. Two principals can display identically. |
+| access mask | The whole question, when the principal is right. |
+| inheritance flags | Decide what child objects get, which is the next directory's privacy. |
+| expected contract | So the failure states the delta rather than leaving the reader to derive it. |
+| raw SDDL | Kept as supplementary evidence. It is the one field that must not be the assertion. |
+
+## Decisions
+
+**Diagnosis is separated from judgement.** Phase one adds a reporting function and a failure message. It does not change `restrict_to_current_user`, and it does not weaken what is asserted — if the DACL is genuinely wrong, this change must still fail, and fail loudly, until phase two repairs it.
+
+**SIDs, never display names.** `LookupAccountSid` is a network call in a domain environment, it is locale-dependent, and it maps distinct SIDs onto identical strings. A diagnostic that says `BUILTIN\Users` when it means `S-1-5-32-545` is easier to read and worse to reason about.
+
+**ACE order is compared, not normalised.** Sorting before comparison would hide the exact defect — a deny placed after an allow — that canonical ordering exists to prevent.
+
+**Masks are reported raw and normalised.** `FILE_ALL_ACCESS`, `GENERIC_ALL`, and `0x1F01FF` can denote the same effective access, and can also denote genuinely different access depending on the mapping. Reporting both is what makes the difference between "equivalent" and "looks similar" checkable rather than assumed.
+
+**Negative tests come with the fix, not after it.** A structural comparison that nothing has ever falsified is the same class of thing as the string comparison being replaced. Each negative case constructs a specific wrong DACL — extra Everyone ACE, missing current-user ACE, unprotected, wrong inheritance, wrong mask, non-canonical order — and requires the check to reject it.
+
+## Sequencing
+
+Phase one runs on Windows CI on its own, targeted:
+
+```
+cargo test --workspace private_relay_fs::windows_directory_and_file_dacls_allow_only_the_current_user -- --nocapture
+```
+
+The point of the targeted run is a fast, readable reading of the runner's actual state, without waiting for a full workspace suite to decide whether the security contract holds.

--- a/openspec/changes/fix-private-relay-windows-acl-contract/proposal.md
+++ b/openspec/changes/fix-private-relay-windows-acl-contract/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+`private_relay_fs` holds MCP relay configuration — environment values, headers, database location, execution context — and `mcp-client-management` requires it be created "with current-user-only access before writing secret-bearing bytes". On Windows that access control is a DACL, and the test that is supposed to prove it does this:
+
+```rust
+assert!(windows_acl::has_private_current_user_dacl(directory.path()).expect("directory ACL"));
+```
+
+`has_private_current_user_dacl` renders the descriptor back to SDDL and compares the resulting string, byte for byte, against `D:P(A;;FA;;;{sid})`.
+
+That fails on the GitHub Windows runner. CI run `32719136242`, job `97406616254`, checkout `1415083`: `platform::private_relay_fs::tests::windows_directory_and_file_dacls_allow_only_the_current_user` FAILED, everything else in a 3730-test workspace passed. It has never run in CI before — the Windows leg only gained `cargo test --workspace` in the change that surfaced this — and it passes on a local Windows 11 developer machine.
+
+**We do not know whether the ACL is wrong or the test is.** Those have opposite fixes: one is a security defect in code that guards secrets, the other is an over-strict assertion. And the current assertion cannot tell us, because `assert!(bool)` prints neither side. A security contract asserted by string equality, failing with no diagnostic, is not a contract that is being checked — it is one that happens to have been passing.
+
+## What Changes
+
+**Phase one adds diagnosis only.** No production ACL change, no relaxed assertion. The check is replaced with a structured report of what is actually on disk, for the directory and the file separately:
+
+* current user SID, and the owner SID
+* whether a DACL is present at all, or NULL — a NULL DACL grants everyone everything and is the one outcome that must never be mistaken for "no entries"
+* whether the DACL is protected, and whether it is auto-inherited
+* the ACE list **in order**, because ACE ordering is itself part of the guarantee
+* per ACE: allow or deny, explicit or inherited, SID, access mask, inheritance flags
+* the expected contract, stated in the same structural terms
+* raw SDDL, as supplementary evidence rather than as the assertion
+
+Friendly account names are not used — they are locale- and domain-dependent, and two different principals can display identically. SIDs are the identity. ACEs are not sorted before comparison; canonical order is a property under test, not noise to normalise away.
+
+**Phase two follows the evidence**, and the branch it takes is a finding rather than a preference:
+
+1. Owner, principal, mask, inheritance, protection and ACE order are all correct and only the SDDL rendering differs → the test moves to structured semantic comparison, and production code is not touched.
+2. There is an extra principal, an inherited ACE, a wrong mask, an unprotected DACL, or the current user's access is missing → the production ACL is repaired. Widening the permitted set to make the test green is forbidden: that is granting the access the contract exists to deny.
+3. The mask difference is generic-versus-expanded rendering → both raw and normalised masks are reported, and equivalence is *proved* before the comparison is adjusted.
+
+**Negative tests, so a passing result means something.** Every one of these must fail the check: an extra ACE for Everyone, Users, or Authenticated Users; a missing ACE for the current user; an unprotected DACL; wrong inheritance flags; a wrong access mask; non-canonical ACE order.
+
+## Impact
+
+* Affected specs: `mcp-client-management`
+* Affected code: `src-tauri/src/platform/private_relay_fs_windows.rs`, `src-tauri/src/platform/private_relay_fs_tests.rs`
+* Blocks: PR #217 (`fix-portable-pty-bounded-termination`) cannot qualify on Windows until this lands on `main`. That PR is frozen and does not touch `private_relay_fs`; it re-qualifies on all three platforms on a new merge SHA afterwards.

--- a/openspec/changes/fix-private-relay-windows-acl-contract/specs/mcp-client-management/spec.md
+++ b/openspec/changes/fix-private-relay-windows-acl-contract/specs/mcp-client-management/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Protected transient MCP relay configuration
+The desktop runtime MUST store invocation-scoped relay configuration in a private, uniquely named VaneHub-owned directory and MUST clean every owned artifact without changing the existing plaintext SQLite or export contract. On Windows, "private" MUST be defined and verified structurally — owner, principals, access masks, inheritance and DACL protection — rather than by the textual rendering of a security descriptor.
+
+#### Scenario: Create relay artifacts
+- **WHEN** the runtime prepares relay files containing MCP environment values, headers, database location, or execution context
+- **THEN** it MUST create a unique per-invocation directory with current-user-only access before writing secret-bearing bytes
+- **AND** it MUST use exclusive file creation with unpredictable names
+
+#### Scenario: Windows relay artifacts grant only the current user
+- **WHEN** the runtime creates a relay directory or file on Windows
+- **THEN** the object's DACL MUST be present rather than NULL, because a NULL DACL grants full control to everyone
+- **AND** it MUST be protected, so that later inheritance from the parent cannot widen it
+- **AND** it MUST contain exactly one access-allowed entry, for the current user's SID, granting full access, with no inherited entries and no additional principal
+- **AND** the owner MUST be the current user, because an owner may rewrite the DACL regardless of its contents
+
+#### Scenario: The privacy check reports what it found
+- **WHEN** the Windows relay access check fails
+- **THEN** it MUST report the current user SID, the owner SID, whether the DACL is present or NULL, whether it is protected and whether it is auto-inherited, and the ordered ACE list
+- **AND** each entry MUST report allow or deny, explicit or inherited, its SID, its access mask, and its inheritance flags
+- **AND** it MUST report the expected contract in the same terms, so the failure states a difference rather than a boolean
+- **AND** raw SDDL MAY be included as supplementary evidence but MUST NOT be the assertion
+
+#### Scenario: The privacy check rejects a widened DACL
+- **WHEN** a relay object's DACL carries an entry for Everyone, Users, or Authenticated Users, omits the current user, is unprotected, carries inherited entries, grants a mask other than full access, or orders its entries non-canonically
+- **THEN** the check MUST fail
+- **AND** principals MUST be compared by SID rather than by display name, which is locale-dependent and ambiguous across domains
+
+#### Scenario: Relay preparation partially fails
+- **WHEN** one server or provider configuration fails after earlier relay artifacts were created
+- **THEN** the runtime MUST remove every artifact already owned by that preparation before returning the failure
+
+#### Scenario: Relay invocation terminates
+- **WHEN** an Agent invocation completes, fails, is cancelled, or times out
+- **THEN** the owning relay guard MUST idempotently remove its provider and per-server configuration artifacts after verifying their canonical paths remain inside the dedicated relay root
+
+#### Scenario: Relay helper consumes its configuration
+- **WHEN** a relay helper successfully opens its configuration file
+- **THEN** it SHALL unlink that file before connecting to the upstream MCP server
+
+#### Scenario: Recover stale relay artifacts
+- **WHEN** desktop startup finds a versioned VaneHub-owned relay invocation directory older than 24 hours
+- **THEN** the runtime SHALL remove it only after canonical-root verification and SHALL log metadata-only cleanup counts
+- **AND** it MUST NOT delete unrelated system temporary files

--- a/openspec/changes/fix-private-relay-windows-acl-contract/tasks.md
+++ b/openspec/changes/fix-private-relay-windows-acl-contract/tasks.md
@@ -1,0 +1,89 @@
+# Tasks
+
+## 1. Phase one — diagnosis only
+
+No production ACL change and no relaxed assertion in this phase. If the DACL is genuinely wrong, this change must still fail, and fail loudly, until phase two repairs it.
+
+- [x] 1.1 Replace `assert!(bool)` with a structured failure report, produced separately for the directory and the file.
+- [x] 1.2 Report the current user SID and the owner SID. An owner can rewrite the DACL regardless of the DACL, so "only the current user has access" is false if the owner is someone else, whatever the entries say.
+- [x] 1.3 Report whether the DACL is present or NULL. A NULL DACL grants everyone full control and an empty one denies everyone; rendered casually both read as "no entries".
+- [x] 1.4 Report protected and auto-inherited separately.
+- [x] 1.5 Report the ACE list **in order**, without sorting. Windows stops at the first match, so a deny after an allow does not deny — order is the guarantee, not noise.
+- [x] 1.6 Per ACE: allow/deny, explicit/inherited, SID, access mask, inheritance flags.
+- [x] 1.7 Report the expected contract in the same structural terms, so the failure states a difference rather than a boolean.
+- [x] 1.8 Include raw SDDL as supplementary evidence only. It must not be the assertion.
+- [x] 1.9 Compare by SID, never by friendly account name: names are locale-dependent, renameable, and can render identically for distinct principals.
+- [ ] 1.10 Run it targeted on Windows CI.
+
+  **The filter in the original instruction matches nothing.** The test's real path carries a `tests::` segment, so `private_relay_fs::windows_directory_and_file_dacls_allow_only_the_current_user` selects zero tests -- and libtest exits 0 on zero matches, so it reads as a pass. Verified locally: `0 passed; 0 failed; 3733 filtered out`, exit 0. The command that actually selects it:
+
+  ```
+  cargo test --workspace private_relay_fs::tests::windows_directory_and_file_dacls_allow_only_the_current_user -- --nocapture
+  ```
+
+- [x] 1.11 Local Windows baseline recorded, so the runner's reading has something to be compared against. Developer machine, Windows 11, user-profile temp directory; directory and file identical:
+
+  ```
+  current user SID : S-1-5-21-2866764460-1384598244-3585758151-1001
+  owner SID        : S-1-5-21-2866764460-1384598244-3585758151-1001
+  DACL             : present
+  protected        : true   auto-inherited : false
+  entries (1, in stored order):
+    #0 allow explicit sid=S-1-5-21-...-1001 mask=0x001f01ff (FILE_ALL_ACCESS) inheritance_flags=0x00
+  differences: <none>
+  raw SDDL (diagnostic only): D:P(A;;FA;;;S-1-5-21-...-1001)
+  ```
+
+  The raw SDDL here is byte-identical to what the old check expected, which is why it passed locally and says nothing about why it fails on the runner.
+
+## 2. Phase two — follow the reading
+
+Exactly one of these applies, and which one is a finding rather than a preference.
+
+- [ ] 2.1 **Rendering only.** Owner, principal, mask, inheritance, protection and ACE order all correct, SDDL text differs → move the test to structured semantic comparison. Do not touch production code.
+- [ ] 2.2 **Real defect.** Extra principal, inherited ACE, wrong mask, unprotected DACL, or missing current-user access → repair the production ACL. Widening the permitted set to make the test green is forbidden: that grants exactly the access the contract exists to deny.
+- [ ] 2.3 **Mask rendering.** Generic versus expanded representation → report raw and normalised masks, and *prove* equivalence before adjusting the comparison.
+
+## 3. Negative tests
+
+A structural check that nothing has ever falsified is the same class of thing as the string comparison it replaces. Each case builds a specific wrong DACL and requires rejection.
+
+- [x] 3.1 Extra ACE for Everyone (`S-1-1-0`).
+- [x] 3.2 Extra ACE for Users (`S-1-5-32-545`).
+- [x] 3.3 Extra ACE for Authenticated Users (`S-1-5-11`).
+- [x] 3.4 Missing ACE for the current user.
+- [x] 3.5 DACL not protected.
+- [x] 3.6 Wrong inheritance flags.
+- [x] 3.7 Wrong access mask.
+- [x] 3.8 Non-canonical ACE order.
+
+## 4. Verification
+
+- [ ] 4.1 Targeted Windows CI run, `--nocapture`, reading recorded verbatim.
+- [ ] 4.2 `cargo test --workspace`: Windows.
+- [ ] 4.3 `cargo test --workspace`: Linux.
+- [ ] 4.4 `cargo test --workspace`: macOS.
+- [ ] 4.5 `clippy`, `fmt`, `architecture:check`, `native:panic:check`, `openspec validate --strict`.
+
+## Forbidden
+
+- [x] X.1 No widening of the permitted access set to turn the test green.
+- [x] X.2 No assertion on raw SDDL equality.
+- [x] X.3 No ACE sorting before comparison.
+- [x] X.4 No friendly account names in the comparison.
+- [x] X.5 No `#[ignore]`, no skip, no retry-until-green.
+- [x] X.6 No change to `fix-portable-pty-bounded-termination` (PR #217) from this branch, and no change to `private_relay_fs` from that one.
+
+## Out of scope
+
+- [x] Y.1 `code_intelligence::initialize_timeout_forces_bounded_process_tree_cleanup` has now failed twice under load (10 pass / 2 fail), which is repeat evidence rather than a one-off. It belongs to `fix-code-intelligence-bounded-cleanup-flake` and is not folded in here.
+
+## Status
+
+- Phase one: **IMPLEMENTED**, awaiting the Windows CI reading
+- Local Windows: focused suite 12/12 (1 contract + 2 negative suites + 9 pre-existing); clippy, fmt, architecture 44/44, native-panic and openspec strict all clean
+- Windows / Linux / macOS: **NOT RUN**
+- Archive: **BLOCKED**
+- `fix-portable-pty-bounded-termination` (PR #217): **FROZEN**, blocked on this change landing on `main`
+- `fix-sqlite-deferred-write-upgrade-contention`: **BLOCKED**
+- `add-unified-extension-platform` Task Group 4: **BLOCKED**

--- a/src-tauri/src/platform/private_relay_fs.rs
+++ b/src-tauri/src/platform/private_relay_fs.rs
@@ -309,6 +309,12 @@ fn restrict_to_current_user(path: &Path) -> io::Result<()> {
 #[path = "private_relay_fs_windows.rs"]
 mod windows_acl;
 
+/// Read-only structural reading of a Windows DACL, used by the privacy contract test. Kept out
+/// of `windows_acl` because that module applies access control and this one only observes it.
+#[cfg(all(windows, test))]
+#[path = "private_relay_fs_windows_acl_report.rs"]
+mod windows_acl_report;
+
 #[cfg(test)]
 #[path = "private_relay_fs_tests.rs"]
 mod tests;

--- a/src-tauri/src/platform/private_relay_fs_tests.rs
+++ b/src-tauri/src/platform/private_relay_fs_tests.rs
@@ -164,8 +164,105 @@ fn windows_directory_and_file_dacls_allow_only_the_current_user() {
     let file_path = directory.path().join("server.json");
     drop(directory.create_file("server.json").expect("file"));
 
-    assert!(windows_acl::has_private_current_user_dacl(directory.path()).expect("directory ACL"));
-    assert!(windows_acl::has_private_current_user_dacl(&file_path).expect("file ACL"));
+    let user = windows_acl_report::current_process_user_sid().expect("current user SID");
+    let readings = [
+        ("directory", directory.path().to_path_buf()),
+        ("file", file_path),
+    ];
+
+    // Read both before asserting either, so one run reports the whole picture instead of
+    // stopping at whichever object happens to be examined first.
+    let mut failures = String::new();
+    for (label, path) in &readings {
+        let reading =
+            windows_acl_report::read_dacl(path, user.clone()).expect("read DACL for reading");
+        // Printed on success too. A security contract that only speaks when it breaks gives
+        // nobody a baseline to compare the break against.
+        eprintln!("{}", reading.describe(label, path));
+        if !reading.satisfies_private_current_user_contract() {
+            failures.push_str(&reading.describe(label, path));
+        }
+    }
+    assert!(failures.is_empty(), "{failures}");
+}
+
+/// Applies a deliberately wrong DACL to a real directory and returns what the check makes of it.
+///
+/// Written against the filesystem rather than by hand-building a `DaclReading`, because half of
+/// what is under test is whether the *reader* can see the defect at all. A check that judges a
+/// struct correctly but cannot observe an extra ACE on disk would still pass every negative case
+/// and still miss a real one.
+#[cfg(windows)]
+fn reading_after_applying(sddl: &str) -> Vec<String> {
+    let root = crate::test_support::TempDirectory::new("private-relay-negative-acl");
+    let target = root.path().join("object");
+    std::fs::create_dir_all(&target).expect("negative fixture directory");
+    let user = windows_acl_report::current_process_user_sid().expect("current user SID");
+    windows_acl::apply_sddl_for_tests(&target, &sddl.replace("{user}", &user))
+        .expect("apply negative DACL");
+    let reading = windows_acl_report::read_dacl(&target, user).expect("read negative DACL");
+    reading.violations()
+}
+
+#[cfg(windows)]
+#[test]
+fn the_windows_privacy_check_rejects_every_way_the_dacl_can_be_wrong() {
+    // Each case is a DACL that grants more, or differently, than the contract allows. If any of
+    // them produced no violation, the check would be decoration: a structural comparison nothing
+    // has ever falsified is worth exactly as much as the string comparison it replaced.
+    let cases: [(&str, &str); 8] = [
+        (
+            "extra ACE for Everyone",
+            "D:P(A;;FA;;;{user})(A;;FA;;;S-1-1-0)",
+        ),
+        (
+            "extra ACE for Users",
+            "D:P(A;;FA;;;{user})(A;;FA;;;S-1-5-32-545)",
+        ),
+        (
+            "extra ACE for Authenticated Users",
+            "D:P(A;;FA;;;{user})(A;;FA;;;S-1-5-11)",
+        ),
+        (
+            "missing ACE for the current user",
+            "D:P(A;;FA;;;S-1-5-32-544)",
+        ),
+        ("DACL not protected", "D:(A;;FA;;;{user})"),
+        ("inheritance flags set", "D:P(A;OICI;FA;;;{user})"),
+        ("wrong access mask", "D:P(A;;FR;;;{user})"),
+        (
+            // A deny placed after an allow does not deny: Windows stops at the first match. The
+            // ordering is the guarantee, which is why the reader never sorts.
+            "non-canonical ACE order",
+            "D:P(A;;FA;;;{user})(D;;FA;;;S-1-1-0)",
+        ),
+    ];
+
+    for (label, sddl) in cases {
+        let violations = reading_after_applying(sddl);
+        assert!(
+            !violations.is_empty(),
+            "the check accepted a DACL it must reject: {label} ({sddl})"
+        );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn the_windows_privacy_check_names_the_specific_defect_it_found() {
+    // Rejecting for the wrong reason is only accidentally correct, and would keep passing if the
+    // reader stopped observing the field the case is actually about.
+    let everyone = reading_after_applying("D:P(A;;FA;;;{user})(A;;FA;;;S-1-1-0)").join(" ");
+    assert!(everyone.contains("S-1-1-0"), "{everyone}");
+
+    let unprotected = reading_after_applying("D:(A;;FA;;;{user})").join(" ");
+    assert!(unprotected.contains("not protected"), "{unprotected}");
+
+    let inheritance = reading_after_applying("D:P(A;OICI;FA;;;{user})").join(" ");
+    assert!(inheritance.contains("inheritance flags"), "{inheritance}");
+
+    let mask = reading_after_applying("D:P(A;;FR;;;{user})").join(" ");
+    assert!(mask.contains("expected 0x001f01ff"), "{mask}");
 }
 
 #[cfg(unix)]

--- a/src-tauri/src/platform/private_relay_fs_tests.rs
+++ b/src-tauri/src/platform/private_relay_fs_tests.rs
@@ -192,16 +192,67 @@ fn windows_directory_and_file_dacls_allow_only_the_current_user() {
 /// what is under test is whether the *reader* can see the defect at all. A check that judges a
 /// struct correctly but cannot observe an extra ACE on disk would still pass every negative case
 /// and still miss a real one.
+/// Restores a deletable DACL when the fixture goes out of scope, including on a panic.
+///
+/// Several negative cases deliberately deny the current user -- `D:P(A;;FA;;;S-1-5-32-544)`
+/// hands the object to Administrators alone, and `D:P(A;;FR;;;{user})` grants read only. Left
+/// that way, the object cannot be removed by the account that made it: `TempDirectory`'s cleanup
+/// fails quietly and the runner keeps an undeletable directory for every case, every run. A test
+/// that proves the checker rejects a bad ACL is not worth leaving a bad ACL behind.
+#[cfg(windows)]
+struct RestoreDeletableAcl {
+    path: std::path::PathBuf,
+    user: String,
+}
+
+#[cfg(windows)]
+impl Drop for RestoreDeletableAcl {
+    fn drop(&mut self) {
+        let _ =
+            windows_acl::apply_sddl_for_tests(&self.path, &format!("D:P(A;;FA;;;{})", self.user));
+    }
+}
+
 #[cfg(windows)]
 fn reading_after_applying(sddl: &str) -> Vec<String> {
+    // Its own temp root per case, so one fixture's DACL cannot affect the next one's cleanup.
     let root = crate::test_support::TempDirectory::new("private-relay-negative-acl");
     let target = root.path().join("object");
     std::fs::create_dir_all(&target).expect("negative fixture directory");
     let user = windows_acl_report::current_process_user_sid().expect("current user SID");
+
+    // Armed before the wrong DACL is applied, so the restore happens even if applying, reading,
+    // or an assertion further up panics.
+    let _restore = RestoreDeletableAcl {
+        path: target.clone(),
+        user: user.clone(),
+    };
     windows_acl::apply_sddl_for_tests(&target, &sddl.replace("{user}", &user))
         .expect("apply negative DACL");
     let reading = windows_acl_report::read_dacl(&target, user).expect("read negative DACL");
     reading.violations()
+}
+
+#[cfg(windows)]
+#[test]
+fn a_negative_fixture_leaves_nothing_undeletable_behind() {
+    // The guard above is only worth having if it works. This drives the harshest case -- an
+    // object handed to Administrators alone -- and then requires the directory to be removable
+    // by this account afterwards.
+    let root = crate::test_support::TempDirectory::new("private-relay-negative-cleanup");
+    let target = root.path().join("object");
+    std::fs::create_dir_all(&target).expect("fixture directory");
+    let user = windows_acl_report::current_process_user_sid().expect("current user SID");
+    {
+        let _restore = RestoreDeletableAcl {
+            path: target.clone(),
+            user: user.clone(),
+        };
+        windows_acl::apply_sddl_for_tests(&target, "D:P(A;;FA;;;S-1-5-32-544)")
+            .expect("apply administrators-only DACL");
+    }
+    std::fs::remove_dir_all(&target).expect("the restored DACL leaves the fixture removable");
+    assert!(!target.exists());
 }
 
 #[cfg(windows)]

--- a/src-tauri/src/platform/private_relay_fs_windows.rs
+++ b/src-tauri/src/platform/private_relay_fs_windows.rs
@@ -3,8 +3,6 @@ use std::os::windows::ffi::OsStrExt;
 use std::path::Path;
 use windows::core::{PCWSTR, PWSTR};
 use windows::Win32::Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL};
-#[cfg(test)]
-use windows::Win32::Security::Authorization::ConvertSecurityDescriptorToStringSecurityDescriptorW;
 use windows::Win32::Security::Authorization::{
     ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
 };
@@ -89,60 +87,12 @@ fn windows_error(error: windows::core::Error) -> io::Error {
     io::Error::other(error.to_string())
 }
 
+/// Applies an arbitrary DACL, for negative tests only.
+///
+/// Exposed so a test can build a *wrong* DACL -- an extra principal, an unprotected descriptor,
+/// a bad mask -- and require the contract check to reject it. A structural check that nothing
+/// has ever falsified is the same class of thing as the string comparison it replaced.
 #[cfg(test)]
-pub(super) fn has_private_current_user_dacl(path: &Path) -> io::Result<bool> {
-    use windows::Win32::Security::GetFileSecurityW;
-
-    let path_wide = path
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
-    let mut required = 0;
-    let _ = unsafe {
-        GetFileSecurityW(
-            PCWSTR(path_wide.as_ptr()),
-            DACL_SECURITY_INFORMATION.0,
-            None,
-            0,
-            &mut required,
-        )
-    };
-    if required == 0 {
-        return Err(io::Error::last_os_error());
-    }
-    let word = std::mem::size_of::<usize>();
-    let mut descriptor = vec![0usize; (required as usize).div_ceil(word)];
-    unsafe {
-        GetFileSecurityW(
-            PCWSTR(path_wide.as_ptr()),
-            DACL_SECURITY_INFORMATION.0,
-            Some(PSECURITY_DESCRIPTOR(descriptor.as_mut_ptr().cast())),
-            required,
-            &mut required,
-        )
-        .ok()
-    }
-    .map_err(windows_error)?;
-    let mut actual_sddl = PWSTR::null();
-    unsafe {
-        ConvertSecurityDescriptorToStringSecurityDescriptorW(
-            PSECURITY_DESCRIPTOR(descriptor.as_mut_ptr().cast()),
-            SDDL_REVISION_1,
-            DACL_SECURITY_INFORMATION,
-            &mut actual_sddl,
-            None,
-        )
-    }
-    .map_err(windows_error)?;
-    let actual = unsafe { actual_sddl.to_string() }
-        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()));
-    unsafe { LocalFree(Some(HLOCAL(actual_sddl.0.cast()))) };
-
-    let mut token = HANDLE::default();
-    unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) }
-        .map_err(windows_error)?;
-    let expected = current_user_sid(token).map(|sid| format!("D:P(A;;FA;;;{sid})"));
-    let _ = unsafe { CloseHandle(token) };
-    Ok(actual? == expected?)
+pub(super) fn apply_sddl_for_tests(path: &Path, sddl: &str) -> io::Result<()> {
+    apply_sddl(path, sddl)
 }

--- a/src-tauri/src/platform/private_relay_fs_windows_acl_report.rs
+++ b/src-tauri/src/platform/private_relay_fs_windows_acl_report.rs
@@ -1,0 +1,483 @@
+//! A structural reading of a Windows object's DACL, for the relay privacy contract.
+//!
+//! The contract in `mcp-client-management` is about *access*: only the current user may reach a
+//! directory that is about to hold secrets. That is a statement about an owner, principals,
+//! masks, inheritance and protection. The check it replaced compared the descriptor's SDDL
+//! rendering as a string, which is a shadow of the contract -- it passed because one Windows
+//! build happened to render one descriptor one way, and when it stopped passing it said only
+//! `false`.
+//!
+//! Everything here is read-only. Nothing in this module changes an ACL.
+
+use std::fmt::Write as _;
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+use windows::core::{PCWSTR, PWSTR};
+use windows::Win32::Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL};
+use windows::Win32::Security::Authorization::{
+    ConvertSecurityDescriptorToStringSecurityDescriptorW, ConvertSidToStringSidW, SDDL_REVISION_1,
+};
+use windows::Win32::Security::{
+    AclSizeInformation, GetAce, GetAclInformation, GetFileSecurityW, GetSecurityDescriptorControl,
+    GetSecurityDescriptorDacl, GetSecurityDescriptorOwner, ACCESS_ALLOWED_ACE, ACCESS_DENIED_ACE,
+    ACE_HEADER, ACL, ACL_SIZE_INFORMATION, DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION,
+    PSECURITY_DESCRIPTOR, PSID, SE_DACL_AUTO_INHERITED, SE_DACL_PRESENT, SE_DACL_PROTECTED,
+};
+
+/// `FILE_ALL_ACCESS` for a file or directory, which is what `FA` denotes in SDDL.
+pub(super) const FILE_ALL_ACCESS_MASK: u32 = 0x001F_01FF;
+
+const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
+const ACCESS_DENIED_ACE_TYPE: u8 = 1;
+const INHERITED_ACE_FLAG: u8 = 0x10;
+
+/// One entry, read in the order Windows stores it.
+///
+/// Order is preserved rather than normalised because Windows evaluates entries in sequence and
+/// stops at the first match: a deny placed after an allow does not deny. Sorting before
+/// comparison would hide exactly the defect canonical ordering exists to prevent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct AceReading {
+    pub(super) index: u32,
+    /// `None` for an ACE type this reader does not model. Reported rather than skipped: an
+    /// unmodelled entry is still an entry, and silently dropping it would let one through.
+    pub(super) allowed: Option<bool>,
+    pub(super) ace_type: u8,
+    pub(super) inherited: bool,
+    pub(super) inheritance_flags: u8,
+    pub(super) sid: String,
+    pub(super) mask: u32,
+}
+
+impl AceReading {
+    fn describe(&self) -> String {
+        let kind = match self.allowed {
+            Some(true) => "allow".to_string(),
+            Some(false) => "deny".to_string(),
+            None => format!("unmodelled(type={})", self.ace_type),
+        };
+        format!(
+            "#{} {} {} sid={} mask={:#010x} ({}) inheritance_flags={:#04x}",
+            self.index,
+            kind,
+            if self.inherited {
+                "inherited"
+            } else {
+                "explicit"
+            },
+            self.sid,
+            self.mask,
+            normalised_mask(self.mask),
+            self.inheritance_flags,
+        )
+    }
+}
+
+/// The whole structural reading of one object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DaclReading {
+    pub(super) current_user_sid: String,
+    pub(super) owner_sid: Option<String>,
+    /// `false` means a NULL DACL, which grants everyone full control. An *empty* DACL denies
+    /// everyone. The two render alike as "no entries" and are opposites, so they are separate
+    /// fields rather than one count.
+    pub(super) dacl_present: bool,
+    pub(super) protected: bool,
+    pub(super) auto_inherited: bool,
+    pub(super) aces: Vec<AceReading>,
+    pub(super) raw_sddl: Option<String>,
+}
+
+impl DaclReading {
+    /// Whether this reading satisfies the contract: present, protected, owned by the current
+    /// user, and exactly one explicit allow-all entry for the current user.
+    pub(super) fn satisfies_private_current_user_contract(&self) -> bool {
+        self.violations().is_empty()
+    }
+
+    /// Every way this reading departs from the contract, each as its own sentence. Reported as
+    /// a list rather than a first-failure so one run shows the whole picture.
+    pub(super) fn violations(&self) -> Vec<String> {
+        let mut violations = Vec::new();
+        if !self.dacl_present {
+            violations.push(
+                "DACL is NULL, which grants full control to everyone rather than to nobody"
+                    .to_string(),
+            );
+            // With no DACL there are no entries to describe; everything below would be noise.
+            return violations;
+        }
+        if !self.protected {
+            violations.push(
+                "DACL is not protected, so inheritance from the parent can widen it later"
+                    .to_string(),
+            );
+        }
+        match &self.owner_sid {
+            Some(owner) if owner == &self.current_user_sid => {}
+            Some(owner) => violations.push(format!(
+                "owner is {owner}, not the current user {}; an owner may rewrite the DACL \
+                 regardless of its contents",
+                self.current_user_sid
+            )),
+            None => violations.push("owner could not be read".to_string()),
+        }
+        if self.aces.len() != 1 {
+            violations.push(format!(
+                "expected exactly one access-allowed entry, found {}",
+                self.aces.len()
+            ));
+        }
+        for ace in &self.aces {
+            if ace.inherited {
+                violations.push(format!(
+                    "entry #{} is inherited; a protected DACL must carry none",
+                    ace.index
+                ));
+            }
+            if ace.allowed != Some(true) {
+                violations.push(format!(
+                    "entry #{} is not an access-allowed entry",
+                    ace.index
+                ));
+            }
+            if ace.sid != self.current_user_sid {
+                violations.push(format!(
+                    "entry #{} names {}, which is not the current user {}",
+                    ace.index, ace.sid, self.current_user_sid
+                ));
+            }
+            if ace.mask != FILE_ALL_ACCESS_MASK {
+                violations.push(format!(
+                    "entry #{} grants mask {:#010x} ({}), expected {:#010x} (FILE_ALL_ACCESS)",
+                    ace.index,
+                    ace.mask,
+                    normalised_mask(ace.mask),
+                    FILE_ALL_ACCESS_MASK
+                ));
+            }
+            if ace.inheritance_flags != 0 {
+                violations.push(format!(
+                    "entry #{} carries inheritance flags {:#04x}, expected none",
+                    ace.index, ace.inheritance_flags
+                ));
+            }
+        }
+        violations
+    }
+
+    /// States what was found, what was expected, and the difference -- so a reader does not have
+    /// to derive any of the three.
+    ///
+    /// Printed on success as well as failure, and the heading says which. A report that always
+    /// reads "not satisfied" would be misleading in the one case where a baseline is most
+    /// useful: comparing a machine where the contract holds against one where it does not.
+    pub(super) fn describe(&self, label: &str, path: &Path) -> String {
+        let violations = self.violations();
+        let mut out = String::new();
+        let _ = writeln!(
+            out,
+            "{label} DACL contract {} for {}",
+            if violations.is_empty() {
+                "SATISFIED"
+            } else {
+                "NOT SATISFIED"
+            },
+            path.display()
+        );
+        let _ = writeln!(out, "  current user SID : {}", self.current_user_sid);
+        let _ = writeln!(
+            out,
+            "  owner SID        : {}",
+            self.owner_sid.as_deref().unwrap_or("<unreadable>")
+        );
+        let _ = writeln!(
+            out,
+            "  DACL             : {}",
+            if self.dacl_present {
+                "present"
+            } else {
+                "NULL (grants everyone full control)"
+            }
+        );
+        let _ = writeln!(
+            out,
+            "  protected        : {}   auto-inherited : {}",
+            self.protected, self.auto_inherited
+        );
+        let _ = writeln!(out, "  entries ({}, in stored order):", self.aces.len());
+        if self.aces.is_empty() {
+            let _ = writeln!(out, "    <none>");
+        }
+        for ace in &self.aces {
+            let _ = writeln!(out, "    {}", ace.describe());
+        }
+        let _ = writeln!(out, "  expected contract:");
+        let _ = writeln!(
+            out,
+            "    DACL present, protected, owner = current user, exactly one explicit"
+        );
+        let _ = writeln!(
+            out,
+            "    access-allowed entry for {} with mask {:#010x} (FILE_ALL_ACCESS)",
+            self.current_user_sid, FILE_ALL_ACCESS_MASK
+        );
+        let _ = writeln!(out, "    and no inheritance flags");
+        let _ = writeln!(out, "  differences:");
+        if violations.is_empty() {
+            let _ = writeln!(out, "    <none>");
+        }
+        for violation in &violations {
+            let _ = writeln!(out, "    - {violation}");
+        }
+        // Supplementary only. This is the field that must never be the assertion.
+        let _ = writeln!(
+            out,
+            "  raw SDDL (diagnostic only): {}",
+            self.raw_sddl.as_deref().unwrap_or("<unreadable>")
+        );
+        out
+    }
+}
+
+/// Renders a mask as the named rights it contains, so `0x1f01ff` and `FA` can be compared as
+/// access rather than as text.
+pub(super) fn normalised_mask(mask: u32) -> String {
+    const NAMED: &[(u32, &str)] = &[
+        (0x1000_0000, "GENERIC_ALL"),
+        (0x2000_0000, "GENERIC_EXECUTE"),
+        (0x4000_0000, "GENERIC_WRITE"),
+        (0x8000_0000, "GENERIC_READ"),
+        (0x0010_0000, "SYNCHRONIZE"),
+        (0x0008_0000, "WRITE_OWNER"),
+        (0x0004_0000, "WRITE_DAC"),
+        (0x0002_0000, "READ_CONTROL"),
+        (0x0001_0000, "DELETE"),
+        (0x0000_0100, "FILE_WRITE_ATTRIBUTES"),
+        (0x0000_0080, "FILE_READ_ATTRIBUTES"),
+        (0x0000_0040, "FILE_DELETE_CHILD"),
+        (0x0000_0020, "FILE_EXECUTE"),
+        (0x0000_0010, "FILE_WRITE_EA"),
+        (0x0000_0008, "FILE_READ_EA"),
+        (0x0000_0004, "FILE_APPEND_DATA"),
+        (0x0000_0002, "FILE_WRITE_DATA"),
+        (0x0000_0001, "FILE_READ_DATA"),
+    ];
+    if mask == FILE_ALL_ACCESS_MASK {
+        return "FILE_ALL_ACCESS".to_string();
+    }
+    let mut parts = Vec::new();
+    let mut remaining = mask;
+    for (bit, name) in NAMED {
+        if mask & bit == *bit {
+            parts.push(*name);
+            remaining &= !bit;
+        }
+    }
+    if remaining != 0 {
+        parts.push("…");
+    }
+    if parts.is_empty() {
+        return "<none>".to_string();
+    }
+    parts.join("|")
+}
+
+fn windows_error(error: windows::core::Error) -> io::Error {
+    io::Error::other(error.to_string())
+}
+
+fn sid_to_string(sid: PSID) -> io::Result<String> {
+    let mut text = PWSTR::null();
+    unsafe { ConvertSidToStringSidW(sid, &mut text) }.map_err(windows_error)?;
+    let value = unsafe { text.to_string() }
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()));
+    unsafe { LocalFree(Some(HLOCAL(text.0.cast()))) };
+    value
+}
+
+/// Reads owner and DACL for one path.
+pub(super) fn read_dacl(path: &Path, current_user_sid: String) -> io::Result<DaclReading> {
+    let path_wide = path
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let information = DACL_SECURITY_INFORMATION.0 | OWNER_SECURITY_INFORMATION.0;
+    let mut required = 0;
+    let _ = unsafe {
+        GetFileSecurityW(
+            PCWSTR(path_wide.as_ptr()),
+            information,
+            None,
+            0,
+            &mut required,
+        )
+    };
+    if required == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let word = std::mem::size_of::<usize>();
+    let mut buffer = vec![0usize; (required as usize).div_ceil(word)];
+    let descriptor = PSECURITY_DESCRIPTOR(buffer.as_mut_ptr().cast());
+    unsafe {
+        GetFileSecurityW(
+            PCWSTR(path_wide.as_ptr()),
+            information,
+            Some(descriptor),
+            required,
+            &mut required,
+        )
+        .ok()
+    }
+    .map_err(windows_error)?;
+
+    let mut control_bits = 0u16;
+    let mut revision = 0u32;
+    unsafe { GetSecurityDescriptorControl(descriptor, &mut control_bits, &mut revision) }
+        .map_err(windows_error)?;
+    let protected = control_bits & SE_DACL_PROTECTED.0 != 0;
+    let auto_inherited = control_bits & SE_DACL_AUTO_INHERITED.0 != 0;
+    let control_says_present = control_bits & SE_DACL_PRESENT.0 != 0;
+
+    let mut owner_sid_ptr = PSID::default();
+    let mut owner_defaulted = windows::core::BOOL::default();
+    let owner_sid =
+        unsafe { GetSecurityDescriptorOwner(descriptor, &mut owner_sid_ptr, &mut owner_defaulted) }
+            .ok()
+            .and_then(|()| {
+                if owner_sid_ptr.0.is_null() {
+                    None
+                } else {
+                    sid_to_string(owner_sid_ptr).ok()
+                }
+            });
+
+    let mut dacl_ptr: *mut ACL = std::ptr::null_mut();
+    let mut dacl_present = windows::core::BOOL::default();
+    let mut dacl_defaulted = windows::core::BOOL::default();
+    unsafe {
+        GetSecurityDescriptorDacl(
+            descriptor,
+            &mut dacl_present,
+            &mut dacl_ptr,
+            &mut dacl_defaulted,
+        )
+    }
+    .map_err(windows_error)?;
+
+    // A present flag with a null pointer is the NULL DACL: everyone, full control.
+    let present = control_says_present && dacl_present.as_bool() && !dacl_ptr.is_null();
+    let mut aces = Vec::new();
+    if present {
+        let mut size = ACL_SIZE_INFORMATION::default();
+        unsafe {
+            GetAclInformation(
+                dacl_ptr,
+                std::ptr::addr_of_mut!(size).cast(),
+                u32::try_from(std::mem::size_of::<ACL_SIZE_INFORMATION>()).unwrap_or(0),
+                AclSizeInformation,
+            )
+        }
+        .map_err(windows_error)?;
+        for index in 0..size.AceCount {
+            let mut ace_ptr: *mut core::ffi::c_void = std::ptr::null_mut();
+            unsafe { GetAce(dacl_ptr, index, &mut ace_ptr) }.map_err(windows_error)?;
+            if ace_ptr.is_null() {
+                continue;
+            }
+            let header = unsafe { *ace_ptr.cast::<ACE_HEADER>() };
+            let allowed = match header.AceType {
+                ACCESS_ALLOWED_ACE_TYPE => Some(true),
+                ACCESS_DENIED_ACE_TYPE => Some(false),
+                _ => None,
+            };
+            // Allowed and denied ACEs share a layout: header, mask, then the SID inline.
+            let (mask, sid) = match allowed {
+                Some(true) => {
+                    let ace = unsafe { &*ace_ptr.cast::<ACCESS_ALLOWED_ACE>() };
+                    let sid_ptr = PSID(std::ptr::addr_of!(ace.SidStart) as *mut core::ffi::c_void);
+                    (ace.Mask, sid_to_string(sid_ptr)?)
+                }
+                Some(false) => {
+                    let ace = unsafe { &*ace_ptr.cast::<ACCESS_DENIED_ACE>() };
+                    let sid_ptr = PSID(std::ptr::addr_of!(ace.SidStart) as *mut core::ffi::c_void);
+                    (ace.Mask, sid_to_string(sid_ptr)?)
+                }
+                None => (0, "<unmodelled ACE type>".to_string()),
+            };
+            aces.push(AceReading {
+                index,
+                allowed,
+                ace_type: header.AceType,
+                inherited: header.AceFlags & INHERITED_ACE_FLAG != 0,
+                inheritance_flags: header.AceFlags & !INHERITED_ACE_FLAG,
+                sid,
+                mask,
+            });
+        }
+    }
+
+    let mut sddl_ptr = PWSTR::null();
+    let raw_sddl = unsafe {
+        ConvertSecurityDescriptorToStringSecurityDescriptorW(
+            descriptor,
+            SDDL_REVISION_1,
+            DACL_SECURITY_INFORMATION,
+            &mut sddl_ptr,
+            None,
+        )
+    }
+    .ok()
+    .and_then(|()| {
+        let text = unsafe { sddl_ptr.to_string() }.ok();
+        unsafe { LocalFree(Some(HLOCAL(sddl_ptr.0.cast()))) };
+        text
+    });
+
+    Ok(DaclReading {
+        current_user_sid,
+        owner_sid,
+        dacl_present: present,
+        protected,
+        auto_inherited,
+        aces,
+        raw_sddl,
+    })
+}
+
+/// The current process token's user SID.
+pub(super) fn current_process_user_sid() -> io::Result<String> {
+    use windows::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER};
+    use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    let mut token = HANDLE::default();
+    unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) }
+        .map_err(windows_error)?;
+    let mut required = 0;
+    let _ = unsafe { GetTokenInformation(token, TokenUser, None, 0, &mut required) };
+    if required == 0 {
+        let error = io::Error::last_os_error();
+        let _ = unsafe { CloseHandle(token) };
+        return Err(error);
+    }
+    let word = std::mem::size_of::<usize>();
+    let mut buffer = vec![0usize; (required as usize).div_ceil(word)];
+    let read = unsafe {
+        GetTokenInformation(
+            token,
+            TokenUser,
+            Some(buffer.as_mut_ptr().cast()),
+            required,
+            &mut required,
+        )
+    }
+    .map_err(windows_error);
+    let sid = read.and_then(|()| {
+        let token_user = unsafe { &*buffer.as_ptr().cast::<TOKEN_USER>() };
+        sid_to_string(token_user.User.Sid)
+    });
+    let _ = unsafe { CloseHandle(token) };
+    sid
+}

--- a/src-tauri/src/platform/private_relay_fs_windows_acl_report.rs
+++ b/src-tauri/src/platform/private_relay_fs_windows_acl_report.rs
@@ -20,7 +20,7 @@ use windows::Win32::Security::Authorization::{
 };
 use windows::Win32::Security::{
     AclSizeInformation, GetAce, GetAclInformation, GetFileSecurityW, GetSecurityDescriptorControl,
-    GetSecurityDescriptorDacl, GetSecurityDescriptorOwner, ACCESS_ALLOWED_ACE, ACCESS_DENIED_ACE,
+    GetSecurityDescriptorDacl, GetSecurityDescriptorOwner, IsValidSid, ACCESS_ALLOWED_ACE,
     ACE_HEADER, ACL, ACL_SIZE_INFORMATION, DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION,
     PSECURITY_DESCRIPTOR, PSID, SE_DACL_AUTO_INHERITED, SE_DACL_PRESENT, SE_DACL_PROTECTED,
 };
@@ -387,23 +387,42 @@ pub(super) fn read_dacl(path: &Path, current_user_sid: String) -> io::Result<Dac
             if ace_ptr.is_null() {
                 continue;
             }
-            let header = unsafe { *ace_ptr.cast::<ACE_HEADER>() };
+            // `GetAce` hands back a pointer into the ACL's own bytes, and how far it is safe to
+            // read from there is described by the ACL itself. Taking that on trust is precisely
+            // the wrong move in a reader whose job is to notice a DACL that is not what it
+            // should be: a malformed or truncated ACE would be read past its end. So the header
+            // is read unaligned first, and its own `AceSize` must account for the larger type
+            // before anything reads that far in.
+            let header = unsafe { std::ptr::read_unaligned(ace_ptr.cast::<ACE_HEADER>()) };
+            let ace_size = usize::from(header.AceSize);
             let allowed = match header.AceType {
                 ACCESS_ALLOWED_ACE_TYPE => Some(true),
                 ACCESS_DENIED_ACE_TYPE => Some(false),
                 _ => None,
             };
-            // Allowed and denied ACEs share a layout: header, mask, then the SID inline.
+            // Allowed and denied ACEs share a layout: header, mask, then the SID inline. Both
+            // are read through the allowed shape because the two are identical up to `SidStart`.
+            let body_fits = ace_size >= std::mem::size_of::<ACCESS_ALLOWED_ACE>();
             let (mask, sid) = match allowed {
-                Some(true) => {
-                    let ace = unsafe { &*ace_ptr.cast::<ACCESS_ALLOWED_ACE>() };
-                    let sid_ptr = PSID(std::ptr::addr_of!(ace.SidStart) as *mut core::ffi::c_void);
-                    (ace.Mask, sid_to_string(sid_ptr)?)
-                }
-                Some(false) => {
-                    let ace = unsafe { &*ace_ptr.cast::<ACCESS_DENIED_ACE>() };
-                    let sid_ptr = PSID(std::ptr::addr_of!(ace.SidStart) as *mut core::ffi::c_void);
-                    (ace.Mask, sid_to_string(sid_ptr)?)
+                Some(_) if !body_fits => (
+                    0,
+                    format!("<ACE truncated: AceSize {ace_size} too small for its type>"),
+                ),
+                Some(_) => {
+                    let ace =
+                        unsafe { std::ptr::read_unaligned(ace_ptr.cast::<ACCESS_ALLOWED_ACE>()) };
+                    // The SID lives in the ACL's bytes, not in the copy just made, so it is read
+                    // through the original pointer -- and validated before conversion, since
+                    // `ConvertSidToStringSidW` on a malformed SID is the same unchecked read
+                    // one layer down.
+                    let sid_ptr = PSID(unsafe {
+                        ace_ptr.byte_add(std::mem::offset_of!(ACCESS_ALLOWED_ACE, SidStart))
+                    });
+                    if unsafe { IsValidSid(sid_ptr) }.as_bool() {
+                        (ace.Mask, sid_to_string(sid_ptr)?)
+                    } else {
+                        (ace.Mask, "<invalid SID>".to_string())
+                    }
                 }
                 None => (0, "<unmodelled ACE type>".to_string()),
             };


### PR DESCRIPTION
**Phase one: diagnosis only.** No production ACL change, no relaxed assertion.

## Why

The relay directory holds MCP environment values, headers, database location and execution context. `mcp-client-management` requires it be created "with current-user-only access before writing secret-bearing bytes". The check that was supposed to prove that did this:

```rust
assert!(windows_acl::has_private_current_user_dacl(directory.path()).expect("directory ACL"));
```

and `has_private_current_user_dacl` rendered the descriptor back to SDDL and compared the resulting string, byte for byte, against `D:P(A;;FA;;;{sid})`.

It fails on the GitHub Windows runner — run [32719136242](https://github.com/cdavid817/vanehub-ai/actions/runs/32719136242), job `97406616254`, checkout `1415083`, one failure in a 3730-test workspace. It had never run in CI before (the Windows leg only gained `cargo test --workspace` in PR #217), and it passes on a local Windows 11 machine.

**We still do not know whether the ACL is wrong or the test is**, and those have opposite fixes: one is a security defect in code that guards secrets, the other is an over-strict assertion. The old check could not tell us, because `assert!(bool)` discards both operands. A security contract asserted by string equality, failing with no diagnostic, was not being checked — it was passing.

## What this adds

A structural reading, per object: current user SID, owner SID, DACL present vs NULL, protected, auto-inherited, and the ACE list **in stored order** with each entry's allow/deny, explicit/inherited, SID, mask and inheritance flags — then the expected contract in the same terms, then the difference. Raw SDDL is supplementary evidence and deliberately not the assertion.

Four of those exist because dropping them hides a hole:

- **owner** — an owner may rewrite the DACL regardless of the DACL
- **present vs NULL** — a NULL DACL grants everyone full control, an empty one denies everyone, and both read casually as "no entries"
- **order** — Windows stops at the first matching entry, so a deny after an allow does not deny
- **SIDs, not names** — names are locale-dependent, renameable, and can render identically for distinct principals

The new check is strictly **stronger** than the string comparison, not weaker: it also verifies the owner, which the old one never looked at. The old function had no callers left and is deleted rather than kept as a second way to do this.

## Negative tests

Eight cases, written against the filesystem rather than by hand-building a struct — half of what is under test is whether the reader can see a defect on disk at all. Extra Everyone / Users / Authenticated Users entries, missing current-user entry, unprotected DACL, inheritance flags, wrong mask, and a deny ordered after an allow. Four additionally assert *which* defect was named, since rejecting for the wrong reason is only accidentally correct.

## A correction

The targeted command specified for this work selects **zero tests**: the real path carries a `tests::` segment, and libtest exits 0 when a filter matches nothing, so it reads as a pass. Measured locally: `0 passed; 0 failed; 3733 filtered out`, exit 0. The working filter is `private_relay_fs::tests::windows_directory_...`, and the new CI step fails explicitly if its filter ever selects nothing.

## Local Windows baseline

Recorded so the runner's reading has something to be compared against — owner and sole allow entry both the current user, `FILE_ALL_ACCESS`, protected, not auto-inherited, no inheritance flags, no differences. Its raw SDDL is byte-identical to what the old check wanted, which is why it passed here and says nothing about the runner.

## Next

The Windows CI reading decides phase two, and which branch it takes is a finding rather than a preference: rendering-only → fix the test; extra principal / inherited ACE / wrong mask / unprotected / missing access → fix the production ACL. Widening the permitted set to make the test green is forbidden — that grants exactly the access the contract exists to deny.

PR #217 is frozen and untouched; it does not modify `private_relay_fs`, and it re-qualifies on all three platforms after this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
