### PR TITLE
chore(release): prepare v1.3.0

### DIFF
--- a/.github/STABLE_RELEASE_NOTES.md
+++ b/.github/STABLE_RELEASE_NOTES.md
@@ -1,6 +1,6 @@
-# VaneHub AI 1.2.0
+# VaneHub AI 1.3.0
 
-VaneHub AI 1.2.0 is the stable desktop release of the unified workspace for Claude Code, Codex CLI, OpenCode, Gemini CLI, Antigravity CLI, and the built-in OnePiece API agent.
+VaneHub AI 1.3.0 is the stable desktop release of the unified workspace for Claude Code, Codex CLI, OpenCode, Gemini CLI, Antigravity CLI, and the built-in OnePiece API agent.
 
 ## Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8019,7 +8019,7 @@ dependencies = [
 
 [[package]]
 name = "vanehub-ai"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,11 +16,11 @@
 
 単一の React インターフェースと明確な Web/mock・Tauri runtime 境界を通じて AI Coding Agent を管理する、デスクトップ優先のワークスペースです。
 
-<!-- docs-fact:project-version value:1.2.0 -->
+<!-- docs-fact:project-version value:1.3.0 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@
 
 Desktop-first workspace for managing AI coding agents through one React interface and explicit Web/mock and Tauri runtime boundaries.
 
-<!-- docs-fact:project-version value:1.2.0 -->
+<!-- docs-fact:project-version value:1.3.0 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,11 +16,11 @@
 
 通过统一 React 界面和明确的 Web/mock、Tauri runtime 边界管理 AI Coding Agent 的桌面优先工作台。
 
-<!-- docs-fact:project-version value:1.2.0 -->
+<!-- docs-fact:project-version value:1.3.0 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vanehub-ai",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vanehub-ai",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.3.3",
         "@tanstack/react-query": "^5.101.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanehub-ai",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanehub-ai"
-version = "1.2.0"
+version = "1.3.0"
 description = "Unified AI coding agent management"
 authors = ["vanehub-ai"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VaneHub AI",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "identifier": "ai.vanehub.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/services/about-service.test.ts
+++ b/src/services/about-service.test.ts
@@ -13,9 +13,9 @@ describe("about-service", () => {
       new Response(
         JSON.stringify({
           body: "Release notes",
-          html_url: "https://github.com/cdavid817/vanehub-ai/releases/tag/v1.2.1",
-          name: "VaneHub AI v1.2.1",
-          tag_name: "v1.2.1",
+          html_url: "https://github.com/cdavid817/vanehub-ai/releases/tag/v1.3.1",
+          name: "VaneHub AI v1.3.1",
+          tag_name: "v1.3.1",
         }),
         { status: 200 },
       );
@@ -23,7 +23,7 @@ describe("about-service", () => {
     const result = await checkAboutUpdates(fetchImpl);
 
     expect(result.updateAvailable).toBe(true);
-    expect(result.latestVersion).toBe("1.2.1");
+    expect(result.latestVersion).toBe("1.3.1");
     expect(result.releaseNotes).toBe("Release notes");
   });
 


### PR DESCRIPTION
## Summary

- Bump the application, npm, Cargo, and Tauri versions to 1.3.0
- Update the English, Simplified Chinese, and Japanese README version badges
- Refresh the stable release notes for VaneHub AI 1.3.0
- Keep the About update-check fixture ahead of the current release version

This release captures everything merged to `main` since `v1.2.0` (2026-08-25): Feishu IM integration, a registry-based LSP language set with managed install/remove, provider-specific Agent evaluation qualification, personalization governance, and the session workspace evidence console, among other fixes. It does not include `fix/desktop-client-verification-defects`, which has not been reviewed yet.

## Validation

- `npm run lint:ci`
- `npm run build`
- `npm run test` (432 files / 2719 tests)
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npm run native:panic:check`
- `cargo test --workspace` (5863 tests across workspace crates)
- `openspec validate --specs --strict` (142 specs)
- `npm run version:check`
- `npm run version:unit:test`
- `npm run release:unit:test`
- `npm run docs:check`
- `npm run contracts:check`
- `npm run coverage:policy:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)