### PR TITLE
Multi-agent verification campaign: provider output resilience, live transcript rendering, and opt-in real-CLI desktop layers

### DIFF
--- a/openspec/changes/fix-chat-transcript-backend-message-updates/proposal.md
+++ b/openspec/changes/fix-chat-transcript-backend-message-updates/proposal.md
@@ -1,0 +1,27 @@
+# Render backend-originated messages in the open chat transcript
+
+## Why
+
+With a multi-agent session open on screen, messages created through the backend — a programmatic `send_message` over IPC, and the seat replies it triggered — never appeared in the chat transcript: the message list stayed on the "开始新的对话" empty state for the entire round, while the turn status bar, seat presence states, and the session status badge all updated live beside it. The transcript only reflects flows the composer itself initiated, so any runtime-originated conversation (IM connector, scheduled task, desktop automation, another window) is invisible until a manual reload. Observed and screenshot-documented during desktop multi-agent verification on 2026-08-24.
+
+## What Changes
+
+- Make the open session's message list reflect messages created through the runtime regardless of origin: user messages injected via the service boundary and assistant turns dispatched by the seat coordinator appear, stream, and settle in the transcript without a reload.
+- Keep the existing composer-originated behavior and message identity/speaker rendering unchanged; this closes the gap for the non-composer origins only.
+- Add regression coverage at two levels: a component test for the transcript's reaction to a runtime-created message event, and a desktop e2e assertion that a programmatically sent message becomes visible in the open transcript.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `chat-experience`: Require the conversation view to display and stream messages that originate outside the composer while the session is open.
+
+## Impact
+
+- Frontend only: the chat message list's data flow (event subscription / query invalidation) in `src/` — no Tauri command or schema change expected; the backend already persists these messages and emits their events.
+- Both service adapters must stay behaviorally aligned: the Web/mock adapter's transcript must follow the same origin-agnostic contract.
+- Desktop e2e: extends existing multi-agent UI coverage; the `ui-multi-agent` layer already proves composer-originated rendering, so the new assertion targets the runtime-originated path.

--- a/openspec/changes/fix-chat-transcript-backend-message-updates/specs/chat-experience/spec.md
+++ b/openspec/changes/fix-chat-transcript-backend-message-updates/specs/chat-experience/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Transcript reflects messages regardless of origin
+While a session is open, its conversation view SHALL display messages created through the runtime regardless of how they originated — the composer, a programmatic send over the service boundary, an instant-messaging connector, a scheduled task, or a seat turn dispatched by the multi-agent coordinator — without requiring a reload. Runtime-originated assistant turns SHALL stream and settle in the transcript with the same status transitions as composer-originated ones.
+
+#### Scenario: A backend-originated user message arrives while the session is open
+- **WHEN** a user message is created for the open session through the service boundary rather than the composer
+- **THEN** the message appears in the conversation view without a reload
+
+#### Scenario: A seat turn dispatched by the coordinator streams into the open transcript
+- **WHEN** the multi-agent coordinator dispatches a seat turn in the open session
+- **THEN** the assistant message appears in the conversation view, streams its content, and shows its settled status
+- **AND** the speaker identity renders with the same captured role and Agent labels as composer-originated turns
+
+#### Scenario: The session is opened after backend-originated messages already exist
+- **WHEN** a session containing runtime-originated messages is opened
+- **THEN** the conversation view lists those messages in order alongside composer-originated ones

--- a/openspec/changes/fix-chat-transcript-backend-message-updates/tasks.md
+++ b/openspec/changes/fix-chat-transcript-backend-message-updates/tasks.md
@@ -1,0 +1,17 @@
+## 1. Diagnosis
+
+- [ ] 1.1 Trace how the open transcript learns about new messages (event subscription vs. query invalidation) and identify why runtime-originated `MessageCreated`/streaming events do not reach it while the turn status bar's subscription does.
+
+## 2. Implementation
+
+- [ ] 2.1 Make the message list react to runtime-originated message lifecycle events for the open session, in both the Tauri and Web/mock service adapters.
+- [ ] 2.2 Verify the fix does not double-render composer-originated flows or break optimistic composer updates.
+
+## 3. Coverage
+
+- [ ] 3.1 Component test: a message event for the open session that did not come from the composer updates the rendered list.
+- [ ] 3.2 Desktop e2e: after a programmatic `send_message`, the open transcript shows the user message and the seat reply (extend the multi-agent UI or longrun layer).
+
+## 4. Verification
+
+- [ ] 4.1 Run the full validation command set from AGENTS.md (UI behavior changed: include `npx playwright test` and the desktop layers), then `openspec validate fix-chat-transcript-backend-message-updates --strict`.

--- a/openspec/changes/fix-chat-transcript-backend-message-updates/tasks.md
+++ b/openspec/changes/fix-chat-transcript-backend-message-updates/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Diagnosis
 
-- [ ] 1.1 Trace how the open transcript learns about new messages (event subscription vs. query invalidation) and identify why runtime-originated `MessageCreated`/streaming events do not reach it while the turn status bar's subscription does.
+- [x] 1.1 Trace how the open transcript learns about new messages (event subscription vs. query invalidation) and identify why runtime-originated `MessageCreated`/streaming events do not reach it while the turn status bar's subscription does. Finding: `applyChatEvents` can only mutate rows already in the react-query cache — stream events carry no role/speaker/sequence and cannot create rows, and neither subscription refetched the list, so every event for an unknown message id was silently dropped; composer flows worked only because their optimistic updates seeded the rows first.
 
 ## 2. Implementation
 
-- [ ] 2.1 Make the message list react to runtime-originated message lifecycle events for the open session, in both the Tauri and Web/mock service adapters.
-- [ ] 2.2 Verify the fix does not double-render composer-originated flows or break optimistic composer updates.
+- [x] 2.1 Make the message list react to runtime-originated message lifecycle events for the open session: `hasEventsForUnknownMessages` (services/chat-events.ts) detects events targeting unknown rows, and both subscription points — `use-session-stream-events.ts` (extracted from `use-main-layout-model.ts`) and `use-active-session-chat.ts` — refetch the list when it fires, plus one settle-time refetch after a stream that ever touched unknown rows. Adapter-agnostic: both the Tauri and Web/mock adapters deliver events through the same `subscribeMessageEvents` boundary.
+- [x] 2.2 Verify the fix does not double-render composer-originated flows or break optimistic composer updates (full vitest suite green; refetch only triggers for unknown ids, which optimistic seeding prevents for composer sends).
 
 ## 3. Coverage
 
-- [ ] 3.1 Component test: a message event for the open session that did not come from the composer updates the rendered list.
-- [ ] 3.2 Desktop e2e: after a programmatic `send_message`, the open transcript shows the user message and the seat reply (extend the multi-agent UI or longrun layer).
+- [x] 3.1 Component test: a message event for the open session that did not come from the composer updates the rendered list (`use-active-session-chat.test.tsx`), plus unit coverage for `hasEventsForUnknownMessages` (`chat-events.test.ts`).
+- [x] 3.2 Desktop e2e: after a programmatic `send_message`, the open transcript shows the backend-originated turns (`message-speaker` assertion in the multi-agent longrun layer; verified 5/5 green on 2026-08-25 with per-stage screenshots showing the rendered thread).
 
 ## 4. Verification
 
-- [ ] 4.1 Run the full validation command set from AGENTS.md (UI behavior changed: include `npx playwright test` and the desktop layers), then `openspec validate fix-chat-transcript-backend-message-updates --strict`.
+- [x] 4.1 Run the full validation command set from AGENTS.md, then `openspec validate fix-chat-transcript-backend-message-updates --strict` (2026-08-25: lint:ci, vitest suite, build, tsc green; `npx playwright test` 155/156 with the one multi-agent-session failure reproducing as a load flake — 5/5 green re-run in isolation; desktop verification via the multi-agent longrun layer, 5/5 green with the transcript assertion).

--- a/openspec/changes/harden-provider-output-oversized-records/proposal.md
+++ b/openspec/changes/harden-provider-output-oversized-records/proposal.md
@@ -1,0 +1,28 @@
+# Harden provider output parsing against oversized records
+
+## Why
+
+A real multi-agent session died mid-turn because one stream-json record from claude-code — a tool result carrying a large file read — exceeded the CLI output parser's per-record bound. The framer treated the overflow as a protocol error and failed the whole generation, so a seat turn that had already produced eight correct file edits was reported as "Claude Code command failed" with no usable diagnostic. Two aggravating defects were found alongside: the streaming read loop hardcodes a 256 KiB bound instead of consulting the provider's declared parser policy (whose domain maximum is 1 MiB), and a dropped record left no trace in unified logs.
+
+## What Changes
+
+- Treat an oversized provider output record as a degradation, not a protocol failure: drop the record through its terminating newline, keep parsing subsequent records, and let the turn complete on the stream's real terminal event.
+- Count dropped records and report them after the stream ends as a redacted `warn` in unified logs, so a drop is never silent.
+- Align the streaming read loop's record bound with the parser policy's domain maximum (1 MiB) instead of a hardcoded 256 KiB.
+- Keep fail-closed behavior for genuinely malformed output (invalid UTF-8) unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-provider-runtime`: Require graceful degradation for oversized output records during CLI generation streaming, with the drop surfaced through unified redacted diagnostics.
+
+## Impact
+
+- Affects `src-tauri/src/contexts/agent_runtime/infrastructure/providers/output.rs` (framer skip-and-continue semantics, discard counter) and `src-tauri/src/contexts/agent_runtime/infrastructure/process_adapter.rs` (bound value, post-stream warn log).
+- No Tauri command signature, frontend, or database change; the Web/mock adapter is unaffected.
+- Existing framer unit tests that asserted the old fail-closed overflow behavior are updated to assert the skip behavior instead.

--- a/openspec/changes/harden-provider-output-oversized-records/specs/agent-provider-runtime/spec.md
+++ b/openspec/changes/harden-provider-output-oversized-records/specs/agent-provider-runtime/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Oversized output records degrade gracefully during streaming
+When a single CLI output record exceeds the bounded parser limit during generation streaming, the runtime SHALL discard that record through its terminating newline and continue parsing subsequent records, instead of failing the generation. The effective bound SHALL be the parser policy's domain maximum rather than a smaller hardcoded value. Every discarded record SHALL be counted and reported after the stream ends as a redacted `warn` diagnostic in unified logs; genuinely malformed output (such as invalid UTF-8) SHALL continue to fail closed.
+
+#### Scenario: One oversized record inside an otherwise healthy stream
+- **WHEN** a CLI generation stream contains a record larger than the bounded parser limit followed by further well-formed records and a terminal completion event
+- **THEN** the oversized record is discarded and the later records are parsed and delivered
+- **AND** the generation completes according to the stream's terminal event rather than failing with a protocol error
+- **AND** unified logs record a redacted `warn` naming the number of discarded oversized records
+
+#### Scenario: The stream ends inside an oversized record
+- **WHEN** the stream ends before an oversized record's terminating newline arrives
+- **THEN** the partial oversized record is discarded rather than surfaced as truncated output or a protocol error
+
+#### Scenario: Malformed output still fails closed
+- **WHEN** a record within the bound contains invalid UTF-8
+- **THEN** the generation fails with the existing protocol error semantics

--- a/openspec/changes/harden-provider-output-oversized-records/tasks.md
+++ b/openspec/changes/harden-provider-output-oversized-records/tasks.md
@@ -1,0 +1,16 @@
+## 1. Framer degradation semantics
+
+- [x] 1.1 Rework `ProviderOutputFramer` so an overflow drops the current record through its terminating newline and resumes parsing, with a discard counter exposed to the consumer.
+- [x] 1.2 Update the framer unit tests that asserted fail-closed overflow to assert the skip behavior (mid-chunk newline, cross-push oversize, unterminated tail), keeping the invalid-UTF-8 fail-closed test.
+
+## 2. Stream consumer
+
+- [x] 2.1 Replace the hardcoded 256 KiB bound in the generation read loop with the parser policy domain maximum (1 MiB).
+- [x] 2.2 After the stream ends, record a redacted `warn` unified-log entry naming the number of discarded oversized records for the generation.
+- [ ] 2.3 Wire the bound to the provider's declared `ProviderParserPolicy` instead of a constant, so a future per-provider policy change reaches the read loop.
+
+## 3. Verification
+
+- [x] 3.1 `cargo check -p vanehub-ai` and the reworked `providers::output` unit tests pass locally.
+- [x] 3.2 A real three-seat desktop session that previously died on an oversized claude-code tool result completes end to end (desktop-multi-agent-longrun layer, 2026-08-24 evidence).
+- [x] 3.3 Run the full validation command set from AGENTS.md, then `openspec validate harden-provider-output-oversized-records --strict` (2026-08-25: all green; the architecture line-budget raise for `agent_runtime/infrastructure` rides in the same commit with its reason recorded).

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "test:desktop:session-workspace": "node scripts/test-desktop.mjs session-workspace",
     "test:desktop:dialogs": "node scripts/test-desktop.mjs dialogs",
     "test:desktop:settings-persistence": "node scripts/test-desktop.mjs settings-persistence",
+    "test:desktop:multi-agent-requirement": "node scripts/test-desktop.mjs multi-agent-requirement",
+    "test:desktop:multi-agent-longrun": "node scripts/test-desktop.mjs multi-agent-longrun",
     "test:desktop": "node scripts/test-desktop.mjs all",
     "test:verify": "node scripts/test-verify.mjs",
     "test:coverage": "vitest run --coverage --maxWorkers=4 --testTimeout=15000",

--- a/scripts/test-desktop.mjs
+++ b/scripts/test-desktop.mjs
@@ -182,6 +182,27 @@ function dialogsDesktop(artifact) {
   });
 }
 
+// Opt-in only, never part of `all`: it drives the REAL codex-cli and claude-code against a real
+// requirement, so it spends model tokens and needs both CLIs authenticated on the host.
+function multiAgentRequirementDesktop(artifact) {
+  return runDesktopLayer({
+    layer: "desktop-multi-agent-requirement",
+    config: "tests/desktop/wdio.multi-agent-requirement.conf.mjs",
+    label: "Desktop multi-agent requirement",
+    artifact,
+  });
+}
+
+// Opt-in only: a long-running three-seat feature build with real model calls.
+function multiAgentLongrunDesktop(artifact) {
+  return runDesktopLayer({
+    layer: "desktop-multi-agent-longrun",
+    config: "tests/desktop/wdio.multi-agent-longrun.conf.mjs",
+    label: "Desktop multi-agent longrun",
+    artifact,
+  });
+}
+
 function settingsPersistenceDesktop(artifact) {
   return runDesktopLayer({
     layer: "desktop-settings-persistence",
@@ -199,6 +220,8 @@ async function main() {
   else if (mode === "session-workspace") await sessionWorkspaceDesktop();
   else if (mode === "dialogs") await dialogsDesktop();
   else if (mode === "settings-persistence") await settingsPersistenceDesktop();
+  else if (mode === "multi-agent-requirement") await multiAgentRequirementDesktop();
+  else if (mode === "multi-agent-longrun") await multiAgentLongrunDesktop();
   else if (mode === "all") {
     const artifact = await buildDesktop();
     const fullSuiteLayers = [smokeDesktop, cliTerminalDesktop, sessionWorkspaceDesktop, dialogsDesktop, settingsPersistenceDesktop];

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/process_adapter.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/process_adapter.rs
@@ -912,7 +912,11 @@ impl ProcessMonitor {
         // terminal `GenerationProcessEvent::Completed` below rather than acted on
         // immediately, since the exit code (not this line) decides success/failure.
         let mut reported_usage: Option<ReportedUsageTotals> = None;
-        for line in BoundedProviderLines::new(&mut reader, 256 * 1024) {
+        // The bound matches ProviderParserPolicy's domain maximum. One oversized record — a CLI
+        // tool result carrying a large file read — is dropped by the framer and reported after
+        // the stream ends, instead of failing a turn that was doing real work.
+        let mut bounded_lines = BoundedProviderLines::new(&mut reader, 1_048_576);
+        for line in &mut bounded_lines {
             let event = match line {
                 Ok(line) => match parser.parse_line(&line) {
                     ProviderOutputEvent::Token(delta) => {
@@ -993,6 +997,26 @@ impl ProcessMonitor {
                     break;
                 }
             }
+        }
+        let discarded_records = bounded_lines.discarded_records();
+        drop(bounded_lines);
+        if discarded_records > 0 {
+            // A dropped record must not be silent: without this line, whatever the record carried
+            // reads as "the Agent never said that".
+            let _ = logging.record(AgentLog {
+                level: AgentLogLevel::Warn,
+                category: "session.runtime.cli".to_string(),
+                message: format!(
+                    "Provider output dropped {discarded_records} oversized record(s) exceeding the bounded parser limit."
+                ),
+                agent_id: Some(agent_id.clone()),
+                session_id: Some(session_id.clone()),
+                operation_id: Some(operation_id.clone()),
+                run_id: Some(execution_context.run_id.as_str().to_string()),
+                trace_id: Some(execution_context.trace_id.as_str().to_string()),
+                span_id: Some(execution_context.span_id.as_str().to_string()),
+                occurred_at: clock.now(),
+            });
         }
         if reader.disconnected {
             record_runner_lifecycle(

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/compatibility.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/compatibility.rs
@@ -111,7 +111,10 @@ impl CompatibilityCliProvider {
             capabilities,
             readiness,
             output_format: definition.output_format,
-            parser_policy: ProviderParserPolicy::new(262_144, true)
+            // 256 KiB starved real seat turns: a claude-code tool_result carrying one large file
+            // read exceeds it and kills the whole generation. Use the domain-validated maximum
+            // (ProviderParserPolicy caps the buffer at 1 MiB).
+            parser_policy: ProviderParserPolicy::new(1_048_576, true)
                 .map_err(|error| preparation_error(&provider_id, error))?,
             version_probe: ProviderVersionProbe::new(vec!["--version".to_string()], 5_000)
                 .map_err(|error| preparation_error(&provider_id, error))?,

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/output.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/output.rs
@@ -17,6 +17,10 @@ pub(crate) struct ProviderOutputFramer {
     #[cfg(test)]
     stderr: Vec<u8>,
     max_buffer_bytes: usize,
+    discarding_stdout: bool,
+    #[cfg(test)]
+    discarding_stderr: bool,
+    discarded_records: usize,
 }
 
 impl ProviderOutputFramer {
@@ -26,7 +30,17 @@ impl ProviderOutputFramer {
             #[cfg(test)]
             stderr: Vec::new(),
             max_buffer_bytes,
+            discarding_stdout: false,
+            #[cfg(test)]
+            discarding_stderr: false,
+            discarded_records: 0,
         }
+    }
+
+    /// How many oversized records this framer has dropped, so the consumer can say so out loud —
+    /// a silent drop would read as "the Agent never said that".
+    pub(crate) fn discarded_records(&self) -> usize {
+        self.discarded_records
     }
 
     pub(crate) fn push(
@@ -34,28 +48,67 @@ impl ProviderOutputFramer {
         stream: ProviderOutputStream,
         chunk: &[u8],
     ) -> Result<Vec<String>, &'static str> {
-        let buffer = match stream {
-            ProviderOutputStream::Stdout => &mut self.stdout,
+        match stream {
+            ProviderOutputStream::Stdout => Self::push_into(
+                &mut self.stdout,
+                &mut self.discarding_stdout,
+                &mut self.discarded_records,
+                self.max_buffer_bytes,
+                chunk,
+            ),
             #[cfg(test)]
-            ProviderOutputStream::Stderr => &mut self.stderr,
-        };
-        if buffer.len().saturating_add(chunk.len()) > self.max_buffer_bytes {
-            buffer.clear();
-            return Err("provider output record exceeds the bounded parser limit");
+            ProviderOutputStream::Stderr => Self::push_into(
+                &mut self.stderr,
+                &mut self.discarding_stderr,
+                &mut self.discarded_records,
+                self.max_buffer_bytes,
+                chunk,
+            ),
         }
-        buffer.extend_from_slice(chunk);
+    }
+
+    /// A record larger than the bound is dropped (through its terminating newline) rather than
+    /// failing the whole generation: one oversized tool result — a CLI reading a lockfile —
+    /// otherwise kills a seat turn that was doing real work. Later records parse normally.
+    fn push_into(
+        buffer: &mut Vec<u8>,
+        discarding: &mut bool,
+        discarded_records: &mut usize,
+        max_buffer_bytes: usize,
+        chunk: &[u8],
+    ) -> Result<Vec<String>, &'static str> {
         let mut lines = Vec::new();
-        while let Some(index) = buffer.iter().position(|byte| *byte == b'\n') {
-            let mut record = buffer.drain(..=index).collect::<Vec<_>>();
-            record.pop();
-            if record.last() == Some(&b'\r') {
-                record.pop();
+        let mut rest = chunk;
+        loop {
+            if *discarding {
+                match rest.iter().position(|byte| *byte == b'\n') {
+                    Some(index) => {
+                        *discarding = false;
+                        rest = &rest[index + 1..];
+                    }
+                    None => return Ok(lines),
+                }
             }
-            lines.push(
-                String::from_utf8(record).map_err(|_| "provider output contains invalid UTF-8")?,
-            );
+            if buffer.len().saturating_add(rest.len()) > max_buffer_bytes {
+                buffer.clear();
+                *discarding = true;
+                *discarded_records += 1;
+                continue;
+            }
+            buffer.extend_from_slice(rest);
+            while let Some(index) = buffer.iter().position(|byte| *byte == b'\n') {
+                let mut record = buffer.drain(..=index).collect::<Vec<_>>();
+                record.pop();
+                if record.last() == Some(&b'\r') {
+                    record.pop();
+                }
+                lines.push(
+                    String::from_utf8(record)
+                        .map_err(|_| "provider output contains invalid UTF-8")?,
+                );
+            }
+            return Ok(lines);
         }
-        Ok(lines)
     }
 
     pub(crate) fn finish(
@@ -91,6 +144,11 @@ impl<R: Read> BoundedProviderLines<R> {
             pending: VecDeque::new(),
             finished: false,
         }
+    }
+
+    /// Oversized records dropped so far; the consumer reports them after the stream ends.
+    pub(crate) fn discarded_records(&self) -> usize {
+        self.framer.discarded_records()
     }
 }
 
@@ -173,9 +231,7 @@ mod framer_tests {
     }
 
     #[test]
-    fn malformed_and_oversized_records_fail_closed() {
-        let mut framer = ProviderOutputFramer::new(4);
-        assert!(framer.push(ProviderOutputStream::Stdout, b"12345").is_err());
+    fn malformed_records_fail_closed() {
         let mut framer = ProviderOutputFramer::new(1024);
         assert!(framer
             .push(ProviderOutputStream::Stdout, &[0xff, b'\n'])
@@ -183,19 +239,56 @@ mod framer_tests {
     }
 
     #[test]
-    fn bounded_line_iterator_preserves_tail_and_classifies_failures() {
+    fn oversized_records_are_dropped_and_later_records_still_parse() {
+        // The oversized record spans several pushes; the record after its newline parses.
+        let mut framer = ProviderOutputFramer::new(4);
+        assert!(framer
+            .push(ProviderOutputStream::Stdout, b"12345")
+            .expect("oversized start")
+            .is_empty());
+        assert!(framer
+            .push(ProviderOutputStream::Stdout, b"67890")
+            .expect("oversized middle")
+            .is_empty());
+        assert_eq!(
+            framer
+                .push(ProviderOutputStream::Stdout, b"x\nok\n")
+                .expect("resumes after the newline"),
+            ["ok"]
+        );
+        assert_eq!(framer.discarded_records(), 1);
+
+        // The terminating newline and the next record arrive in the SAME chunk as the overflow.
+        let mut framer = ProviderOutputFramer::new(8);
+        assert_eq!(
+            framer
+                .push(ProviderOutputStream::Stdout, b"0123456789abcdef\nok\n")
+                .expect("skip within one chunk"),
+            ["ok"]
+        );
+        assert_eq!(framer.discarded_records(), 1);
+    }
+
+    #[test]
+    fn bounded_line_iterator_preserves_tail_and_skips_oversized_records() {
         let lines = BoundedProviderLines::new(&b"one\ntwo"[..], 16)
             .collect::<Result<Vec<_>, _>>()
             .expect("bounded lines");
         assert_eq!(lines, ["one", "two"]);
 
-        let error = BoundedProviderLines::new(&b"oversized"[..], 4)
+        let mut iterator = BoundedProviderLines::new(&b"oversized-record\nok\n"[..], 4);
+        let lines = (&mut iterator)
             .collect::<Result<Vec<_>, _>>()
-            .expect_err("oversized record");
-        assert_eq!(
-            error,
-            "provider output record exceeds the bounded parser limit"
-        );
+            .expect("skips the oversized record");
+        assert_eq!(lines, ["ok"]);
+        assert_eq!(iterator.discarded_records(), 1);
+
+        // An oversized record that never terminates is dropped entirely rather than surfaced as
+        // a truncated tail.
+        let lines = BoundedProviderLines::new(&b"oversized"[..], 4)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("drops the unterminated oversized tail");
+        assert!(lines.is_empty());
     }
 
     #[test]

--- a/src-tauri/tests/architecture.rs
+++ b/src-tauri/tests/architecture.rs
@@ -2385,10 +2385,17 @@ const NATIVE_SUBTREE_BUDGETS: &[SubtreeBudget] = &[
     // -328 production: `invocation.rs` loses its per-parameter-id renderer branches and
     // `cli_profile.rs` its duplicate `default` interpretation, both now owned by the tooling
     // resolver.
+    //
+    // Raised from 60,547 by `harden-provider-output-oversized-records`: the provider output
+    // framer gains skip-and-resume handling for oversized records plus a discard counter
+    // (`providers/output.rs`, production and reworked framer tests), and the generation read
+    // loop reports discarded records to unified logs after the stream ends
+    // (`process_adapter.rs`). No code was moved or duplicated; the raise is the resilience
+    // logic and its tests.
     SubtreeBudget {
         root: "src-tauri/src/contexts/agent_runtime/infrastructure",
-        budget: 60_547,
-        owner: "decompose-api-tool-use-loop",
+        budget: 60_665,
+        owner: "harden-provider-output-oversized-records",
     },
     // Raised from 2,914 by `split-database-migrations`, which turned `migrations.rs` into a
     // directory module. The +51 is entirely per-file boilerplate: +29 module headers (the `mod`
@@ -2416,8 +2423,12 @@ const NATIVE_PRODUCTION_SUBTREE_BUDGETS: &[SubtreeBudget] = &[
         // at its first `#[cfg(test)]` and several files declare `#[cfg(test)] mod tests;` near the
         // top and continue with production code below. That discarded 5,966 real production lines
         // and left the subtree that much silent headroom — the opposite of what a ceiling is for.
-        budget: 32_964,
-        owner: "upgrade-cli-parameter-management",
+        // Raised from 32,964 by `harden-provider-output-oversized-records`: the framer's
+        // skip-and-resume path and discard counter in `providers/output.rs`, and the
+        // post-stream discarded-records warn log in `process_adapter.rs`, are production code
+        // measured on the same commit.
+        budget: 33_049,
+        owner: "harden-provider-output-oversized-records",
     },
 ];
 

--- a/src/hooks/use-active-session-chat.test.tsx
+++ b/src/hooks/use-active-session-chat.test.tsx
@@ -13,6 +13,7 @@ const service = vi.hoisted(() => ({
 vi.mock("../services/runtime-agent-client", () => ({ agentService: service }));
 
 import { useSessionMessageEvents } from "./use-active-session-chat";
+import type { ChatMessage, ChatStreamEvent } from "../types/chat";
 
 function Subscriber({ sessionId }: { sessionId: string }) {
   useSessionMessageEvents({ queryKey: ["messages", sessionId], sessionId });
@@ -57,5 +58,32 @@ describe("background session message subscription", () => {
     await waitFor(() => expect(unsubscribe).toHaveBeenCalledOnce());
 
     expect(service.stopGeneration).not.toHaveBeenCalled();
+  });
+
+  it("refetches the list when events target a message the cache has never seen", async () => {
+    // A programmatic send, an IM message, or a seat turn creates rows behind this client's
+    // back; their stream events cannot create cache rows, so the hook must refetch the list.
+    let handler: ((event: ChatStreamEvent) => void) | undefined;
+    service.subscribeMessageEvents.mockImplementation(
+      (_sessionId: string, callback: (event: ChatStreamEvent) => void) => {
+        handler = callback;
+        return Promise.resolve(() => {});
+      },
+    );
+    const client = new QueryClient();
+    client.setQueryData(["messages", "session-3"], [] as ChatMessage[]);
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    render(
+      <QueryClientProvider client={client}>
+        <Subscriber sessionId="session-3" />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(handler).toBeDefined());
+
+    // A terminal event flushes synchronously, so no animation-frame pump is needed.
+    handler?.({ type: "completed", sessionId: "session-3", messageId: "seat-turn-1" });
+
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["messages", "session-3"] }));
   });
 });

--- a/src/hooks/use-active-session-chat.ts
+++ b/src/hooks/use-active-session-chat.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { applyChatEvents } from "../services/chat-events";
+import { applyChatEvents, hasEventsForUnknownMessages } from "../services/chat-events";
 import { agentService } from "../services/runtime-agent-client";
 import type { ChatMessage, ChatStreamEvent } from "../types/chat";
 
@@ -33,14 +33,23 @@ export function useSessionMessageEvents({
     // an animation frame so a burst collapses into one array rebuild per frame.
     let pending: ChatStreamEvent[] = [];
     let frame = 0;
+    // Stream events can only mutate rows the cache already holds; events for an unknown id mean
+    // the thread advanced outside this client (a programmatic send, an IM message, a seat turn)
+    // and the list has to be refetched for the new rows to appear.
+    let refreshingUnknown = false;
     const flush = () => {
       frame = 0;
       if (pending.length === 0) return;
       const batch = pending;
       pending = [];
-      queryClient.setQueryData<ChatMessage[]>(queryKey, (current) =>
-        applyChatEvents(current ?? [], batch),
-      );
+      const current = queryClient.getQueryData<ChatMessage[]>(queryKey) ?? [];
+      queryClient.setQueryData<ChatMessage[]>(queryKey, applyChatEvents(current, batch));
+      if (!refreshingUnknown && hasEventsForUnknownMessages(current, batch)) {
+        refreshingUnknown = true;
+        void queryClient
+          .invalidateQueries({ queryKey })
+          .finally(() => { refreshingUnknown = false; });
+      }
     };
     void agentService.subscribeMessageEvents(sessionId, (event) => {
       pending.push(event);

--- a/src/main-layout/use-main-layout-model.ts
+++ b/src/main-layout/use-main-layout-model.ts
@@ -9,17 +9,17 @@ import { normalizeDisplayPath } from "../lib/session-path";
 import { useDebouncedValue } from "../hooks/use-debounced-value";
 import type { TurnStatus } from "../components/chat/TurnStatusBar";
 import { turnStatusFromEvent, waitedMinutes } from "../services/turn-status";
-import { applyChatEvents } from "../services/chat-events";
 import { agentService } from "../services/runtime-agent-client";
 import { permissionsService } from "../services/runtime-permissions-client";
 import { settingsService } from "../services/runtime-settings-client";
 import type { Session, SessionCategory, SessionExportFormat } from "../types/agent";
 import { useFileReferences } from "./use-file-references";
 import { useMentionCandidates } from "./use-mention-candidates";
-import { MAX_CHAT_FILE_REFERENCES, type ChatMessage, type ChatStreamEvent } from "../types/chat";
+import { MAX_CHAT_FILE_REFERENCES, type ChatMessage } from "../types/chat";
 import { appendMessageIfMissing, createOptimisticUserMessage, removeMessageById, type SendMessageMutationInput } from "./optimistic-message";
 import { canSendToSession, hasLiveSessionGeneration } from "../services/session-admission";
 import { useSessionRecoverySync } from "./use-session-recovery-sync";
+import { useSessionStreamEvents } from "./use-session-stream-events";
 import { useSessionSwitch } from "./use-session-switch";
 export function useMainLayoutModel() {
   const { t } = useTranslation();
@@ -172,52 +172,15 @@ export function useMainLayoutModel() {
     onSuccess: invalidateRuntime,
     onError: (reason, sessionId) => reportChatFailure("MainLayout.stopGeneration", reason, sessionId),
   });
-  useEffect(() => {
-    if (!activeSessionId) return;
-    let cleanup: (() => void) | null = null;
-    let cancelled = false;
-    // Token events arrive in the thousands per turn; buffer them and flush on an animation
-    // frame so the message array is rebuilt once per frame instead of once per token.
-    let pending: ChatStreamEvent[] = [];
-    let frame = 0;
-    const flush = () => {
-      frame = 0;
-      if (pending.length === 0) return;
-      const batch = pending;
-      pending = [];
-      queryClient.setQueryData<ChatMessage[]>(messagesKey, (current) =>
-        applyChatEvents(current ?? [], batch),
-      );
-    };
-    void agentService.subscribeMessageEvents(activeSessionId, (event) => {
-      if (event.type === "turn_status") {
-        // turn_status is session-scoped, not message-scoped, and drives the waiting bar; it
-        // must update immediately rather than ride a frame delay.
-        waitingSince.current = event.status.kind === "waiting_human" ? event.status.since : null;
-        setTurnStatus(turnStatusFromEvent(event.status));
-        return;
-      }
-      pending.push(event);
-      if (event.type === "completed" && event.tokenUsage) {
-        void queryClient.invalidateQueries({ queryKey: ["session-usage-summary", event.sessionId] });
-        void queryClient.invalidateQueries({ queryKey: ["usage-statistics"] });
-      }
-      // A round that ends leaves nobody holding the turn, so the bar has to go rather than freeze.
-      if (["completed", "failed", "cancelled"].includes(event.type)) {
-        invalidateSessions();
-        // Flush the buffered tokens now so the terminal message lands with the status change.
-        if (frame !== 0) { cancelAnimationFrame(frame); frame = 0; }
-        flush();
-      } else if (frame === 0) {
-        frame = requestAnimationFrame(flush);
-      }
-    }).then((unsubscribe) => { if (cancelled) unsubscribe(); else cleanup = unsubscribe; });
-    return () => {
-      cancelled = true;
-      if (frame !== 0) cancelAnimationFrame(frame);
-      cleanup?.();
-    };
-  }, [activeSessionId, invalidateSessions, messagesKey, queryClient]);
+  useSessionStreamEvents({
+    invalidateSessions,
+    messagesKey,
+    onTurnStatus: (status) => {
+      waitingSince.current = status.kind === "waiting_human" ? status.since : null;
+      setTurnStatus(turnStatusFromEvent(status));
+    },
+    sessionId: activeSessionId,
+  });
   useEffect(() => { setMessageLimit(50); setDraft(""); setFileReferences([]); setTurnStatus(null); waitingSince.current = null; }, [activeSessionId, setFileReferences]);
   // Keep a human-wait duration moving without backend minute-by-minute events.
   useEffect(() => {

--- a/src/main-layout/use-session-stream-events.ts
+++ b/src/main-layout/use-session-stream-events.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { applyChatEvents, hasEventsForUnknownMessages } from "../services/chat-events";
+import { agentService } from "../services/runtime-agent-client";
+import type { TurnStatusEvent } from "../services/turn-status";
+import type { ChatMessage, ChatStreamEvent } from "../types/chat";
+
+/**
+ * The active session's chat-event subscription: buffers the token firehose into one array
+ * rebuild per animation frame, keeps the turn-status bar immediate, and — because stream events
+ * can only mutate rows the cache already holds — refetches the message list whenever events
+ * target a message this client has never seen (a programmatic send through the service
+ * boundary, an IM-originated message, or a seat turn dispatched by the multi-agent
+ * coordinator).
+ */
+export function useSessionStreamEvents({
+  invalidateSessions,
+  messagesKey,
+  onTurnStatus,
+  sessionId,
+}: {
+  invalidateSessions: () => void;
+  messagesKey: readonly unknown[];
+  onTurnStatus: (status: TurnStatusEvent) => void;
+  sessionId: string | null;
+}) {
+  const queryClient = useQueryClient();
+  // Callback props ride refs so a per-render identity does not tear down the subscription.
+  const onTurnStatusRef = useRef(onTurnStatus);
+  onTurnStatusRef.current = onTurnStatus;
+  const invalidateSessionsRef = useRef(invalidateSessions);
+  invalidateSessionsRef.current = invalidateSessions;
+
+  useEffect(() => {
+    if (!sessionId) return;
+    let cleanup: (() => void) | null = null;
+    let cancelled = false;
+    // Token events arrive in the thousands per turn; buffer them and flush on an animation
+    // frame so the message array is rebuilt once per frame instead of once per token.
+    let pending: ChatStreamEvent[] = [];
+    let frame = 0;
+    // Events for a message the cache has never seen cannot create rows, so the list has to be
+    // refetched; the flag collapses a burst into one refetch.
+    let refreshingUnknown = false;
+    let sawUnknown = false;
+    const flush = () => {
+      frame = 0;
+      if (pending.length === 0) return;
+      const batch = pending;
+      pending = [];
+      const current = queryClient.getQueryData<ChatMessage[]>(messagesKey) ?? [];
+      queryClient.setQueryData<ChatMessage[]>(messagesKey, applyChatEvents(current, batch));
+      if (!refreshingUnknown && hasEventsForUnknownMessages(current, batch)) {
+        refreshingUnknown = true;
+        sawUnknown = true;
+        void queryClient
+          .invalidateQueries({ queryKey: messagesKey })
+          .finally(() => { refreshingUnknown = false; });
+      }
+    };
+    void agentService.subscribeMessageEvents(sessionId, (event) => {
+      if (event.type === "turn_status") {
+        // turn_status is session-scoped, not message-scoped, and drives the waiting bar; it
+        // must update immediately rather than ride a frame delay.
+        onTurnStatusRef.current(event.status);
+        return;
+      }
+      pending.push(event);
+      if (event.type === "completed" && event.tokenUsage) {
+        void queryClient.invalidateQueries({ queryKey: ["session-usage-summary", event.sessionId] });
+        void queryClient.invalidateQueries({ queryKey: ["usage-statistics"] });
+      }
+      // A round that ends leaves nobody holding the turn, so the bar has to go rather than freeze.
+      if (["completed", "failed", "cancelled"].includes(event.type)) {
+        invalidateSessionsRef.current();
+        // Flush the buffered tokens now so the terminal message lands with the status change.
+        if (frame !== 0) { cancelAnimationFrame(frame); frame = 0; }
+        flush();
+        // A stream that ever touched unknown rows may have dropped deltas that raced the
+        // refetch; one settle-time refetch restores exact parity with the persisted thread.
+        if (sawUnknown) {
+          sawUnknown = false;
+          void queryClient.invalidateQueries({ queryKey: messagesKey });
+        }
+      } else if (frame === 0) {
+        frame = requestAnimationFrame(flush);
+      }
+    }).then((unsubscribe) => { if (cancelled) unsubscribe(); else cleanup = unsubscribe; });
+    return () => {
+      cancelled = true;
+      if (frame !== 0) cancelAnimationFrame(frame);
+      cleanup?.();
+    };
+  }, [messagesKey, queryClient, sessionId]);
+}

--- a/src/services/chat-events.test.ts
+++ b/src/services/chat-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyChatEvent, applyChatEvents } from "./chat-events";
+import { applyChatEvent, applyChatEvents, hasEventsForUnknownMessages } from "./chat-events";
 import type { ChatMessage, ChatStreamEvent } from "../types/chat";
 
 const baseMessage: ChatMessage = {
@@ -142,5 +142,37 @@ describe("applyChatEvents", () => {
   it("ignores an empty event batch", () => {
     const messages: ChatMessage[] = [{ ...baseMessage, id: "assistant-1", content: "x" }];
     expect(applyChatEvents(messages, [])).toBe(messages);
+  });
+});
+
+describe("hasEventsForUnknownMessages", () => {
+  it("flags events that target a message the list has never seen", () => {
+    const messages: ChatMessage[] = [{ ...baseMessage }];
+    const events: ChatStreamEvent[] = [
+      { type: "token", sessionId: "session-1", messageId: "assistant-1", contentDelta: "known" },
+      { type: "started", sessionId: "session-1", messageId: "seat-turn-9" },
+    ];
+    expect(hasEventsForUnknownMessages(messages, events)).toBe(true);
+  });
+
+  it("stays quiet when every event targets a known message", () => {
+    const messages: ChatMessage[] = [{ ...baseMessage }];
+    const events: ChatStreamEvent[] = [
+      { type: "token", sessionId: "session-1", messageId: "assistant-1", contentDelta: "known" },
+      { type: "completed", sessionId: "session-1", messageId: "assistant-1" },
+    ];
+    expect(hasEventsForUnknownMessages(messages, events)).toBe(false);
+  });
+
+  it("does not treat session-scoped turn_status as an unknown message", () => {
+    const events: ChatStreamEvent[] = [
+      {
+        type: "turn_status",
+        sessionId: "session-1",
+        status: { kind: "round_complete", seatIndex: 0, mention: "架构师" },
+      },
+    ];
+    expect(hasEventsForUnknownMessages([], events)).toBe(false);
+    expect(hasEventsForUnknownMessages([], [])).toBe(false);
   });
 });

--- a/src/services/chat-events.ts
+++ b/src/services/chat-events.ts
@@ -49,6 +49,22 @@ export function applyChatEvents(messages: ChatMessage[], events: readonly ChatSt
   return changed ? next : messages;
 }
 
+/**
+ * Whether any event targets a message the current list has never seen. Stream events can only
+ * mutate existing rows — they carry no role, speaker, or sequence — so events for an unknown id
+ * mean the thread advanced outside this client's composer (a programmatic send through the
+ * service boundary, an IM-originated message, or a seat turn dispatched by the multi-agent
+ * coordinator) and the list has to be refetched for the new rows to appear at all.
+ */
+export function hasEventsForUnknownMessages(
+  messages: readonly ChatMessage[],
+  events: readonly ChatStreamEvent[],
+): boolean {
+  if (events.length === 0) return false;
+  const known = new Set(messages.map((message) => message.id));
+  return events.some((event) => event.type !== "turn_status" && !known.has(event.messageId));
+}
+
 function applyEventToMessage(message: ChatMessage, event: ChatStreamEvent): ChatMessage {
   if (event.type === "turn_status") return message;
   if (message.id !== event.messageId) return message;

--- a/tests/desktop/specs-multi-agent-longrun/develop-copy-diagnostics.e2e.mjs
+++ b/tests/desktop/specs-multi-agent-longrun/develop-copy-diagnostics.e2e.mjs
@@ -1,0 +1,574 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, symlink, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const invoke = (fn, ...args) => globalThis.browser.tauri.execute(fn, ...args);
+const blocked = [];
+const stamp = Date.now().toString(36);
+
+/**
+ * A LARGE-granularity requirement through a full three-seat relay on the product's own source
+ * tree: "settings → about gains a 复制诊断信息 feature" — a new pure service module, a page
+ * change, five locale files, and a new unit test. Four mandated agent turns (架构师 → 实现者 →
+ * 代码审查 → 实现者 rework) exercise the depth-4 chain and the re-dispatch of a seat that has
+ * already spoken. `VANEHUB_LONGRUN_ADJUDICATION` picks the relay discipline: `human` (default)
+ * makes the implementer stop on a blocking `@用户 handoff` — the harness, playing the human,
+ * verifies the round actually pauses and then routes the review with a line-leading mention —
+ * while `auto` lets the seats relay unattended end to end. Long enough (typically 15-30 minutes
+ * of real model work) to surface duration problems: the 4000-char shared-thread injection
+ * budget, per-turn timeouts, oversized provider records, and coordinator lifetime.
+ *
+ * The judge is the project's own toolchain run by this harness after the round — vitest on the
+ * new test file, `tsc --noEmit`, eslint over the changed files, and locale-key greps — with the
+ * criteria quoted verbatim in the requirement message.
+ *
+ * Host findings carried over: codex-cli takes the words-only architect seat; claude-code and
+ * opencode run the `trusted` template (edits auto-approved, commands not), and every acting seat
+ * is told to write files and never run commands.
+ */
+// Reviewer-seat history on this host: opencode's model gateway 400s on every second step
+// (`input.status` missing, isRetryable:false — an opencode↔endpoint break, not VaneHub), and
+// codex's bwrap command sandbox intermittently cannot start inside the app
+// (`bwrap: loopback: RTM_NEWADDR Operation not permitted`), leaving it unable to read anything.
+// claude-code takes the reviewer seat: its file reads do not depend on bwrap. Same model family
+// as the implementer — `requireDifferentFamily` is presentational in the frontend, not enforced
+// at seat assignment — which this rehearsal accepts in exchange for a review that can actually
+// see the code.
+const TRIO = ["codex-cli", "claude-code", "claude-code"];
+const TRUSTED_SEATS = ["claude-code"];
+// Two relay disciplines, chosen per run: with `human` (the default) the implementer must stop on
+// a blocking `@用户 handoff` and the harness — playing the human — verifies the pause and routes
+// the review; with `auto` the implementer hands off straight to the reviewer and the round runs
+// unattended end to end. The product itself needs no switch — the discipline lives entirely in
+// the requirement message, which is exactly how a real dispatcher would choose a mode.
+const HUMAN_ADJUDICATION = globalThis.process.env.VANEHUB_LONGRUN_ADJUDICATION !== "auto";
+const BUILTIN_ROLES = ["builtin-architect", "builtin-implementer", "builtin-reviewer"];
+const STAGE_BUDGET_MS = 12 * 60 * 1000;
+const LOCALES = ["en", "zh-CN", "zh-TW", "ja", "ko"];
+const NEW_KEYS = ["about.diagnostics.copy", "about.diagnostics.copied"];
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(specDir, "..", "..", "..");
+
+async function settleOperation(operation, timeoutMsg) {
+  const settled = await globalThis.browser.waitUntil(async () => {
+    const status = await invoke(
+      ({ core }, operationId) => core.invoke("get_operation_status", { operationId }),
+      operation.id,
+    );
+    return ["succeeded", "failed", "cancelled"].includes(status.status) ? status : false;
+  }, { timeout: 90_000, timeoutMsg });
+  assert.equal(settled.status, "succeeded", settled.error ?? timeoutMsg);
+  return settled;
+}
+
+async function createTargetWorktree() {
+  const dest = join(await mkdtemp(join(tmpdir(), "vanehub-agent-longrun-")), "repo");
+  const branch = `agents/copy-diagnostics-${stamp}`;
+  await run("git", ["worktree", "add", dest, "-b", branch, "main"], { cwd: repoRoot });
+  return { dest, branch };
+}
+
+let target = null;
+const flow = { session: null, seats: [], handles: [], failed: false, ordinal: 0, retried: false };
+
+const listMessages = (sessionId) => invoke(({ core }, id) => core.invoke("list_messages", {
+  sessionId: id,
+  limit: null,
+  beforeId: null,
+}), sessionId);
+
+const assistantsOf = (messages) => messages.filter((message) => message.role === "assistant");
+
+async function dumpDiagnostics(tag) {
+  const resultDir = globalThis.process.env.VANEHUB_DESKTOP_RESULT_DIR;
+  if (!resultDir || !flow.session) return;
+  const capture = {};
+  capture.messages = await listMessages(flow.session.id).catch((error) => String(error));
+  capture.details = await invoke(
+    ({ core }, id) => core.invoke("get_session_details", { sessionId: id }),
+    flow.session.id,
+  ).catch((error) => String(error));
+  capture.logs = await invoke(({ core }, id) => core.invoke("list_session_logs", {
+    input: { sessionId: id, levels: ["error", "warn", "info", "debug"], search: "", cursor: null, limit: 500 },
+  }), flow.session.id).catch((error) => String(error));
+  await writeFile(
+    join(resultDir, `longrun-diagnostics-${tag}.json`),
+    `${JSON.stringify(capture, null, 2)}\n`,
+  ).catch(() => {});
+}
+
+async function turnAt(stage, ordinal, seat, handle) {
+  const row = await globalThis.browser.waitUntil(async () => {
+    const rows = assistantsOf(await listMessages(flow.session.id).catch(() => []));
+    return rows.length > ordinal ? rows[ordinal] : false;
+  }, {
+    timeout: STAGE_BUDGET_MS,
+    interval: 5_000,
+    timeoutMsg: `turn ${ordinal} (${handle}) was never dispatched`,
+  }).catch(() => null);
+  if (!row) {
+    const rows = assistantsOf(await listMessages(flow.session.id).catch(() => []));
+    const previous = rows[ordinal - 1];
+    if (previous && !(previous.content ?? "").includes(`@${handle}`)) {
+      blocked.push(`${stage}: the previous turn did not emit @${handle}, so the relay had `
+        + `nothing to act on (it replied: ${JSON.stringify((previous.content ?? "").slice(0, 200))})`);
+      await dumpDiagnostics(`${stage}-no-mention`);
+      return null;
+    }
+    flow.failed = true;
+    await dumpDiagnostics(`${stage}-never-dispatched`);
+    assert.fail(`turn ${ordinal} for @${handle} (${seat.agentId}) was never dispatched`);
+  }
+  assert.equal(row.speakerSeatId, seat.seatId, `turn ${ordinal} belongs to a seat other than @${handle}`);
+  const settled = await globalThis.browser.waitUntil(async () => {
+    const current = assistantsOf(await listMessages(flow.session.id).catch(() => []))[ordinal];
+    return ["completed", "failed", "cancelled"].includes(current?.status) ? current : false;
+  }, {
+    timeout: STAGE_BUDGET_MS,
+    interval: 5_000,
+    timeoutMsg: `turn ${ordinal} (${handle}) never settled`,
+  }).catch(() => null);
+  if (!settled || settled.status !== "completed" || !settled.content.trim()) {
+    blocked.push(`${stage}: the ${seat.agentId} turn ended ${settled?.status ?? "never"} `
+      + `(${JSON.stringify((settled?.error ?? settled?.content ?? "").slice(0, 200))}); that `
+      + "seat's runtime failed, not the relay");
+    await dumpDiagnostics(`${stage}-turn-${ordinal}`);
+    return null;
+  }
+  return settled;
+}
+
+function bail(context) {
+  flow.failed = true;
+  context.skip();
+}
+
+/** A stage snapshot beside the wdio evidence, so the visible run leaves visible proof. */
+async function snap(tag) {
+  const resultDir = globalThis.process.env.VANEHUB_DESKTOP_RESULT_DIR;
+  if (!resultDir) return;
+  await globalThis.browser
+    .saveScreenshot(join(resultDir, "screenshots", `stage-${tag}.png`))
+    .catch(() => {});
+}
+
+/**
+ * Puts the fixture session on screen. The session was created behind the UI's back, and the
+ * workspace route only mounts a session the UI's own list already contains — a reload is how the
+ * UI learns about it (same maneuver as ui-multi-agent.e2e.mjs). After this, every turn of the
+ * relay renders live in the window instead of happening invisibly over IPC.
+ */
+async function openSessionInUi() {
+  await globalThis.browser.refresh();
+  const root = await globalThis.$("#root");
+  await root.waitForExist({ timeout: 120_000 });
+  await globalThis.browser.waitUntil(
+    async () => (await root.getAttribute("data-vanehub-bootstrap")) === "ready",
+    { timeout: 120_000, timeoutMsg: "React bootstrap did not come back after the reload." },
+  );
+  await globalThis.browser.execute((target) => {
+    globalThis.history.pushState({}, "", target);
+    globalThis.dispatchEvent(new globalThis.PopStateEvent("popstate"));
+  }, `/workspace/sessions/${encodeURIComponent(flow.session.id)}`);
+  await (await globalThis.$('[aria-controls="session-tab-panel-chat"]')).waitForExist({ timeout: 30_000 });
+  await globalThis.browser.waitUntil(async () => {
+    const active = await invoke(({ core }) => core.invoke("get_active_session"));
+    return active?.id === flow.session.id;
+  }, { timeout: 30_000, timeoutMsg: "The app never switched to the longrun session." });
+}
+
+/**
+ * One seat turn at the thread's cursor, with a single human-style retry: when a seat's runtime
+ * fails transiently (a provider error event mid-stream — observed once with opencode/glm), a
+ * person would tell it to try again rather than abandon a 20-minute round. The retry is itself a
+ * long-run behavior worth exercising: the failed row stays in the thread and the relay resumes.
+ */
+async function relayTurn(stage, seat, handle) {
+  let attempt = await turnAt(stage, flow.ordinal, seat, handle);
+  if (attempt) {
+    flow.ordinal += 1;
+    return attempt;
+  }
+  const rows = assistantsOf(await listMessages(flow.session.id).catch(() => []));
+  const last = rows[flow.ordinal];
+  if (!last || !["failed", "cancelled"].includes(last.status)) return null;
+  flow.retried = true;
+  blocked.push(`${stage}: retrying after a ${last.status} ${seat.agentId} turn`);
+  await invoke(({ core }, payload) => core.invoke("send_message", payload), {
+    sessionId: flow.session.id,
+    content: `@${handle} 上一轮执行失败,请重新执行你负责的步骤,遵守原始分工与结尾提及规则。`,
+    config: {
+      agentId: flow.session.agentId,
+      interactionMode: "cli",
+      executionMode: "inherit",
+      providerId: null,
+      modelId: null,
+      reasoningDepth: null,
+      streaming: true,
+      thinking: false,
+      longContext: false,
+    },
+    fileReferences: null,
+  });
+  flow.ordinal += 1;
+  attempt = await turnAt(`${stage}-retry`, flow.ordinal, seat, handle);
+  if (!attempt) return null;
+  flow.ordinal += 1;
+  return attempt;
+}
+
+/** Toolchain commands need node_modules; borrow this checkout's via a symlink. */
+async function withNodeModules(fn) {
+  const link = join(target.dest, "node_modules");
+  await symlink(join(repoRoot, "node_modules"), link).catch(() => {});
+  try {
+    return await fn();
+  } finally {
+    await unlink(link).catch(() => {});
+  }
+}
+
+async function tool(command, args, timeout) {
+  try {
+    const { stdout, stderr } = await run(command, args, { cwd: target.dest, timeout });
+    return { ok: true, output: `${stdout}\n${stderr}` };
+  } catch (error) {
+    return { ok: false, output: `${error.stdout ?? ""}\n${error.stderr ?? error.message}` };
+  }
+}
+
+/** The verbatim criteria: project toolchain plus structural greps. */
+async function judge() {
+  const failures = [];
+  const { stdout: porcelain } = await run("git", ["status", "--porcelain"], { cwd: target.dest });
+  if (!porcelain.includes("src/services/about-diagnostics.ts")) {
+    failures.push("src/services/about-diagnostics.ts was not created");
+  }
+  if (!porcelain.includes("src/settings/pages/about-page.tsx")) {
+    failures.push("src/settings/pages/about-page.tsx was not modified");
+  }
+  for (const locale of LOCALES) {
+    const text = await readFile(join(target.dest, `src/i18n/locales/${locale}.json`), "utf8")
+      .catch(() => "");
+    for (const key of NEW_KEYS) {
+      if (!text.includes(`"${key}"`)) failures.push(`${locale}.json is missing ${key}`);
+    }
+  }
+  await withNodeModules(async () => {
+    const vitest = await tool("npx", [
+      "vitest", "run",
+      "src/services/about-diagnostics.test.ts",
+      "src/settings/pages/about-page.test.tsx",
+    ], 240_000);
+    if (!vitest.ok) failures.push(`vitest failed:\n${vitest.output.slice(-1_800)}`);
+    const tsc = await tool("npx", ["tsc", "--noEmit"], 300_000);
+    if (!tsc.ok) failures.push(`tsc --noEmit failed:\n${tsc.output.slice(-1_200)}`);
+    const { stdout: changed } = await run(
+      "git", ["diff", "--name-only", "main"], { cwd: target.dest },
+    );
+    const lintable = changed.split("\n").filter((file) => /\.(ts|tsx)$/u.test(file));
+    if (lintable.length > 0) {
+      const eslint = await tool("npx", ["eslint", "--no-warn-ignored", ...lintable], 240_000);
+      if (!eslint.ok) failures.push(`eslint failed:\n${eslint.output.slice(-1_200)}`);
+    }
+  });
+  return failures;
+}
+
+globalThis.describe("VaneHub AI multi-Agent develops a large-granularity feature", () => {
+  globalThis.before(async function prepare() {
+    this.timeout(180_000);
+    const root = await globalThis.$("#root");
+    await root.waitForExist({ timeout: 120_000 });
+    await globalThis.browser.waitUntil(
+      async () => (await root.getAttribute("data-vanehub-bootstrap")) === "ready",
+      { timeout: 120_000, timeoutMsg: "React bootstrap did not become ready." },
+    );
+    target = await createTargetWorktree();
+  });
+
+  globalThis.it("seats the trio and the 架构师 designs the feature", async function architect() {
+    this.timeout(STAGE_BUDGET_MS * 2 + 240_000);
+    const lineupAgents = await globalThis.browser.waitUntil(async () => {
+      const agents = await invoke(({ core }) => core.invoke("list_agents", { capabilityTag: null }))
+        .catch(() => null);
+      if (!Array.isArray(agents)) return false;
+      const lineup = TRIO.map((id) => agents.find((agent) => agent.id === id
+        && agent.availabilityState === "available"
+        && agent.supportedInteractionModes.includes("cli")));
+      return lineup.every(Boolean) ? lineup : false;
+    }, { timeout: 120_000, interval: 3_000, timeoutMsg: "the trio never became available" })
+      .catch(() => null);
+    if (!lineupAgents) {
+      blocked.push(`longrun flow: ${TRIO.join(", ")} not all installed/usable on this host`);
+      bail(this);
+    }
+    const roles = await invoke(({ core }) => core.invoke("list_expert_roles"));
+    const seatRoles = BUILTIN_ROLES.map((id) => roles.find((role) => role.id === id)).filter(Boolean);
+    if (seatRoles.length < 3) {
+      blocked.push("longrun flow: fewer than three built-in expert roles are available");
+      bail(this);
+    }
+    for (const agentId of TRUSTED_SEATS) {
+      await invoke(({ core }, input) => core.invoke("apply_policy_template", { input }), {
+        agentId,
+        template: "trusted",
+      });
+    }
+
+    const title = `multiagent-longrun-${stamp}`;
+    const operation = await invoke(({ core }, input) => core.invoke("create_session", { input }), {
+      agentId: lineupAgents[0].id,
+      interactionMode: "cli",
+      title,
+      folder: target.dest,
+      projectPath: target.dest,
+      remoteWorkspace: null,
+      worktree: null,
+    });
+    await settleOperation(operation, "Creating the longrun session never settled.");
+    const created = await globalThis.browser.waitUntil(async () => {
+      const sessions = await invoke(({ core }) => core.invoke("list_sessions"));
+      return sessions.find((item) => item.title === title) ?? false;
+    }, { timeout: 30_000, timeoutMsg: "The longrun session was not created." });
+
+    flow.session = await invoke(({ core }, input) => core.invoke("update_session_seats", { input }), {
+      sessionId: created.id,
+      expectedUpdatedAt: created.updatedAt,
+      seats: lineupAgents.map((agent, index) => ({ agentId: agent.id, roleId: seatRoles[index].id })),
+    });
+    flow.seats = flow.session.seats.filter((seat) => !seat.leftAt);
+    flow.handles = seatRoles.map((role) => role.displayName.split(/\s+/u).filter(Boolean).join("-"));
+    assert.deepEqual(flow.seats.map((seat) => seat.agentId), TRIO);
+
+    // Pin the UI language before it goes on screen, then put the session's chat view up so the
+    // whole relay scrolls live in the window.
+    await invoke(({ core }) => core.invoke("save_setting", {
+      input: { key: "applicationLanguage", value: "zh-CN" },
+    }));
+    await openSessionInUi();
+    await snap("0-session-open");
+
+    await invoke(({ core }, payload) => core.invoke("send_message", payload), {
+      sessionId: flow.session.id,
+      content: [
+        `@${flow.handles[0]} 大颗粒真实需求:当前仓库是 VaneHub AI 桌面应用源码。为「设置 → 关于」页新增`,
+        "「复制诊断信息」功能,分工与纪律必须严格遵守:",
+        "",
+        "功能要求:",
+        "- 新建 src/services/about-diagnostics.ts:导出纯函数 buildAboutDiagnostics,返回多行诊断文本",
+        "  (至少含产品名、当前版本、仓库地址;版本等取值通过参数传入或复用 about-service 的导出,",
+        "  函数本身不得直接访问 Tauri API 或 window,保证可单测)。",
+        "- 修改 src/settings/pages/about-page.tsx:新增一个复制按钮,点击后用 navigator.clipboard",
+        "  写入 buildAboutDiagnostics 的结果,复制成功后按钮短暂显示「已复制」态;按钮文案走 i18n。",
+        "- 5 个语言文件 src/i18n/locales/{en,zh-CN,zh-TW,ja,ko}.json 各新增两个键:",
+        "  about.diagnostics.copy 与 about.diagnostics.copied。",
+        "- 新建单测 src/services/about-diagnostics.test.ts 覆盖纯函数的正常与边界情况。",
+        "",
+        "分工(外部系统会核对轮次顺序):",
+        "1. 架构师(你):只做设计,不改代码。给出文件清单、buildAboutDiagnostics 的完整签名与返回格式、",
+        "   about-page 的接入方式与「已复制」状态的实现方案、测试用例要点,并说明取舍与被否决的替代方案。",
+        `   设计写完后,最后单独起一行、只写 @${flow.handles[1]}。`,
+        "2. 实现者:你有仓库文件写权限,没有命令执行权限。按设计创建/修改全部文件,不要征求确认,",
+        "   也不要运行任何命令——lint 与测试由外部系统执行。注意 about-page.tsx 全文件不得超过 300 行。",
+        ...(HUMAN_ADJUDICATION
+          ? [
+            "   改完说明动了哪些文件,然后最后单独起一行、只写 @用户 handoff ——把是否进入审查交给",
+            "   人类决定,在人类回复之前不要点名任何席位。",
+            "3. 代码审查(仅在人类点名你之后开始):读取全部改动文件,必须提出恰好一条需要实现者修改的",
+          ]
+          : [
+            `   改完说明动了哪些文件,然后最后单独起一行、只写 @${flow.handles[2]}。`,
+            "3. 代码审查:读取全部改动文件,必须提出恰好一条需要实现者修改的",
+          ]),
+        "   具体意见(引用文件与行内内容,例如遗漏的边界测试、错误处理或 i18n 遗漏),不要运行命令,",
+        "   只用文件读取工具。然后,",
+        `   然后最后单独起一行、只写 @${flow.handles[1]},把工作交回实现者。`,
+        "4. 实现者(第二轮):按审查意见直接修改文件,不要运行命令,",
+        "   然后最后单独起一行、只写 @用户 done,结束本轮。",
+        "",
+        "外部系统的验收标准(逐字执行):a) about-diagnostics.ts 与其单测存在且 vitest 通过;",
+        "b) npx tsc --noEmit 通过;c) eslint 对全部改动 ts/tsx 文件通过(含 max-lines 300 行规则);",
+        "d) 5 个语言文件都含上述两个键;e) about-page.tsx 被修改且引用 buildAboutDiagnostics。",
+      ].join("\n"),
+      config: {
+        agentId: flow.session.agentId,
+        interactionMode: "cli",
+        executionMode: "inherit",
+        providerId: null,
+        modelId: null,
+        reasoningDepth: null,
+        streaming: true,
+        thinking: false,
+        longContext: false,
+      },
+      fileReferences: null,
+    });
+
+    const turn = await relayTurn("architect", flow.seats[0], flow.handles[0]);
+    await snap("1-architect");
+    if (!turn) bail(this);
+    assert.ok(
+      /buildAboutDiagnostics/u.test(turn.content),
+      `the design never names buildAboutDiagnostics (got ${JSON.stringify(turn.content.slice(0, 200))})`,
+    );
+  });
+
+  globalThis.it("the 实现者 builds the feature across files", async function implement() {
+    this.timeout(STAGE_BUDGET_MS * 2 + 120_000);
+    if (flow.failed) this.skip();
+    const turn = await relayTurn("implementer", flow.seats[1], flow.handles[1]);
+    await snap("2-implementer");
+    if (!turn) bail(this);
+  });
+
+  globalThis.it("the blocking handoff pauses the round until the human routes the review", async function adjudicate() {
+    this.timeout(5 * 60 * 1000);
+    if (flow.failed) this.skip();
+    // In auto mode the implementer hands off straight to the reviewer; there is no human stage.
+    if (!HUMAN_ADJUDICATION) this.skip();
+    const rows = assistantsOf(await listMessages(flow.session.id));
+    const implementerTurn = rows[flow.ordinal - 1];
+    if (!/^\s*@用户\s+handoff/mu.test(implementerTurn?.content ?? "")) {
+      blocked.push("adjudicate: the implementer did not end with a line-leading @用户 handoff "
+        + `(replied: ${JSON.stringify((implementerTurn?.content ?? "").slice(0, 160))}); the `
+        + "relay continues without a human pause this round");
+      this.skip();
+    }
+    // The pause, asserted as an absence over a window: nobody may be dispatched while the round
+    // waits on the human (same technique as domain-multi-agent-human-decision.e2e.mjs).
+    const before = assistantsOf(await listMessages(flow.session.id)).length;
+    const dispatchedAnyway = await globalThis.browser.waitUntil(async () => {
+      const current = assistantsOf(await listMessages(flow.session.id).catch(() => []));
+      return current.length > before ? current[before] : false;
+    }, { timeout: 30_000, interval: 3_000, timeoutMsg: "" }).catch(() => null);
+    assert.equal(
+      dispatchedAnyway,
+      null,
+      "the round continued while it was meant to be waiting on the human "
+        + `(a turn belongs to ${JSON.stringify(dispatchedAnyway?.speakerSeatId ?? null)})`,
+    );
+    await snap("2b-handoff-pause");
+
+    // The human's adjudication: a line-leading mention hands the turn to the reviewer seat.
+    await invoke(({ core }, payload) => core.invoke("send_message", payload), {
+      sessionId: flow.session.id,
+      content: `@${flow.handles[2]} 人类裁决:实现说明已确认,请按原始分工第3条开始审查。`,
+      config: {
+        agentId: flow.session.agentId,
+        interactionMode: "cli",
+        executionMode: "inherit",
+        providerId: null,
+        modelId: null,
+        reasoningDepth: null,
+        streaming: true,
+        thinking: false,
+        longContext: false,
+      },
+      fileReferences: null,
+    });
+  });
+
+  globalThis.it("the 代码审查 sends one concrete rework item back", async function review() {
+    this.timeout(STAGE_BUDGET_MS * 2 + 120_000);
+    if (flow.failed) this.skip();
+    const turn = await relayTurn("reviewer", flow.seats[2], flow.handles[2]);
+    await snap("3-reviewer");
+    if (!turn) bail(this);
+    assert.ok(
+      /diagnostics|about|test|i18n|copy/iu.test(turn.content),
+      `the review does not reference the feature's files (got ${JSON.stringify(turn.content.slice(0, 200))})`,
+    );
+  });
+
+  globalThis.it("the rework lands and the project's own toolchain accepts the feature", async function rework() {
+    this.timeout(STAGE_BUDGET_MS * 2 + 15 * 60 * 1000);
+    if (flow.failed) this.skip();
+    const turn = await relayTurn("rework", flow.seats[1], flow.handles[1]);
+    await snap("4-rework");
+    if (!turn) bail(this);
+
+    await globalThis.browser.waitUntil(async () => {
+      const current = assistantsOf(await listMessages(flow.session.id).catch(() => []));
+      return current.every((row) => ["completed", "failed", "cancelled"].includes(row.status))
+        ? current.length
+        : false;
+    }, {
+      timeout: STAGE_BUDGET_MS,
+      interval: 5_000,
+      timeoutMsg: "the round never settled: some turn is still streaming",
+    });
+
+    const rows = assistantsOf(await listMessages(flow.session.id));
+    // Failed-and-retried turns stay in the thread, so the mandated relay is asserted over the
+    // COMPLETED turns' prefix rather than raw row positions.
+    const completedSpeakers = rows
+      .filter((row) => row.status === "completed")
+      .map((row) => row.speakerSeatId);
+    assert.deepEqual(
+      completedSpeakers.slice(0, 4),
+      [flow.seats[0], flow.seats[1], flow.seats[2], flow.seats[1]].map((seat) => seat.seatId),
+      "the completed turns do not begin with the relay 架构师 → 实现者 → 代码审查 → 实现者",
+    );
+    const known = new Set(flow.seats.map((seat) => seat.seatId));
+    assert.ok(
+      rows.every((row) => known.has(row.speakerSeatId)),
+      "a turn in the thread belongs to no seated participant",
+    );
+
+    await snap("5-round-complete");
+    const failures = await judge();
+    assert.deepEqual(failures, [], `acceptance criteria failed:\n  ${failures.join("\n  ")}`);
+
+    await run("git", ["add", "-A"], { cwd: target.dest });
+    await run("git", [
+      "-c", "user.name=VaneHub Multi-Agent E2E",
+      "-c", "user.email=desktop-e2e@example.invalid",
+      "commit", "-m", "feat: add copy-diagnostics action to Settings About page\n\n"
+        + "Produced by a VaneHub AI three-seat multi-agent session (codex architect,\n"
+        + "claude implementer, opencode reviewer); accepted by the project toolchain\n"
+        + "run mechanically by the desktop e2e harness.",
+    ], { cwd: target.dest });
+
+    const resultDir = globalThis.process.env.VANEHUB_DESKTOP_RESULT_DIR;
+    if (resultDir) {
+      const { stdout: diff } = await run("git", ["show", "--stat", "-p", "HEAD"], { cwd: target.dest });
+      await writeFile(join(resultDir, "longrun-feature.patch"), diff);
+      await writeFile(join(resultDir, "longrun-thread.json"), `${JSON.stringify({
+        branch: target.branch,
+        worktree: target.dest,
+        thread: (await listMessages(flow.session.id)).map((row) => ({
+          role: row.role,
+          speakerSeatId: row.speakerSeatId ?? null,
+          status: row.status ?? null,
+          createdAt: row.createdAt ?? null,
+          content: row.content,
+        })),
+      }, null, 2)}\n`);
+    }
+  });
+
+  globalThis.after(async () => {
+    if (flow.session) {
+      await invoke(({ core }, id) => core.invoke("stop_generation", { sessionId: id }), flow.session.id)
+        .catch(() => {});
+      if (!flow.failed && globalThis.process?.env?.VANEHUB_DESKTOP_KEEP_SESSIONS !== "1") {
+        await invoke(({ core }, id) => core.invoke("delete_session", { sessionId: id }), flow.session.id)
+          .catch(() => {});
+      }
+    }
+    if (target) {
+      globalThis.console.warn(`Task worktree kept for review: ${target.dest} (branch ${target.branch})`);
+    }
+    if (blocked.length > 0) {
+      globalThis.console.warn(`BLOCKED on this host:\n  ${blocked.join("\n  ")}`);
+    }
+  });
+});

--- a/tests/desktop/specs-multi-agent-longrun/develop-copy-diagnostics.e2e.mjs
+++ b/tests/desktop/specs-multi-agent-longrun/develop-copy-diagnostics.e2e.mjs
@@ -150,6 +150,41 @@ function bail(context) {
   context.skip();
 }
 
+/** The harness speaking as the human: one message into the session. */
+async function sendHuman(content) {
+  await invoke(({ core }, payload) => core.invoke("send_message", payload), {
+    sessionId: flow.session.id,
+    content,
+    config: {
+      agentId: flow.session.agentId,
+      interactionMode: "cli",
+      executionMode: "inherit",
+      providerId: null,
+      modelId: null,
+      reasoningDepth: null,
+      streaming: true,
+      thinking: false,
+      longContext: false,
+    },
+    fileReferences: null,
+  });
+}
+
+/**
+ * A seat may end on a blocking handoff the script did not plan for — a reviewer once escalated
+ * an OpenSpec-process question to the human, and per the routing rules that pause wins over the
+ * teammate mention in the same reply. Answer it and hand the turn to `handle` so the relay
+ * continues instead of timing out.
+ */
+async function answerUnplannedHandoff(handle) {
+  const rows = assistantsOf(await listMessages(flow.session.id).catch(() => []));
+  const last = rows[flow.ordinal - 1];
+  if (!/^\s*@用户\s+handoff/mu.test(last?.content ?? "")) return;
+  blocked.push(`unplanned handoff answered: routed to @${handle}`);
+  await sendHuman(`@${handle} 人类裁决:流程类事项(如 OpenSpec 提案)本轮豁免,由外部系统另行处理;`
+    + "请按审查中标记为必须修的意见继续返工,不要再等待人类。");
+}
+
 /** A stage snapshot beside the wdio evidence, so the visible run leaves visible proof. */
 async function snap(tag) {
   const resultDir = globalThis.process.env.VANEHUB_DESKTOP_RESULT_DIR;
@@ -419,6 +454,19 @@ globalThis.describe("VaneHub AI multi-Agent develops a large-granularity feature
       /buildAboutDiagnostics/u.test(turn.content),
       `the design never names buildAboutDiagnostics (got ${JSON.stringify(turn.content.slice(0, 200))})`,
     );
+
+    // The transcript on screen must show this backend-originated conversation — the requirement
+    // message and the seat's reply were injected over IPC, not typed into the composer
+    // (fix-chat-transcript-backend-message-updates). message-speaker is MessageItem's speaker
+    // label testid.
+    await globalThis.browser.waitUntil(async () => {
+      const speakers = await globalThis.$$('[data-testid="message-speaker"]');
+      return speakers.length >= 1;
+    }, {
+      timeout: 30_000,
+      interval: 2_000,
+      timeoutMsg: "the open transcript never rendered the backend-originated turns",
+    });
   });
 
   globalThis.it("the 实现者 builds the feature across files", async function implement() {
@@ -458,22 +506,7 @@ globalThis.describe("VaneHub AI multi-Agent develops a large-granularity feature
     await snap("2b-handoff-pause");
 
     // The human's adjudication: a line-leading mention hands the turn to the reviewer seat.
-    await invoke(({ core }, payload) => core.invoke("send_message", payload), {
-      sessionId: flow.session.id,
-      content: `@${flow.handles[2]} 人类裁决:实现说明已确认,请按原始分工第3条开始审查。`,
-      config: {
-        agentId: flow.session.agentId,
-        interactionMode: "cli",
-        executionMode: "inherit",
-        providerId: null,
-        modelId: null,
-        reasoningDepth: null,
-        streaming: true,
-        thinking: false,
-        longContext: false,
-      },
-      fileReferences: null,
-    });
+    await sendHuman(`@${flow.handles[2]} 人类裁决:实现说明已确认,请按原始分工第3条开始审查。`);
   });
 
   globalThis.it("the 代码审查 sends one concrete rework item back", async function review() {
@@ -491,6 +524,7 @@ globalThis.describe("VaneHub AI multi-Agent develops a large-granularity feature
   globalThis.it("the rework lands and the project's own toolchain accepts the feature", async function rework() {
     this.timeout(STAGE_BUDGET_MS * 2 + 15 * 60 * 1000);
     if (flow.failed) this.skip();
+    await answerUnplannedHandoff(flow.handles[1]);
     const turn = await relayTurn("rework", flow.seats[1], flow.handles[1]);
     await snap("4-rework");
     if (!turn) bail(this);

--- a/tests/desktop/specs-multi-agent-requirement/remove-about-preview.e2e.mjs
+++ b/tests/desktop/specs-multi-agent-requirement/remove-about-preview.e2e.mjs
@@ -1,0 +1,348 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const invoke = (fn, ...args) => globalThis.browser.tauri.execute(fn, ...args);
+const blocked = [];
+const stamp = Date.now().toString(36);
+
+/**
+ * A REAL product requirement carried end to end by a two-seat group chat: the codex-cli 架构师
+ * designs, the claude-code 实现者 edits, and the change lands in a disposable git worktree of
+ * THIS repository — "settings → about: remove the Preview badge".
+ *
+ * What distinguishes this from `domain-multi-agent-project.e2e.mjs` is the workspace: not a
+ * synthetic fixture repo, but the product's own source tree, so the implementer has to locate
+ * `about-page.tsx` / `about-service.ts` among thousands of files from the requirement text alone.
+ *
+ * Host findings inherited from the business/project specs: codex-cli takes the words-only seat
+ * (its sandbox cannot start under `apparmor_restrict_unprivileged_userns=1`, and an architect
+ * does not need write access anyway); claude-code runs the `trusted` template (projects to
+ * acceptEdits — file writes auto-approved, commands not), so the seats are told to write files
+ * and never run commands. Lint and review are the harness's job, done after the round.
+ *
+ * The judge is mechanical and spelled out verbatim in the requirement message, so a completed
+ * round that fails it is the collaboration failing, not the test guessing at intent.
+ */
+const DUO = ["codex-cli", "claude-code"];
+const ROLES = ["builtin-architect", "builtin-implementer"];
+const STAGE_BUDGET_MS = 6 * 60 * 1000;
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+// tests/desktop/specs-multi-agent-requirement → the checkout that owns this spec.
+const repoRoot = path.resolve(specDir, "..", "..", "..");
+
+async function settleOperation(operation, timeoutMsg) {
+  const settled = await globalThis.browser.waitUntil(async () => {
+    const status = await invoke(
+      ({ core }, operationId) => core.invoke("get_operation_status", { operationId }),
+      operation.id,
+    );
+    return ["succeeded", "failed", "cancelled"].includes(status.status) ? status : false;
+  }, { timeout: 90_000, timeoutMsg });
+  assert.equal(settled.status, "succeeded", settled.error ?? timeoutMsg);
+  return settled;
+}
+
+/** A throwaway worktree of this repository, branched off main, for the seats to edit. */
+async function createTargetWorktree() {
+  const dest = join(await mkdtemp(join(tmpdir(), "vanehub-agent-task-")), "repo");
+  const branch = `agents/remove-about-preview-${stamp}`;
+  await run("git", ["worktree", "add", dest, "-b", branch, "main"], { cwd: repoRoot });
+  return { dest, branch };
+}
+
+let target = null;
+const flow = { session: null, seats: [], handles: [], failed: false };
+
+const listMessages = (sessionId) => invoke(({ core }, id) => core.invoke("list_messages", {
+  sessionId: id,
+  limit: null,
+  beforeId: null,
+}), sessionId);
+
+const assistantsOf = (messages) => messages.filter((message) => message.role === "assistant");
+
+/** Everything the runtime knows about the session, written beside the wdio evidence. */
+async function dumpDiagnostics(tag) {
+  const resultDir = globalThis.process.env.VANEHUB_DESKTOP_RESULT_DIR;
+  if (!resultDir || !flow.session) return;
+  const capture = {};
+  capture.messages = await listMessages(flow.session.id).catch((error) => String(error));
+  capture.details = await invoke(
+    ({ core }, id) => core.invoke("get_session_details", { sessionId: id }),
+    flow.session.id,
+  ).catch((error) => String(error));
+  capture.logs = await invoke(({ core }, id) => core.invoke("list_session_logs", {
+    input: { sessionId: id, levels: ["error", "warn", "info", "debug"], search: "", cursor: null, limit: 500 },
+  }), flow.session.id).catch((error) => String(error));
+  await writeFile(
+    join(resultDir, `diagnostics-${tag}.json`),
+    `${JSON.stringify(capture, null, 2)}\n`,
+  ).catch(() => {});
+}
+
+async function turnAt(stage, ordinal, seat, handle) {
+  const row = await globalThis.browser.waitUntil(async () => {
+    const rows = assistantsOf(await listMessages(flow.session.id));
+    return rows.length > ordinal ? rows[ordinal] : false;
+  }, {
+    timeout: STAGE_BUDGET_MS,
+    interval: 3_000,
+    timeoutMsg: `turn ${ordinal} (${handle}) was never dispatched`,
+  }).catch(() => null);
+  if (!row) {
+    const rows = assistantsOf(await listMessages(flow.session.id));
+    const previous = rows[ordinal - 1];
+    if (previous && !(previous.content ?? "").includes(`@${handle}`)) {
+      blocked.push(`${stage}: the previous turn did not emit @${handle}, so the relay had `
+        + `nothing to act on (it replied: ${JSON.stringify((previous.content ?? "").slice(0, 160))})`);
+      return null;
+    }
+    flow.failed = true;
+    assert.fail(`turn ${ordinal} for @${handle} (${seat.agentId}) was never dispatched`);
+  }
+  assert.equal(row.speakerSeatId, seat.seatId, `turn ${ordinal} belongs to a seat other than @${handle}`);
+  const settled = await globalThis.browser.waitUntil(async () => {
+    const current = assistantsOf(await listMessages(flow.session.id))[ordinal];
+    return ["completed", "failed", "cancelled"].includes(current?.status) ? current : false;
+  }, {
+    timeout: STAGE_BUDGET_MS,
+    interval: 3_000,
+    timeoutMsg: `turn ${ordinal} (${handle}) never settled`,
+  }).catch(() => null);
+  if (!settled || settled.status !== "completed" || !settled.content.trim()) {
+    blocked.push(`${stage}: the ${seat.agentId} turn ended ${settled?.status ?? "never"} `
+      + `(${JSON.stringify((settled?.error ?? settled?.content ?? "").slice(0, 160))}); that `
+      + "seat's runtime failed, not the relay");
+    await dumpDiagnostics(`${stage}-turn-${ordinal}`);
+    return null;
+  }
+  return settled;
+}
+
+function bail(context) {
+  flow.failed = true;
+  context.skip();
+}
+
+/** The mechanical acceptance criteria the requirement message promises the seats. */
+async function judge() {
+  const failures = [];
+  const { stdout: porcelain } = await run("git", ["status", "--porcelain"], { cwd: target.dest });
+  if (!porcelain.trim()) failures.push("the worktree has no changes at all");
+  if (!porcelain.includes("src/settings/pages/about-page.tsx")) {
+    failures.push("src/settings/pages/about-page.tsx was not modified");
+  }
+  const aboutPage = await readFile(join(target.dest, "src/settings/pages/about-page.tsx"), "utf8");
+  if (aboutPage.includes("aboutBuildChannel")) failures.push("about-page.tsx still references aboutBuildChannel");
+  if (aboutPage.includes("Preview")) failures.push('about-page.tsx still contains a hardcoded "Preview"');
+  const aboutService = await readFile(join(target.dest, "src/services/about-service.ts"), "utf8");
+  if (aboutService.includes('"Preview"')) failures.push('about-service.ts still contains "Preview"');
+  return failures;
+}
+
+globalThis.describe("VaneHub AI multi-Agent delivers a real product requirement", () => {
+  globalThis.before(async function prepare() {
+    this.timeout(180_000);
+    const root = await globalThis.$("#root");
+    await root.waitForExist({ timeout: 120_000 });
+    await globalThis.browser.waitUntil(
+      async () => (await root.getAttribute("data-vanehub-bootstrap")) === "ready",
+      { timeout: 120_000, timeoutMsg: "React bootstrap did not become ready." },
+    );
+    target = await createTargetWorktree();
+  });
+
+  globalThis.it("seats the duo and the 架构师 designs the removal", async function architect() {
+    this.timeout(STAGE_BUDGET_MS * 2 + 180_000);
+    // Wait out the startup detection refresh: creating the session while probes are still
+    // running raced the runtime on the first honest run of this file.
+    const lineupAgents = await globalThis.browser.waitUntil(async () => {
+      // A transient list_agents failure during the startup refresh must read as "not yet",
+      // not abort the whole wait — waitUntil rethrows a throwing condition immediately.
+      const agents = await invoke(({ core }) => core.invoke("list_agents", { capabilityTag: null }))
+        .catch(() => null);
+      if (!Array.isArray(agents)) return false;
+      const lineup = DUO.map((id) => agents.find((agent) => agent.id === id
+        && agent.availabilityState === "available"
+        && agent.supportedInteractionModes.includes("cli")));
+      return lineup.every(Boolean) ? lineup : false;
+    }, { timeout: 120_000, interval: 3_000, timeoutMsg: "codex-cli/claude-code never became available" })
+      .catch(() => null);
+    if (!lineupAgents) {
+      const resultDir = globalThis.process.env.VANEHUB_DESKTOP_RESULT_DIR;
+      const snapshot = await invoke(({ core }) => core.invoke("list_agents", { capabilityTag: null }))
+        .catch((error) => String(error));
+      if (resultDir) {
+        await writeFile(join(resultDir, "diagnostics-list-agents.json"), `${JSON.stringify(
+          Array.isArray(snapshot)
+            ? snapshot.filter((agent) => DUO.includes(agent.id))
+            : snapshot,
+          null,
+          2,
+        )}\n`).catch(() => {});
+      }
+      blocked.push(`requirement flow: ${DUO.join(", ")} not both installed/usable on this host`);
+      bail(this);
+    }
+    const roles = await invoke(({ core }) => core.invoke("list_expert_roles"));
+    const seatRoles = ROLES.map((id) => roles.find((role) => role.id === id)).filter(Boolean);
+    if (seatRoles.length < 2) {
+      blocked.push("requirement flow: built-in architect/implementer roles are unavailable");
+      bail(this);
+    }
+    await invoke(({ core }, input) => core.invoke("apply_policy_template", { input }), {
+      agentId: "claude-code",
+      template: "trusted",
+    });
+
+    const title = `multiagent-requirement-${stamp}`;
+    const operation = await invoke(({ core }, input) => core.invoke("create_session", { input }), {
+      agentId: lineupAgents[0].id,
+      interactionMode: "cli",
+      title,
+      folder: target.dest,
+      projectPath: target.dest,
+      remoteWorkspace: null,
+      worktree: null,
+    });
+    await settleOperation(operation, "Creating the requirement session never settled.");
+    const created = await globalThis.browser.waitUntil(async () => {
+      const sessions = await invoke(({ core }) => core.invoke("list_sessions"));
+      return sessions.find((item) => item.title === title) ?? false;
+    }, { timeout: 30_000, timeoutMsg: "The requirement session was not created." });
+
+    flow.session = await invoke(({ core }, input) => core.invoke("update_session_seats", { input }), {
+      sessionId: created.id,
+      expectedUpdatedAt: created.updatedAt,
+      seats: lineupAgents.map((agent, index) => ({ agentId: agent.id, roleId: seatRoles[index].id })),
+    });
+    flow.seats = flow.session.seats.filter((seat) => !seat.leftAt);
+    flow.handles = seatRoles.map((role) => role.displayName.split(/\s+/u).filter(Boolean).join("-"));
+    assert.deepEqual(flow.seats.map((seat) => seat.agentId), DUO);
+
+    // The real requirement, with the judge's criteria quoted verbatim so a completed round that
+    // fails them is a collaboration failure, not a moving goalpost.
+    await invoke(({ core }, payload) => core.invoke("send_message", payload), {
+      sessionId: flow.session.id,
+      content: [
+        `@${flow.handles[0]} 真实产品需求:当前仓库是 VaneHub AI 桌面应用的源码。`,
+        "「设置 → 关于」页面标题旁有一个绿色的 \"Preview\" 徽标,产品决定将它移除。分工与纪律:",
+        "",
+        "1. 架构师(你):只做设计,不改代码。先定位相关源文件,给出改动方案:要删/改哪些代码、",
+        "   因此不再被使用的常量或文案如何清理、「发布通道」信息行如何处理,并说明取舍。",
+        `   方案写完后,最后单独起一行、只写 @${flow.handles[1]}。`,
+        "2. 实现者:你拥有仓库文件写权限,但没有命令执行权限。按方案直接修改文件,不要征求确认,",
+        "   也不要运行任何命令——lint 与测试由外部系统执行。外部系统的验收标准(逐字执行):",
+        "   a) src/settings/pages/about-page.tsx 中不再出现 aboutBuildChannel,也不再出现 Preview 字样;",
+        "   b) src/services/about-service.ts 中不再出现 \"Preview\" 字符串;",
+        "   c) 不留下未使用的导入或导出常量。",
+        `   改完说明动了哪些文件与原因,然后最后单独起一行、只写 @用户 done。`,
+      ].join("\n"),
+      config: {
+        agentId: flow.session.agentId,
+        interactionMode: "cli",
+        executionMode: "inherit",
+        providerId: null,
+        modelId: null,
+        reasoningDepth: null,
+        streaming: true,
+        thinking: false,
+        longContext: false,
+      },
+      fileReferences: null,
+    });
+
+    const turn = await turnAt("architect", 0, flow.seats[0], flow.handles[0]);
+    if (!turn) bail(this);
+    // A design that never names the badge's home has not located the work; the implementer would
+    // be starting the search over, which is the architect seat failing its half of the split.
+    assert.ok(
+      /about/iu.test(turn.content),
+      `the design never mentions the about page (got ${JSON.stringify(turn.content.slice(0, 200))})`,
+    );
+  });
+
+  globalThis.it("the 实现者 lands the change and the acceptance criteria hold", async function implement() {
+    this.timeout(STAGE_BUDGET_MS * 2 + 120_000);
+    if (flow.failed) this.skip();
+    const turn = await turnAt("implementer", 1, flow.seats[1], flow.handles[1]);
+    if (!turn) bail(this);
+
+    const failures = await judge();
+    assert.deepEqual(failures, [], `acceptance criteria failed:\n  ${failures.join("\n  ")}\n`
+      + `implementer's completed turn said: ${JSON.stringify(turn.content.slice(0, 400))}`);
+  });
+
+  globalThis.it("the round closes and the harness records the evidence", async function close() {
+    this.timeout(STAGE_BUDGET_MS + 120_000);
+    if (flow.failed) this.skip();
+    await globalThis.browser.waitUntil(async () => {
+      const current = assistantsOf(await listMessages(flow.session.id));
+      return current.every((row) => ["completed", "failed", "cancelled"].includes(row.status))
+        ? current.length
+        : false;
+    }, {
+      timeout: STAGE_BUDGET_MS,
+      interval: 3_000,
+      timeoutMsg: "the round never settled: some turn is still streaming",
+    });
+    const rows = assistantsOf(await listMessages(flow.session.id));
+    const known = new Set(flow.seats.map((seat) => seat.seatId));
+    assert.ok(
+      rows.every((row) => known.has(row.speakerSeatId)),
+      "a turn in the thread belongs to no seated participant",
+    );
+
+    // Commit on the task branch so the run's outcome survives worktree cleanup and can be
+    // reviewed or cherry-picked by a human afterwards.
+    await run("git", ["add", "-A"], { cwd: target.dest });
+    await run("git", [
+      "-c", "user.name=VaneHub Multi-Agent E2E",
+      "-c", "user.email=desktop-e2e@example.invalid",
+      "commit", "-m", "feat: remove Preview badge from Settings About page\n\n"
+        + "Produced by a VaneHub AI multi-agent session: codex-cli architect designed,\n"
+        + "claude-code implementer edited; acceptance judged mechanically by the harness.",
+    ], { cwd: target.dest });
+
+    const resultDir = globalThis.process.env.VANEHUB_DESKTOP_RESULT_DIR;
+    if (resultDir) {
+      const { stdout: diff } = await run("git", ["show", "--stat", "-p", "HEAD"], { cwd: target.dest });
+      await writeFile(join(resultDir, "multi-agent-requirement.patch"), diff);
+      await writeFile(join(resultDir, "multi-agent-thread.json"), `${JSON.stringify({
+        branch: target.branch,
+        worktree: target.dest,
+        thread: (await listMessages(flow.session.id)).map((row) => ({
+          role: row.role,
+          speakerSeatId: row.speakerSeatId ?? null,
+          status: row.status ?? null,
+          content: row.content,
+        })),
+      }, null, 2)}\n`);
+    }
+  });
+
+  globalThis.after(async () => {
+    if (flow.session) {
+      await invoke(({ core }, id) => core.invoke("stop_generation", { sessionId: id }), flow.session.id)
+        .catch(() => {});
+      if (!flow.failed && globalThis.process?.env?.VANEHUB_DESKTOP_KEEP_SESSIONS !== "1") {
+        await invoke(({ core }, id) => core.invoke("delete_session", { sessionId: id }), flow.session.id)
+          .catch(() => {});
+      }
+    }
+    if (target) {
+      globalThis.console.warn(`Task worktree kept for review: ${target.dest} (branch ${target.branch})`);
+    }
+    if (blocked.length > 0) {
+      globalThis.console.warn(`BLOCKED on this host:\n  ${blocked.join("\n  ")}`);
+    }
+  });
+});

--- a/tests/desktop/wdio.multi-agent-longrun.conf.mjs
+++ b/tests/desktop/wdio.multi-agent-longrun.conf.mjs
@@ -6,3 +6,9 @@ import { createDesktopConfig } from "./wdio-shared.mjs";
 export const config = await createDesktopConfig({
   specDirectory: "specs-multi-agent-longrun",
 });
+
+// A real seat turn routinely runs past the shared 300s mocha cap (a rework that rewrites tests
+// takes minutes on its own, and the toolchain judge runs after it) — and per-test
+// `this.timeout()` does not take effect under this wdio/mocha combination. Give every stage the
+// spec's worst-case budget at the framework level instead.
+config.mochaOpts = { ...config.mochaOpts, timeout: 45 * 60 * 1000 };

--- a/tests/desktop/wdio.multi-agent-longrun.conf.mjs
+++ b/tests/desktop/wdio.multi-agent-longrun.conf.mjs
@@ -1,0 +1,8 @@
+import { createDesktopConfig } from "./wdio-shared.mjs";
+
+// Long-running large-granularity rehearsal: a three-seat group chat (codex-cli 架构师 →
+// claude-code 实现者 → opencode 代码审查 → 实现者 rework) develops a real multi-file feature
+// against a worktree of this repository. Real CLIs, real model calls, mechanical judging.
+export const config = await createDesktopConfig({
+  specDirectory: "specs-multi-agent-longrun",
+});

--- a/tests/desktop/wdio.multi-agent-requirement.conf.mjs
+++ b/tests/desktop/wdio.multi-agent-requirement.conf.mjs
@@ -1,0 +1,13 @@
+import { createDesktopConfig } from "./wdio-shared.mjs";
+
+// A real-requirement rehearsal layer: two seats (codex-cli 架构师 → claude-code 实现者) drive an
+// actual product change against a disposable worktree of this repository, and the harness — not
+// the Agents — judges the result. Uses the plain host PATH: the seats must be the real CLIs.
+//
+// Opt-in only, never part of `all`: it spends real model tokens and needs both CLIs authenticated
+// on the host. When running beside another desktop e2e session on the same machine, export BOTH
+// VANEHUB_WEBDRIVER_PORT and TAURI_WEBDRIVER_PORT to a private port — the tauri service's
+// direct-eval channel (browser.tauri.execute) reads only the latter and defaults to 4445.
+export const config = await createDesktopConfig({
+  specDirectory: "specs-multi-agent-requirement",
+});

--- a/tests/desktop/wdio.multi-agent-requirement.conf.mjs
+++ b/tests/desktop/wdio.multi-agent-requirement.conf.mjs
@@ -11,3 +11,8 @@ import { createDesktopConfig } from "./wdio-shared.mjs";
 export const config = await createDesktopConfig({
   specDirectory: "specs-multi-agent-requirement",
 });
+
+// Real model turns can exceed the shared 300s mocha cap, and per-test `this.timeout()` does not
+// take effect under this wdio/mocha combination; raise the framework-level cap to the layer's
+// worst-case stage budget.
+config.mochaOpts = { ...config.mochaOpts, timeout: 25 * 60 * 1000 };


### PR DESCRIPTION
## Summary

This PR lands the results of an end-to-end verification campaign that drove VaneHub's multi-agent group chat with **real CLI seats** (codex-cli architect, claude-code implementer/reviewer) through WebdriverIO against the desktop client, fixed the two product defects the campaign uncovered, and adds the campaign itself as two opt-in desktop test layers.

### Product fixes (each backed by an OpenSpec change)

- **`fix: drop oversized provider output records instead of failing the turn`** (`harden-provider-output-oversized-records`)
  A single stream-json record larger than the parser bound — e.g. a claude-code tool result carrying a big file read — used to fail the whole generation and kill a seat turn mid-work. The framer now drops the oversized record through its terminating newline and keeps parsing; drops are counted and reported to unified logs as a `warn` after the stream ends. The read loop's bound moves from a hardcoded 256 KiB to the parser-policy domain maximum (1 MiB). Malformed UTF-8 still fails closed. Includes the architecture line-budget raise with its reason recorded, per the guard's protocol.

- **`fix: render backend-originated messages in the open chat transcript`** (`fix-chat-transcript-backend-message-updates`)
  Messages created outside the composer (programmatic send over the service boundary, IM, seat turns dispatched by the coordinator) never appeared in the open transcript: stream events can only mutate cache rows and nothing refetched the list. Both subscription points now refetch when events target an unknown message id, plus one settle-time parity refetch; the main-layout subscription is extracted into `use-session-stream-events.ts`.

### Test infrastructure

- **`test: add opt-in multi-agent desktop layers driving real CLI seats`** — two WDIO layers, never part of `all` (they spend real model tokens and need authenticated CLIs):
  - `desktop-multi-agent-requirement`: two seats carry a small real product change against a disposable worktree; the harness judges mechanically and commits to a task branch.
  - `desktop-multi-agent-longrun`: a three-seat feature build (design → implement → review → rework) judged by the project's own toolchain, with `VANEHUB_LONGRUN_ADJUDICATION=human|auto` selecting between a blocking `@用户 handoff` human-adjudication relay (default; the harness verifies the round actually pauses) and an unattended relay.
- **`test: harden the multi-agent longrun layer for real-length turns`** — per-layer mocha timeout (real turns outrun the shared 300s cap and per-test `this.timeout()` is inert under this wdio/mocha combination), an answer path for unplanned blocking handoffs, and the on-screen transcript assertion that regression-checks the rendering fix.

## Validation

- Full AGENTS.md command set green: `lint:ci`, `npm test`, `npm run build`, `cargo fmt --check`, `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `native:panic:check`, `cargo test --workspace`, `openspec validate --specs --strict`, plus `--strict` validation of both changes.
- `npx playwright test`: 155/156, the single multi-agent-session failure reproduced as a load flake and passes 5/5 in isolation.
- Live desktop verification: the longrun layer completed 5/5 green (9m52s) with the human-adjudication pause verified and the transcript assertion passing; per-stage screenshots archived in the run evidence.

## Notes for reviewers

- The two OpenSpec changes are included under `openspec/changes/`; `harden-provider-output-oversized-records` has one open task (wire the bound to the per-provider `ProviderParserPolicy` instead of a constant).
- Campaign findings that are environmental rather than VaneHub defects (opencode↔GLM gateway 400 on second-step Responses requests, intermittent in-app codex bwrap sandbox failures, debug-build OOM pressure under parallel cargo builds) are recorded in the change documents and test-layer comments, not patched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EyK86jiwHgpKBojLs7Jsn