### PR TITLE
Stabilize Windows CLI parameter fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,12 +487,14 @@ jobs:
       # Path-list normalization, executable status, argv token preservation, and profile
       # persistence with revision and catalog CAS. No provider is launched, no credential is read,
       # and the only executable involved is the repository's own stub, which is inspected rather
-      # than run.
+      # than run. Keep the native test fan-out bounded: each test creates and migrates an isolated
+      # SQLite database, and the Windows hosted runner can otherwise exhaust r2d2's five-second
+      # connection acquisition window while hundreds of migrations start concurrently.
       - name: Native CLI parameter fixtures
-        run: cargo test --workspace platform_fixture_tests
+        run: cargo test --workspace platform_fixture_tests -- --test-threads=4
 
       - name: Native CLI parameter subdomain
-        run: cargo test --workspace cli_parameters
+        run: cargo test --workspace cli_parameters -- --test-threads=4
 
       - name: Install npm dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- bound the Rust test fan-out for CLI parameter fixture jobs
- prevent Windows hosted runners from starting hundreds of isolated SQLite migrations concurrently
- keep the production database timeout and runtime behavior unchanged

## Root cause

The CLI Parameter Fixtures (windows-latest) push check for #238 failed in legacy_rows_and_malformed_json_survive_the_migration_untouched. The assertion was not the cause: NativeDatabase::new timed out acquiring an r2d2 connection while 158 matching Rust tests ran concurrently and many tests created and migrated independent SQLite databases.

## Validation

- cargo test --workspace platform_fixture_tests -- --test-threads=4 (17 passed)
- cargo test --workspace cli_parameters -- --test-threads=4 (158 passed)
- 
pm run lint:ci`n- workflow YAML parse check
- openspec validate --specs --strict (139 passed)