### PR TITLE
test(skills): verify desktop agent effectiveness

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:desktop:session-workspace": "node scripts/test-desktop.mjs session-workspace",
     "test:desktop:dialogs": "node scripts/test-desktop.mjs dialogs",
     "test:desktop:settings-persistence": "node scripts/test-desktop.mjs settings-persistence",
+    "test:desktop:skills": "node scripts/test-desktop.mjs skills",
     "test:desktop": "node scripts/test-desktop.mjs all",
     "test:verify": "node scripts/test-verify.mjs",
     "test:coverage": "vitest run --coverage --maxWorkers=4 --testTimeout=15000",

--- a/scripts/desktop-orchestrator.node-test.mjs
+++ b/scripts/desktop-orchestrator.node-test.mjs
@@ -166,6 +166,18 @@ test("each desktop layer owns a disjoint spec directory and its own wdio configu
   assert.match(cliTerminal, /specDirectory: "specs-cli-terminal"/);
 });
 
+test("the live Skill layer is explicitly runnable without joining the deterministic full suite", async () => {
+  const orchestrator = await readFile("scripts/test-desktop.mjs", "utf8");
+  const { scripts } = JSON.parse(await readFile("package.json", "utf8"));
+  const config = await readFile("tests/desktop/wdio.skills.conf.mjs", "utf8");
+
+  assert.match(orchestrator, /mode === "skills"/);
+  assert.match(orchestrator, /function skillsDesktop\(artifact\)/);
+  assert.doesNotMatch(orchestrator, /fullSuiteLayers = \[[^\]]*skillsDesktop/);
+  assert.equal(scripts["test:desktop:skills"], "node scripts/test-desktop.mjs skills");
+  assert.match(config, /specDirectory: "specs-skills"/);
+});
+
 test("the CLI terminal layer resolves its fixture Agent instead of an installed one", async () => {
   const config = await readFile("tests/desktop/wdio.cli-terminal.conf.mjs", "utf8");
   const fixture = "tests/desktop/fixtures/cli/opencode";

--- a/scripts/test-desktop.mjs
+++ b/scripts/test-desktop.mjs
@@ -191,6 +191,15 @@ function settingsPersistenceDesktop(artifact) {
   });
 }
 
+function skillsDesktop(artifact) {
+  return runDesktopLayer({
+    layer: "desktop-skills",
+    config: "tests/desktop/wdio.skills.conf.mjs",
+    label: "Desktop Skills effectiveness",
+    artifact,
+  });
+}
+
 async function main() {
   const mode = process.argv[2] ?? "all";
   if (mode === "build") await buildDesktop();
@@ -199,6 +208,7 @@ async function main() {
   else if (mode === "session-workspace") await sessionWorkspaceDesktop();
   else if (mode === "dialogs") await dialogsDesktop();
   else if (mode === "settings-persistence") await settingsPersistenceDesktop();
+  else if (mode === "skills") await skillsDesktop();
   else if (mode === "all") {
     const artifact = await buildDesktop();
     const fullSuiteLayers = [smokeDesktop, cliTerminalDesktop, sessionWorkspaceDesktop, dialogsDesktop, settingsPersistenceDesktop];

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/process_adapter.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/process_adapter.rs
@@ -1,7 +1,7 @@
 use super::providers::{
-    add_codex_output_capture_args, output_parser_for_format, BoundedProviderLines,
-    ProviderOutputEvent, ProviderPromptDelivery, ProviderReportedUsage, ProviderToolEvent,
-    ProviderToolPhase, ProviderUsageOverlap,
+    add_codex_output_capture_args, add_opencode_directory_args, output_parser_for_format,
+    BoundedProviderLines, ProviderOutputEvent, ProviderPromptDelivery, ProviderReportedUsage,
+    ProviderToolEvent, ProviderToolPhase, ProviderUsageOverlap,
 };
 use crate::contexts::agent_runtime::application::{
     AgentClockPort, AgentLog, AgentLogLevel, AgentLoggingPort, AgentProcessEventSink,
@@ -219,6 +219,11 @@ impl RuntimeAgentProcessAdapter {
         } else {
             None
         };
+        if request.agent.id == "opencode" {
+            if let Some(folder) = request.session.folder.as_deref() {
+                add_opencode_directory_args(&mut spec.args, folder);
+            }
+        }
         let runner_spec = local_runner_launch_spec(
             &spec,
             Some(request.session.id.clone()),

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/invocation.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/invocation.rs
@@ -5,7 +5,6 @@ use crate::contexts::agent_runtime::application::{
 use crate::contexts::permissions::api::PolicyTemplateName;
 use crate::contexts::tooling::api::{CliParameterSelection, CliParameterSelectionMap};
 use std::fmt::{Display, Formatter};
-
 /// Managed CLI agents whose chat and terminal launches receive a final policy projection.
 pub(crate) const POLICY_TEMPLATE_GOVERNED_AGENT_IDS: [&str; 5] = [
     "claude-code",
@@ -14,7 +13,6 @@ pub(crate) const POLICY_TEMPLATE_GOVERNED_AGENT_IDS: [&str; 5] = [
     "opencode",
     "antigravity-cli",
 ];
-
 /// The two registry-declared placement slots, resolved by the Tooling CLI-parameter API. The
 /// provider grammar decides where each lands; the builder never inspects a token's spelling.
 #[derive(Debug, Clone, Copy, Default)]
@@ -22,12 +20,10 @@ pub(crate) struct ProviderLaunchSegments<'a> {
     pub(crate) global: &'a [String],
     pub(crate) invocation: &'a [String],
 }
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ProviderInvocationError {
     UnsupportedAgent(String),
 }
-
 impl Display for ProviderInvocationError {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -38,9 +34,7 @@ impl Display for ProviderInvocationError {
         }
     }
 }
-
 impl std::error::Error for ProviderInvocationError {}
-
 /// Builds an invocation, optionally placing a seat's role briefing in the CLI's own system-prompt
 /// channel.
 ///
@@ -84,7 +78,6 @@ pub(crate) fn build_invocation_with_role(
         },
     )
 }
-
 pub(crate) fn build_invocation(
     agent_id: &str,
     executable: String,
@@ -173,7 +166,6 @@ pub(crate) fn build_invocation(
         prompt_delivery,
     })
 }
-
 pub(crate) fn build_interactive_invocation(
     agent_id: &str,
     executable: String,
@@ -233,7 +225,6 @@ pub(crate) fn build_interactive_invocation(
         assigned_runtime_session_id,
     })
 }
-
 pub(crate) fn add_codex_output_capture_args(args: &mut Vec<String>, output_path: &str) {
     let insert_at = args
         .iter()
@@ -244,7 +235,13 @@ pub(crate) fn add_codex_output_capture_args(args: &mut Vec<String>, output_path:
         ["-o".to_string(), output_path.to_string()],
     );
 }
-
+pub(crate) fn add_opencode_directory_args(args: &mut Vec<String>, directory: &str) {
+    let insert_at = args.len().saturating_sub(1);
+    args.splice(
+        insert_at..insert_at,
+        ["--dir".to_string(), directory.to_string()],
+    );
+}
 /// Per-message overrides for ordinary parameters only. A message can govern model, reasoning
 /// depth, and opencode's thinking display; every other parameter stays absent so the saved profile
 /// decides. Policy-governed and runtime-reserved ids are never produced here.
@@ -260,7 +257,6 @@ pub(crate) fn message_override_selections(
     {
         overrides.insert("model".to_string(), CliParameterSelection::text(model));
     }
-
     if let Some(reasoning_depth) = configuration.reasoning_depth.as_deref() {
         match agent_id {
             "claude-code" => {
@@ -293,17 +289,14 @@ pub(crate) fn message_override_selections(
             _ => {}
         }
     }
-
     if agent_id == "opencode" {
         overrides.insert(
             "thinking".to_string(),
             CliParameterSelection::boolean(configuration.thinking),
         );
     }
-
     overrides
 }
-
 /// Projects an agent principal's assigned policy template onto the registry's policy-governed
 /// parameters. These values never come from a saved profile or a message: the resolver accepts
 /// them on a separate input and refuses a user-editable id on that path.

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/mod.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/mod.rs
@@ -6,9 +6,9 @@ mod session_capture;
 
 pub(crate) use crate::contexts::agent_runtime::application::ProviderPromptDelivery;
 pub(crate) use invocation::{
-    add_codex_output_capture_args, build_interactive_invocation, build_invocation_with_role,
-    message_override_selections, opencode_standard_permission_env_var, policy_override_selections,
-    ProviderLaunchSegments, POLICY_TEMPLATE_GOVERNED_AGENT_IDS,
+    add_codex_output_capture_args, add_opencode_directory_args, build_interactive_invocation,
+    build_invocation_with_role, message_override_selections, opencode_standard_permission_env_var,
+    policy_override_selections, ProviderLaunchSegments, POLICY_TEMPLATE_GOVERNED_AGENT_IDS,
 };
 pub(crate) use output::{
     output_parser_for_format, BoundedProviderLines, ProviderOutputEvent, ProviderOutputFramer,

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/providers/tests.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/providers/tests.rs
@@ -982,7 +982,6 @@ fn opencode_unsafe_step_identity_and_revision_are_not_retained() {
     assert_eq!(usage.source_identity, None);
     assert_eq!(usage.source_revision, None);
 }
-
 #[test]
 fn opencode_all_zero_usage_is_treated_as_absent() {
     let event = output_parser_for("opencode").parse_line(

--- a/src-tauri/src/contexts/tooling/skills/infrastructure/filesystem/mod.rs
+++ b/src-tauri/src/contexts/tooling/skills/infrastructure/filesystem/mod.rs
@@ -268,7 +268,8 @@ impl ManagedSkillFilesystem {
             let target =
                 self.paths
                     .mount_target(&record.key.location, &record.key.id, mount_path)?;
-            if paths_overlap(&source, &target) {
+            let already_mounted = is_managed_link(&target, &source);
+            if !already_mounted && paths_overlap(&source, &target) {
                 return Err(SkillApplicationError::Validation(format!(
                     "Skill mount target overlaps its managed source: {}",
                     target.display()
@@ -284,7 +285,7 @@ impl ManagedSkillFilesystem {
             let mut overwritten = Vec::new();
             let mut backed_up = Vec::new();
             if path_exists(&target) {
-                if is_managed_link(&target, &source) {
+                if already_mounted {
                     return Ok(repair_binding(
                         agent_id,
                         mount_path,
@@ -1376,6 +1377,41 @@ mod tests {
             std::fs::read_to_string(mounted.join("references/guide.md")).expect("mounted resource"),
             "Effective resource"
         );
+    }
+
+    #[test]
+    fn repairing_an_existing_managed_link_is_idempotent() {
+        let home = TempDirectory::new("Skill idempotent mount");
+        let filesystem = ManagedSkillFilesystem::with_home_root(home.path().to_path_buf());
+        let id = SkillId::parse("idempotent-mount").expect("Skill id");
+        let source_transaction = filesystem.begin_mutation().expect("source transaction");
+        let source = filesystem
+            .create_source(
+                &source_transaction,
+                &location(),
+                &id,
+                &document("idempotent-mount", "body"),
+            )
+            .expect("source");
+        filesystem.commit_mutation(source_transaction);
+        let stored = record("idempotent-mount", source);
+        let mount_path = SkillMountPath::parse(".codex/skills").expect("mount path");
+
+        for _ in 0..2 {
+            let transaction = filesystem.begin_mutation().expect("mount transaction");
+            let repair = filesystem
+                .repair_binding(&transaction, &stored, "codex-cli", &mount_path)
+                .expect("idempotent mount repair");
+            filesystem.commit_mutation(transaction);
+            assert!(repair.binding.mounted);
+            assert!(repair.overwritten.is_empty());
+            assert!(repair.backed_up.is_empty());
+        }
+
+        assert!(is_managed_link(
+            home.path().join(".codex/skills/idempotent-mount").as_path(),
+            Path::new(&stored.managed_source.skill_dir)
+        ));
     }
 
     #[test]

--- a/tests/desktop/specs-skills/skill-effectiveness.e2e.mjs
+++ b/tests/desktop/specs-skills/skill-effectiveness.e2e.mjs
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, realpath, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const invoke = (fn, ...args) => globalThis.browser.tauri.execute(fn, ...args);
+const CLI_AGENTS = ["claude-code", "codex-cli", "opencode"];
+const BUILTIN_ROLES = ["builtin-architect", "builtin-implementer", "builtin-reviewer"];
+const SKILL_ID = "desktop-skill-effectiveness";
+const SKILL_MARKER = "VANEHUB_SKILL_EFFECTIVENESS_MARKER_8F3C";
+const EXPECTED_REPLY = "VANEHUB_SKILL_ACTIVE_8F3C";
+const LOCAL_MODEL_ID = "skill-effectiveness-local-model";
+const LOCAL_PROFILE_NAME = "Skill effectiveness local model";
+const blocked = [];
+const sessions = [];
+
+const fixtureRoot = process.env.VANEHUB_APP_DATA_DIR
+  ? join(dirname(process.env.VANEHUB_APP_DATA_DIR), "fixtures")
+  : null;
+
+let workspace;
+let profileId = null;
+let localServer;
+let localBaseUrl;
+const localRequests = [];
+
+async function settleOperation(operation, timeoutMsg) {
+  const settled = await globalThis.browser.waitUntil(async () => {
+    const status = await invoke(
+      ({ core }, operationId) => core.invoke("get_operation_status", { operationId }),
+      operation.id,
+    );
+    return ["succeeded", "failed", "cancelled"].includes(status.status) ? status : false;
+  }, { timeout: 90_000, interval: 1_000, timeoutMsg });
+  assert.equal(settled.status, "succeeded", settled.error ?? timeoutMsg);
+}
+
+async function createRepository() {
+  if (!fixtureRoot) throw new Error("VANEHUB_APP_DATA_DIR is required for isolated Skill tests.");
+  await mkdir(fixtureRoot, { recursive: true });
+  const root = await mkdtemp(join(fixtureRoot, "skill-effectiveness-"));
+  await run("git", ["init"], { cwd: root });
+  await run("git", ["config", "user.email", "desktop-e2e@example.invalid"], { cwd: root });
+  await run("git", ["config", "user.name", "Desktop E2E"], { cwd: root });
+  await writeFile(join(root, "README.md"), "# Skill effectiveness fixture\n", "utf8");
+  await run("git", ["add", "README.md"], { cwd: root });
+  await run("git", ["commit", "-m", "fixture"], { cwd: root });
+  return realpath(root);
+}
+
+async function createSession(agentId, interactionMode, title) {
+  const operation = await invoke(({ core }, input) => core.invoke("create_session", { input }), {
+    agentId,
+    interactionMode,
+    title,
+    folder: workspace,
+    projectPath: workspace,
+    remoteWorkspace: null,
+    worktree: null,
+  });
+  await settleOperation(operation, `Creating ${title} never settled.`);
+  const session = await globalThis.browser.waitUntil(async () => {
+    const listed = await invoke(({ core }) => core.invoke("list_sessions"));
+    return listed.find((entry) => entry.title === title) ?? false;
+  }, { timeout: 30_000, interval: 500, timeoutMsg: `${title} was not created.` });
+  sessions.push(session.id);
+  return session;
+}
+
+const listMessages = (sessionId) => invoke(({ core }, id) => core.invoke("list_messages", {
+  sessionId: id,
+  limit: null,
+  beforeId: null,
+}), sessionId);
+
+async function sendAndAwaitReply(sessionId, agentId, interactionMode, content, speakerSeatId = null) {
+  const before = (await listMessages(sessionId)).filter((message) => message.role === "assistant");
+  await invoke(({ core }, payload) => core.invoke("send_message", payload), {
+    sessionId,
+    content,
+    config: {
+      agentId,
+      interactionMode,
+      executionMode: "inherit",
+      providerId: null,
+      modelId: null,
+      reasoningDepth: null,
+      streaming: true,
+      thinking: false,
+      longContext: false,
+    },
+    fileReferences: null,
+    runner: null,
+  });
+  const reply = await globalThis.browser.waitUntil(async () => {
+    const assistants = (await listMessages(sessionId)).filter((message) => message.role === "assistant");
+    const candidates = assistants.slice(before.length);
+    const current = speakerSeatId
+      ? candidates.find((message) => message.speakerSeatId === speakerSeatId)
+      : candidates[0];
+    return ["completed", "failed", "cancelled"].includes(current?.status) ? current : false;
+  }, {
+    timeout: 4 * 60_000,
+    interval: 2_000,
+    timeoutMsg: `${agentId} did not finish its Skill verification turn.`,
+  });
+  assert.equal(reply.status, "completed", reply.error ?? `${agentId} turn did not complete.`);
+  return reply;
+}
+
+async function startLocalModel() {
+  localServer = createServer((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      localRequests.push({ url: request.url, body });
+      if (request.url === "/v1/models") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ data: [{ id: LOCAL_MODEL_ID }] }));
+        return;
+      }
+      if (request.url === "/v1/chat/completions") {
+        const content = body.includes(SKILL_MARKER) ? EXPECTED_REPLY : "SKILL_NOT_INJECTED";
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        response.write(`data: ${JSON.stringify({ choices: [{ index: 0, delta: { content }, finish_reason: null }] })}\n\n`);
+        response.write(`data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 8, completion_tokens: 2, total_tokens: 10 } })}\n\n`);
+        response.end("data: [DONE]\n\n");
+        return;
+      }
+      response.writeHead(404);
+      response.end();
+    });
+  });
+  await new Promise((resolve, reject) => {
+    localServer.once("error", reject);
+    localServer.listen(0, "127.0.0.1", resolve);
+  });
+  const address = localServer.address();
+  assert.ok(address && typeof address !== "string", "The local model fixture did not bind.");
+  localBaseUrl = `http://127.0.0.1:${address.port}/v1`;
+}
+
+async function configureOnePiece() {
+  const profiles = await invoke(({ core }, input) => (
+    core.invoke("save_custom_onepiece_provider_profile", { input })
+  ), {
+    id: null,
+    name: LOCAL_PROFILE_NAME,
+    baseUrl: localBaseUrl,
+    modelId: LOCAL_MODEL_ID,
+    runtimeKind: "local",
+    authenticationMode: "none",
+    apiKey: null,
+    timeoutMs: 10_000,
+    privacyClassification: "local",
+    toolCallingCapability: "unsupported",
+    imageInputCapability: "unsupported",
+    structuredOutputCapability: "unknown",
+    reasoningFieldCapability: "unsupported",
+    contextWindowTokens: 8_192,
+    reservedOutputTokens: 1_024,
+  });
+  const profile = profiles.profiles.find((entry) => entry.name === LOCAL_PROFILE_NAME);
+  assert.equal(profile?.active, true, "The local OnePiece profile did not become active.");
+  profileId = profile.id;
+}
+
+async function createAndBindSkill() {
+  await invoke(({ core }, input) => core.invoke("create_skill", { input }), {
+    id: SKILL_ID,
+    scope: "workspace",
+    workspacePath: workspace,
+    metadata: {
+      id: SKILL_ID,
+      name: "Desktop Skill Effectiveness",
+      description: "Proves that a newly created Skill reaches an Agent runtime",
+      category: "testing",
+      version: "1.0.0",
+      triggers: [SKILL_ID],
+      type: "role",
+      delivery: "eager",
+    },
+    body: [
+      `Private verification marker: ${SKILL_MARKER}.`,
+      `When asked to use this Skill, reply with exactly ${EXPECTED_REPLY} and nothing else.`,
+    ].join("\n"),
+    enabled: true,
+    boundAgentIds: [],
+    source: "user",
+  });
+  const scope = { scope: "workspace", workspacePath: workspace };
+  for (const agentId of CLI_AGENTS) {
+    const bound = await invoke(({ core }, args) => core.invoke("bind_skill_to_cli_agent", args), {
+      skillId: SKILL_ID,
+      input: scope,
+      agentId,
+    });
+    const binding = bound.bindings.find((entry) => entry.agentId === agentId);
+    assert.equal(binding?.mounted, true, `${agentId} did not receive a Skill mount.`);
+  }
+  await invoke(({ core }, args) => core.invoke("bind_skill_to_api_agent", args), {
+    skillId: SKILL_ID,
+    input: scope,
+    agentId: "onepiece",
+  });
+}
+
+function handleFor(seat, roles, agents) {
+  return seat.roleSnapshot?.roleName
+    ?? roles.find((entry) => entry.id === seat.roleId)?.displayName
+    ?? seat.roleSnapshot?.agentName
+    ?? agents.find((entry) => entry.id === seat.agentId)?.displayName;
+}
+
+globalThis.describe("VaneHub AI desktop Skill effectiveness", () => {
+  globalThis.before(async () => {
+    const root = await globalThis.$("#root");
+    await root.waitForExist({ timeout: 120_000 });
+    await globalThis.browser.waitUntil(
+      async () => (await root.getAttribute("data-vanehub-bootstrap")) === "ready",
+      { timeout: 120_000, timeoutMsg: "React bootstrap did not become ready." },
+    );
+    workspace = await createRepository();
+    await startLocalModel();
+    await configureOnePiece();
+    await createAndBindSkill();
+  });
+
+  for (const agentId of CLI_AGENTS) {
+    globalThis.it(`applies a newly created Skill in a single ${agentId} session`, async function cliSkill() {
+      if (process.env.VANEHUB_DESKTOP_LIVE_AGENTS !== "1") {
+        blocked.push(`${agentId}: set VANEHUB_DESKTOP_LIVE_AGENTS=1 to run the installed CLI`);
+        this.skip();
+      }
+      const agents = await invoke(({ core }) => core.invoke("list_agents", { capabilityTag: null }));
+      const agent = agents.find((entry) => entry.id === agentId);
+      if (agent?.availabilityState !== "available") {
+        blocked.push(`${agentId}: ${agent?.unavailableReason ?? "Agent is unavailable"}`);
+        this.skip();
+      }
+      const session = await createSession(agentId, "cli", `Skill single ${agentId}`);
+      const reply = await sendAndAwaitReply(
+        session.id,
+        agentId,
+        "cli",
+        `Use the ${SKILL_ID} Skill and follow its response contract.`,
+      );
+      assert.match(reply.content, new RegExp(EXPECTED_REPLY),
+        `${agentId} replied without the private Skill marker: ${reply.content.slice(0, 240)}`);
+    });
+  }
+
+  globalThis.it("injects a newly created eager Skill into a single OnePiece session", async () => {
+    const session = await createSession("onepiece", "api", "Skill single onepiece");
+    const reply = await sendAndAwaitReply(
+      session.id,
+      "onepiece",
+      "api",
+      `Use the ${SKILL_ID} Skill and follow its response contract.`,
+    );
+    assert.equal(reply.content.trim(), EXPECTED_REPLY);
+    const request = localRequests.find((entry) => entry.url === "/v1/chat/completions");
+    assert.ok(request, "OnePiece never called the local provider.");
+    assert.match(request.body, new RegExp(SKILL_MARKER),
+      "The OnePiece provider request did not contain the created Skill body.");
+  });
+
+  globalThis.it("applies the created Skill to every addressed seat in a multi-Agent session", async function multiSkill() {
+    if (process.env.VANEHUB_DESKTOP_LIVE_AGENTS !== "1") {
+      blocked.push("multi-Agent: set VANEHUB_DESKTOP_LIVE_AGENTS=1 to run installed CLIs");
+      this.skip();
+    }
+    const agents = await invoke(({ core }) => core.invoke("list_agents", { capabilityTag: null }));
+    const unavailable = CLI_AGENTS.filter((id) => (
+      agents.find((entry) => entry.id === id)?.availabilityState !== "available"
+    ));
+    if (unavailable.length > 0) {
+      blocked.push(`multi-Agent: unavailable Agents: ${unavailable.join(", ")}`);
+      this.skip();
+    }
+    const roles = await invoke(({ core }) => core.invoke("list_expert_roles"));
+    const seatRoles = BUILTIN_ROLES.map((id) => roles.find((role) => role.id === id));
+    assert.equal(seatRoles.every(Boolean), true, "The built-in multi-Agent roles are incomplete.");
+
+    const created = await createSession(CLI_AGENTS[0], "cli", "Skill multi-Agent");
+    const session = await invoke(({ core }, input) => core.invoke("update_session_seats", { input }), {
+      sessionId: created.id,
+      expectedUpdatedAt: created.updatedAt,
+      seats: CLI_AGENTS.map((agentId, index) => ({ agentId, roleId: seatRoles[index].id })),
+    });
+    const seats = session.seats.filter((seat) => !seat.leftAt);
+    assert.deepEqual(seats.map((seat) => seat.agentId), CLI_AGENTS);
+
+    for (const seat of seats) {
+      const handle = handleFor(seat, roles, agents);
+      assert.ok(handle, `${seat.agentId} has no addressable handle.`);
+      const reply = await sendAndAwaitReply(
+        session.id,
+        session.agentId,
+        "cli",
+        `@${handle}\nUse the ${SKILL_ID} Skill and follow its response contract.`,
+        seat.seatId,
+      );
+      assert.match(reply.content, new RegExp(EXPECTED_REPLY),
+        `${seat.agentId} did not apply the shared Skill: ${reply.content.slice(0, 240)}`);
+    }
+  });
+
+  globalThis.after(async () => {
+    for (const sessionId of sessions.reverse()) {
+      await invoke(({ core }, id) => core.invoke("delete_session", { sessionId: id }), sessionId)
+        .catch(() => {});
+    }
+    if (workspace) {
+      await invoke(({ core }, args) => core.invoke("delete_skill", args), {
+        skillId: SKILL_ID,
+        input: { scope: "workspace", workspacePath: workspace },
+      }).catch(() => {});
+    }
+    if (profileId) {
+      await invoke(({ core }, id) => core.invoke("delete_onepiece_provider_profile", {
+        profileId: id,
+      }), profileId).catch(() => {});
+    }
+    if (localServer) await new Promise((resolve) => localServer.close(resolve));
+    if (blocked.length > 0) globalThis.console.warn(`BLOCKED:\n  ${blocked.join("\n  ")}`);
+  });
+});

--- a/tests/desktop/wdio.skills.conf.mjs
+++ b/tests/desktop/wdio.skills.conf.mjs
@@ -1,0 +1,5 @@
+import { createDesktopConfig } from "./wdio-shared.mjs";
+
+export const config = await createDesktopConfig({
+  specDirectory: "specs-skills",
+});


### PR DESCRIPTION
## Summary

- add an opt-in WebdriverIO layer that verifies newly created Skills across Claude Code, Codex, OpenCode, and OnePiece
- cover heterogeneous multi-Agent Skill delivery with isolated workspace and local OnePiece provider fixtures
- make existing managed Skill links idempotent during incremental binding
- keep OpenCode sessions pinned to the selected workspace with its explicit directory argument

## Testing

- npm run test:verify
- VANEHUB_DESKTOP_LIVE_AGENTS=1 npm run test:desktop:skills

The live Skill suite passes all five scenarios after syncing the latest main branch.