### PR TITLE
chore(release): prepare v1.4.0

### DIFF
--- a/.github/STABLE_RELEASE_NOTES.md
+++ b/.github/STABLE_RELEASE_NOTES.md
@@ -1,6 +1,6 @@
-# VaneHub AI 1.3.0
+# VaneHub AI 1.4.0
 
-VaneHub AI 1.3.0 is the stable desktop release of the unified workspace for Claude Code, Codex CLI, OpenCode, Gemini CLI, Antigravity CLI, and the built-in OnePiece API agent.
+VaneHub AI 1.4.0 is the stable desktop release of the unified workspace for Claude Code, Codex CLI, OpenCode, Gemini CLI, Antigravity CLI, and the built-in OnePiece API agent.
 
 ## Highlights
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,9 @@ jobs:
   cli-parameter-fixtures:
     name: CLI Parameter Fixtures (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # A cold macOS Rust cache can spend almost 25 minutes compiling the native fixture domain
+    # before the subdomain suite starts, so 30 minutes cancels a healthy run mid-verification.
+    timeout-minutes: 45
     # Every platform reports independently. A Windows separator rule and a POSIX executable bit
     # fail for unrelated reasons, and stopping the matrix on the first one hides the other.
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8019,7 +8019,7 @@ dependencies = [
 
 [[package]]
 name = "vanehub-ai"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,11 +16,11 @@
 
 単一の React インターフェースと明確な Web/mock・Tauri runtime 境界を通じて AI Coding Agent を管理する、デスクトップ優先のワークスペースです。
 
-<!-- docs-fact:project-version value:1.3.0 -->
+<!-- docs-fact:project-version value:1.4.0 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-1.4.0-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@
 
 Desktop-first workspace for managing AI coding agents through one React interface and explicit Web/mock and Tauri runtime boundaries.
 
-<!-- docs-fact:project-version value:1.3.0 -->
+<!-- docs-fact:project-version value:1.4.0 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-1.4.0-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,11 +16,11 @@
 
 通过统一 React 界面和明确的 Web/mock、Tauri runtime 边界管理 AI Coding Agent 的桌面优先工作台。
 
-<!-- docs-fact:project-version value:1.3.0 -->
+<!-- docs-fact:project-version value:1.4.0 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-1.4.0-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vanehub-ai",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vanehub-ai",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.3.3",
         "@tanstack/react-query": "^5.101.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanehub-ai",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanehub-ai"
-version = "1.3.0"
+version = "1.4.0"
 description = "Unified AI coding agent management"
 authors = ["vanehub-ai"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VaneHub AI",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "identifier": "ai.vanehub.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/services/about-service.test.ts
+++ b/src/services/about-service.test.ts
@@ -13,9 +13,9 @@ describe("about-service", () => {
       new Response(
         JSON.stringify({
           body: "Release notes",
-          html_url: "https://github.com/cdavid817/vanehub-ai/releases/tag/v1.3.1",
-          name: "VaneHub AI v1.3.1",
-          tag_name: "v1.3.1",
+          html_url: "https://github.com/cdavid817/vanehub-ai/releases/tag/v1.4.1",
+          name: "VaneHub AI v1.4.1",
+          tag_name: "v1.4.1",
         }),
         { status: 200 },
       );
@@ -23,7 +23,7 @@ describe("about-service", () => {
     const result = await checkAboutUpdates(fetchImpl);
 
     expect(result.updateAvailable).toBe(true);
-    expect(result.latestVersion).toBe("1.3.1");
+    expect(result.latestVersion).toBe("1.4.1");
     expect(result.releaseNotes).toBe("Release notes");
   });
 

--- a/tests/e2e/slash-commands.spec.ts
+++ b/tests/e2e/slash-commands.spec.ts
@@ -33,7 +33,15 @@ async function createOnePieceSession(page: Page, title: string) {
   await dialog.getByPlaceholder(/code.*project/).fill("D:\\example-workspace");
   await dialog.getByPlaceholder("新会话").fill(title);
   await dialog.getByRole("button", { name: "创建", exact: true }).click();
-  await expect(page.getByTestId("wechat-style-composer")).toBeVisible();
+  const composer = page.getByTestId("wechat-style-composer");
+  const input = composer.getByRole("textbox");
+  await expect(composer).toBeVisible();
+  // A composer can remain visible while the new session is still becoming active. Wait for the
+  // OnePiece-only completion surface so Enter dispatches against the new session rather than the
+  // session that was active before the dialog closed.
+  await input.fill("/");
+  await expect(page.getByRole("button", { name: /\/help/ })).toBeVisible();
+  await input.fill("");
 }
 
 test.describe("OnePiece slash commands", () => {


### PR DESCRIPTION
## Summary

- Bump the npm, Cargo, and Tauri application versions to 1.4.0.
- Refresh version badges, stable release notes, and the About update-check fixture.
- Release includes the seven changes merged to main after v1.3.0.

## Validation

- npm run version:check -- v1.4.0
- npm run version:unit:test
- npm run release:unit:test
- npm run docs:check
- npm run test -- --run src/services/about-service.test.ts
- git diff --check