### PR TITLE
Stop the session's agent terminal before removing its worktree, and prepare 1.5.0

### DIFF
--- a/.github/STABLE_RELEASE_NOTES.md
+++ b/.github/STABLE_RELEASE_NOTES.md
@@ -1,6 +1,6 @@
-# VaneHub AI 1.4.0
+# VaneHub AI 1.5.0
 
-VaneHub AI 1.4.0 is the stable desktop release of the unified workspace for Claude Code, Codex CLI, OpenCode, Gemini CLI, Antigravity CLI, and the built-in OnePiece API agent.
+VaneHub AI 1.5.0 is the stable desktop release of the unified workspace for Claude Code, Codex CLI, OpenCode, Gemini CLI, Antigravity CLI, and the built-in OnePiece API agent.
 
 ## Highlights
 
@@ -9,6 +9,13 @@ VaneHub AI 1.4.0 is the stable desktop release of the unified workspace for Clau
 - Manage MCP servers, SDKs, Skills, prompt hooks, extensions, scheduled tasks, notifications, and provider profiles.
 - Inspect usage, task output, and redacted unified logs without bypassing the desktop service boundary.
 - Use the browser-accessible Web/mock runtime for interface evaluation when native desktop capabilities are unavailable.
+
+## What's new since 1.4.0
+
+- **Session deletion now confirms what it removed.** Deleting a session previews the real side effects, keeps the Git worktree unless removal is chosen explicitly, refuses to clean up a worktree holding untracked work, and stops the session's own agents, shells, and terminals before touching the directory. A stop that cannot be confirmed retains the session rather than reporting success.
+- **Long conversations no longer grow the cost of every turn.** Transcript rendering is bounded by what is on screen, and repeated launches of an already-running agent are collapsed instead of starting a second process.
+- **Session creation and single-agent tracing corrected.** Execution traces attribute work to the layer that performed it rather than classifying it as unknown.
+- **Workspace layouts hardened, plus a CLI terminal theme.** Folder-opener discovery also finds JetBrains Toolbox, Flatpak, and Scoop installations that earlier releases missed.
 
 ## Downloads
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,6 +638,9 @@ jobs:
       - name: Verify desktop automation boundaries
         run: npm run desktop:unit:test
 
+      # More than the smoke contract: `CI` is set here, so `test-desktop.mjs` runs its `gatedLayers`
+      # set. Which layers those are, and why each one is worth its runtime on every PR, is decided
+      # there -- restating the list here would give it two homes and one of them would go stale.
       - name: Run native desktop smoke on Linux
         if: runner.os == 'Linux'
         run: xvfb-run -a npm run test:desktop

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8058,7 +8058,7 @@ dependencies = [
 
 [[package]]
 name = "vanehub-ai"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,11 +16,11 @@
 
 デスクトップ優先の AI コーディングエージェントワークベンチ。OnePiece、Claude Code、Codex CLI、OpenCode、Gemini CLI、Antigravity CLI を統一インターフェースで利用・管理します。
 
-<!-- docs-fact:project-version value:1.4.0 -->
+<!-- docs-fact:project-version value:1.5.0 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-1.4.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-1.5.0-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@
 
 A desktop-first workbench for AI coding agents: use and manage OnePiece, Claude Code, Codex CLI, OpenCode, Gemini CLI, and Antigravity CLI in one unified interface.
 
-<!-- docs-fact:project-version value:1.4.0 -->
+<!-- docs-fact:project-version value:1.5.0 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-1.4.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-1.5.0-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,11 +16,11 @@
 
 桌面优先的 AI 编码 Agent 工作台：在一个统一界面里使用与管理 OnePiece、Claude Code、Codex CLI、OpenCode、Gemini CLI 和 Antigravity CLI。
 
-<!-- docs-fact:project-version value:1.4.0 -->
+<!-- docs-fact:project-version value:1.5.0 -->
 <!-- docs-fact:tauri-major value:2.x -->
 <!-- docs-fact:react-major value:19.x -->
 
-[![Version](https://img.shields.io/badge/version-1.4.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-1.5.0-blue.svg)](package.json)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB.svg)](src-tauri/Cargo.toml)
 [![React](https://img.shields.io/badge/React-19.x-61DAFB.svg)](package.json)
 [![CI](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/cdavid817/vanehub-ai/actions/workflows/ci.yml)

--- a/openspec/changes/add-session-worktree-cleanup/tasks.md
+++ b/openspec/changes/add-session-worktree-cleanup/tasks.md
@@ -57,7 +57,8 @@
 
 - [x] 5.1 实现只读预览、opaque preview 存储、有效期、目标集合绑定、风险摘要和允许策略；UI 预览不产生停止/删除副作用。
 - [x] 5.2 实现 requestId + canonical request hash 幂等创建、活动 session claim 唯一性、资源分组和选择冲突校验。
-- [x] 5.3 实现 quiesce barrier：等待所有本应用生成/seat/工具、CLI、后台命令、Shell 和应释放句柄退出，超时保留会话。
+- [ ] 5.3 实现 quiesce barrier：等待所有本应用生成/seat/工具、CLI、后台命令、Shell 和应释放句柄退出，超时保留会话。
+      *2026-09-07 撤回勾选*：barrier 实现了，但只覆盖生成、工具审批等待者、后台命令、Shell 四类，**漏了 CLI 模式的 agent 终端**。该终端以会话 worktree 为当前工作目录，Windows 因此拒绝删除该目录，`git worktree remove` 返回 255 `Permission denied`，删除以 `needs_attention` 收场。`desktop-session-deletion` 层 6/6 确定性复现，而该层不在 CI 闸门内（`Desktop Full Suite` 需标签触发）故未被拦截。补齐工作见 `stop-session-terminals-before-worktree-removal`。
 - [x] 5.4 在静止且门禁持有后执行最终核验，忽略仅由正常停止导致的 lifecycle 更新，但拒绝安全相关文件/资源/引用变化。
 - [x] 5.5 持久化 remove_started 后执行 Git，观测并写入 receipt；写失败、超时、部分移除均不得声称零副作用。
 - [x] 5.6 以每资源组单一事务完成会话/消息删除、条件清空 active selection、更新资源/绑定/journal；事件仅在 commit 后发出。

--- a/openspec/changes/stop-session-terminals-before-worktree-removal/.openspec.yaml
+++ b/openspec/changes/stop-session-terminals-before-worktree-removal/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-09-07
+skip_specs: true

--- a/openspec/changes/stop-session-terminals-before-worktree-removal/design.md
+++ b/openspec/changes/stop-session-terminals-before-worktree-removal/design.md
@@ -1,0 +1,96 @@
+# Design
+
+## Context
+
+动机见 `proposal.md - Why`。这里只列影响方案的现状约束。
+
+`deletion_runtime.rs::quiesce`（89 行）是静止屏障的唯一适配器，按 deadline 预算依次停四类写入者：生成、工具审批等待者、后台命令、Shell。它已经通过 `published_agent_runtime()` 使用 `agent_runtime::api`，也通过 `workspaces()` 使用工作区能力，因此本变更不需要引入新的上下文依赖。
+
+agent 终端子系统的现有接口是本设计的主要约束：
+
+- `stop(StopAgentTerminalRequest { terminal_id })` — **按 terminal_id**，而删除协调器手上只有 `session_id`。
+- `cleanup_idle(idle_after_seconds)` / `shutdown()` — 返回 `Vec<String>` 会话 id，说明端口内部掌握会话映射，但作用域是全局，会波及其他会话。
+- **没有任何存活查询**，无法回答"这个会话还有终端活着吗"。
+
+Shell 子系统已有正好对应的一对：`kill_shells_for_session(session_id)` 与 `live_session_shell_count(session_id)`。
+
+## Goals / Non-Goals
+
+**Goals**
+
+- 会话删除在执行 Git 移除前，终止该会话的 agent 终端并确认其真实退出。
+- 终端未能在预算内退出时，沿用既有阻塞语义：保留会话、阻止移除、不谎报成功。
+
+**Non-Goals**
+
+- 不改 `git worktree remove` 的无 `--force` 策略。该策略是刻意的安全设计，强删会把"进程仍在写入"变成静默的数据损坏。
+- 不处理非本应用管理的外部进程。规范已明确对这类进程不宣称排他隔离。
+- 不修 e2e 第 4 个用例。它的失败是第 3 个用例断言抛出后对话框未关的连带效应，第 3 个转绿后即消失；若未消失，说明存在独立缺陷，另行处理。
+- 不改动 `Desktop Full Suite` 整体是否 opt-in 这一更大问题，只收敛本路径的闸门缺口。
+
+## Decisions
+
+### D1：在适配器而非协调器中扩展
+
+`quiesce` 的实现放在 `deletion_runtime.rs`，协调器只通过 port 消费 `QuiescenceReport`。
+
+**理由**：协调器是平台无关的策略层，"哪些算本应用管理的写入者"属于运行时装配知识。**备选**：给协调器加一个新 port。**否决**：`agent_runtime::api` 已是该适配器的依赖，新增抽象只会增加一层无收益的间接。
+
+### D2：新增按会话的停止与存活查询，照搬 Shell 的形状
+
+在 agent 终端服务与端口上新增两个方法，命名与语义对齐既有 Shell 版本：
+
+- 按 `session_id` 停止该会话的全部终端
+- 返回该会话仍存活的终端数
+
+**理由**：`stop` 的 `terminal_id` 粒度在此处不可用，而 `cleanup_idle`/`shutdown` 会误伤其他会话的终端——那会违反规范中「keep 不得冻结同目录的其他会话」的约束。照搬 Shell 的方法对，读者不必学第二套心智模型。**备选**：让协调器先列出会话的 terminal_id 再逐个 stop。**否决**：把会话→终端的映射泄漏到调用方，且列举与停止之间存在竞态窗口。
+
+### D3：轮询存活数确认退出，不采信 `stop` 的返回值
+
+`stop` 返回 `bool` 表示请求是否被受理。规范对此有明确禁令：「取消请求受理 SHALL 不作为退出回执」。因此必须在同一 deadline 预算内轮询存活数直至归零。
+
+**理由**：这正是本缺陷的形状——受理了停止请求，进程却还占着工作目录。采信受理回执会让修复只是把失败时机往后挪。**备选**：停止后固定 sleep 一段时间。**否决**：既不可靠又拖慢正常路径。
+
+### D4：超时压入 `agent_terminal` 阻塞项
+
+与 `generation` / `background_command` / `shell` 完全一致：压入阻塞项、`quiet=false`，由既有逻辑保留会话并阻止移除。
+
+**理由**：不新增失败模式，UI 与重试入口无需改动。阻塞项名称对齐原生日志类别 `session.agent_terminal`，便于把失败与日志对上。
+
+### D5：在 Shell 之前停终端
+
+顺序放在后台命令之后、Shell 块之前。
+
+**理由**：终端可能派生 shell；若先做 Shell 的严格关闭再停终端，终端可能在计数校验之后再拉起 shell，使检查失效。反向则不存在这个窗口。
+
+### D6：把 `desktop-session-deletion` 纳入 CI 闸门
+
+**理由**：该缺陷的失败模式是静默的——不丢数据、只是 worktree 残留并报 `needs_attention`，人不盯着就发现不了，而它已经这样进了 main。该层通过时约 2:44，加进 smoke 闸门的三平台成本可接受。**备选**：让 `Desktop Full Suite` 恒跑。**否决**：三平台 150 分钟预算，为一层付整套代价。
+
+## Task 1.1 核实结论（2026-09-07 已查证，取代 D2 的部分前提）
+
+读 `terminal_process.rs` 后确认三件事，前两件推翻了 D2「照搬 Shell 那对方法」的可行性：
+
+1. **`stop()` 先摘注册表再 kill。** 顺序是 `terminals.remove(&session_id)` → `terminate_terminal_child`。任何基于注册表的存活计数在 `stop()` 返回后立刻为 0，不能作为退出证据。
+2. **收尸有界且结果被丢弃。** `terminate_terminal_child` 以 `TERMINAL_REAP_BUDGET = 1500ms` 调 `reap_terminal_before`，写法是 `let _ = ...`。子进程仍存活时 `stop()` 一样返回 `Ok(true)`——正是规范禁止的「以受理充当退出回执」。
+3. **PTY 子进程没有 job object 容器。** 终端经 `portable_pty::spawn_command` 启动，不走 `platform::process` 的 process-wrap 链，现成的 `windows_job::TerminateTreeJobObject` 够不着它。会话 Shell（`retained_shell_runtime.rs:545`）用同一条 spawn 路径，**同样没有容器**——该弱点非 agent 终端独有。
+
+**对 D2 的修正**：放弃「停止 + 独立存活查询」两个方法的形状，改为**单个按会话的方法：请求停止，并在调用方给定的 deadline 内确认真实退出，返回是否已确认**。理由是第 1、2 条——注册表不能作为事实来源，且调用方（quiesce）持有的预算远大于固定的 1.5s。
+
+**关于进程树范围**：第 3 条意味着 kill 直接子进程 `cmd.exe` 未必带走孙进程 `opencode.exe`，而占着 worktree 的是这两者。但现有证据**不足以**断定 `stop()` 杀不掉整棵树——当前 quiesce 从未调用过 `stop_agent_terminal`，终端存活只能证明"没人停它"，不能证明"停不掉"；ConPTY 主端关闭时附着进程通常会退出。因此先按最小正确修复实现并以 e2e 实测为判据，不为假想情况预先加设计。
+
+**升级路径（仅在实测失败时启用）**：在 PTY spawn 处引入进程树容器，或按 pid 终止后代树；届时应同时覆盖 `retained_shell_runtime.rs`，因为两者共用同一条无容器的 spawn 路径。
+
+## Risks / Trade-offs
+
+- **孙进程可能在直接子进程被杀后存活并继续持有 worktree** → 见上面的升级路径；以 e2e 层的真实结果为判据，不以推测为准。
+- **Windows 上 ConPTY 关闭已知会拖到超时**（本仓库已有记录：reader 要等 master 句柄释放才收到 EOF）→ 可能表现为删除比现在慢，最坏情况以 `agent_terminal` 阻塞项收尾。这仍严格优于现状：现状是无声地失败在 Git 上，改后是有名有姓的阻塞项加保留的会话。
+- **终端停止会话正在用的终端** → 仅限被删除的会话，删除本身即蕴含停止其工作；且规范已要求如此。
+
+## Migration Plan
+
+无数据模型或 schema 变更，无迁移。回滚即还原该 commit，不留持久化痕迹。
+
+## Open Questions
+
+无。

--- a/openspec/changes/stop-session-terminals-before-worktree-removal/proposal.md
+++ b/openspec/changes/stop-session-terminals-before-worktree-removal/proposal.md
@@ -1,0 +1,43 @@
+# Stop session agent terminals before removing the worktree
+
+## Why
+
+删除会话并勾选「同时移除 worktree」时，Git 移除在 Windows 上必定失败，操作以 `needs_attention` 收场而不是 `succeeded`。
+
+根因是删除前的静止屏障漏掉了一类写入者。`deletion_runtime.rs` 的 `quiesce` 只停四类：生成、工具审批等待者、后台命令、Shell。CLI 模式的 **agent 终端**不属于其中任何一类——它是 `vanehub-ai.exe` 直接派生的 `cmd.exe`，包装脚本首行就是 `cd /d <会话 worktree>`，因此该 worktree 是这个活进程的当前工作目录。Windows 拒绝删除任何活进程的当前工作目录，`git worktree remove` 于是返回 255 与 `failed to delete <path> Permission denied`，运行时如实映射为 `Refused`。
+
+这不是规范缺口。`add-session-worktree-cleanup` 的「Quiescence before session deletion」已经写明「会话删除 SHALL 停止并等待本应用管理的生成、**CLI**、后台命令、Shell 及相关工作区句柄释放」——agent 终端正是其中的 CLI。**规范是对的，实现没做到。** 该变更的任务 5.3 声称已实现 quiesce barrier 并已勾选，但对 agent 终端不成立。
+
+现在做，是因为它已随 #278 进入 main，且没有任何 CI 闸门会发现它：`Desktop Smoke` 在 `CI=true` 下只跑 core smoke 契约，覆盖此路径的 `desktop-session-deletion` 层属于 `Desktop Full Suite`，需要 `desktop-full-suite` 标签才触发。本地全量运行 6/6 确定性复现。
+
+## What Changes
+
+- 在 `quiesce` 静止屏障中加入 agent 终端：请求停止，并在同一个 deadline 预算内等待其真实退出。
+- 超时未退出时压入 `agent_terminal` 阻塞项，沿用既有语义——保留会话记录、阻止 Git 移除、不谎报成功。这与现有 `generation` / `background_command` / `shell` 阻塞项的处理方式一致，不新增失败模式。
+- 修正 `add-session-worktree-cleanup` 任务 5.3 的完成状态，使其不再声称已覆盖 CLI。
+- 关闭 CI 闸门缺口，使这一层不再只能靠人工全量运行发现。
+
+不含破坏性变更。不新增 UI、状态库或依赖。
+
+## Capabilities
+
+### New Capabilities
+
+无。
+
+### Modified Capabilities
+
+无。本变更设置 `skip_specs: true`。
+
+规范层面的行为**没有**改变：应停止 CLI 的要求已由 `add-session-worktree-cleanup` 的「Quiescence before session deletion」规定，本变更只是让实现满足它。刻意不重复声明一份 delta——该 capability（`session-deletion-operations`）尚未同步进 `openspec/specs/`，两个未归档变更同时重建同一条需求会让其中一份 delta 失效。该需求的归属与同步仍由 `add-session-worktree-cleanup` 负责。
+
+## Impact
+
+**运行时范围：仅桌面端。** Web/mock adapter 不派生进程，不受影响。
+
+- `src-tauri/src/contexts/sessions/infrastructure/deletion_runtime.rs` — `quiesce` 增加 agent 终端停止与有界等待。这是唯一需要改的生产代码路径。
+- 不跨越新的上下文边界：该文件已通过 `published_agent_runtime()` 依赖 `agent_runtime::api`（用于 `stop_generation` 与 `reap_background_commands_and_wait`），`stop_agent_terminal` 就在同一个 API 上。前后端隔离与运行时适配器边界均不受影响。
+- `src-tauri/src/contexts/sessions/application/deletion/tests.rs` — 补充 agent 终端未退出即阻止移除的用例。
+- `tests/desktop/specs-session-deletion/session-deletion.e2e.mjs` — 既有用例即验收标准，不需修改；本变更使其转绿。
+- `.github/workflows/ci.yml` — 收敛闸门缺口。
+- `openspec/changes/add-session-worktree-cleanup/tasks.md` — 修正 5.3 的失实勾选。

--- a/openspec/changes/stop-session-terminals-before-worktree-removal/tasks.md
+++ b/openspec/changes/stop-session-terminals-before-worktree-removal/tasks.md
@@ -1,0 +1,46 @@
+## 1. 核实退出确认强度（先做，结论决定第 2 组的范围）
+
+- [x] 1.1 阅读 `src-tauri/src/contexts/agent_runtime/infrastructure/terminal_process.rs`，确认终端被 stop 后是从注册表摘除即算结束，还是等到真实 OS 进程退出；把结论写进 design.md，不要停留在口头。
+      **结论**：先摘注册表再 kill；收尸预算固定 1500ms 且结果被 `let _ =` 丢弃；子进程存活时 `stop()` 仍返回 `Ok(true)`。注册表不可作为退出证据。已写入 design.md「Task 1.1 核实结论」并据此修正 D2。
+- [x] 1.2 按修正后的 D2 实现真实退出确认（不再新增独立存活查询——注册表已被证明不可信）。
+
+## 2. 按会话的停止并确认退出
+
+- [x] 2.1 在 agent 终端端口与 `AgentTerminalApplicationService` 上新增单个方法：按 `session_id` 停止该会话的终端，并在**调用方给定的 deadline** 内确认真实退出，返回是否已确认。不得改动现有按 `terminal_id` 的 `stop`（其固定 1500ms 预算服务于退出路径，语义不同）。
+- [x] 2.2 在 `agent_runtime::api` 上暴露该方法，供 `deletion_runtime.rs` 通过既有的 `published_agent_runtime()` 调用；不新增上下文依赖。
+- [x] 2.3 补单元测试：只影响目标会话的终端，其他会话的终端不受影响（对应规范中 keep 不得冻结同目录其他会话的约束）；以及子进程未退出时返回未确认而非 true。
+
+## 3. 接入静止屏障
+
+- [x] 3.1 在 `deletion_runtime.rs::quiesce` 的后台命令之后、Shell 块之前加入终端停止（见 design.md D5 的顺序理由）。
+- [x] 3.2 在同一 `remaining()` deadline 预算内轮询存活数直至归零；**不得**采信 stop 的返回值作为退出回执。
+- [x] 3.3 超时未归零时压入 `agent_terminal` 阻塞项，名称对齐原生日志类别 `session.agent_terminal`；不新增失败模式。
+- [x] 3.4 在 `src-tauri/src/contexts/sessions/application/deletion/tests.rs` 增加用例：终端未退出时 `quiet=false`、会话保留、不进入 Git 移除。
+
+## 4. 端到端验证
+
+- [x] 4.1 运行 `npm run test:desktop:session-deletion`（单层模式不自建，需先 `npm run test:desktop:build`，且必须经 npm 启动）；4 个用例全绿。不修改 `tests/desktop/specs-session-deletion/session-deletion.e2e.mjs`——它就是验收标准。
+- [x] 4.2 确认第 4 个用例「deletes a project session without offering or touching its directory」随第 3 个转绿而恢复；若仍失败，说明是独立缺陷，单独记录不要顺手改测试。
+- [x] 4.3 运行结束后检查 `%TEMP%` 下不再残留 `vanehub-deletion-*-feature-*` 空目录——这是缺陷仍在的直接痕迹。
+- [x] 4.4 运行 `npm run test:desktop` 全量 10 层，确认本改动没有破坏其他层。rc=0，10/10 层通过（43 分钟）；session-deletion 层 36 秒通过。session-shell 层 1 次重试后通过，属既有偶发。
+
+## 5. 收敛 CI 闸门
+
+- [x] 5.1 把 `desktop-session-deletion` 纳入 CI 恒跑的层集合（见 design.md D6），使该路径不再只能靠人工全量运行发现。
+- [x] 5.2 在 `.github/workflows/ci.yml` 相应位置写明纳入理由：失败模式静默、不丢数据，仅表现为 worktree 残留与 `needs_attention`。
+
+## 6. 修正失实记录
+
+- [x] 6.1 将 `openspec/changes/add-session-worktree-cleanup/tasks.md` 的任务 5.3 改回未完成，并注明 quiesce barrier 当时未覆盖 agent 终端；不要静默改写描述来掩盖。
+
+## 7. 校验命令
+
+- [x] 7.1 `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
+- [x] 7.2 `cargo check --workspace`
+- [x] 7.3 `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] 7.4 `npm run native:panic:check`
+- [x] 7.5 `cargo test --workspace` — rc=0，6717 passed / 0 failed / 15 ignored（860s，空闲机器）。此前一轮的 4 个 folder_opener 失败已按跨平台方式修好；再前一轮出现的 2 个 `platform::git` locale 失败与一次阻塞经空闲机器定向复跑证明是负载所致（4 个 git 测试 0.13s 全过），非代码问题。
+- [x] 7.6 `npm run lint:ci`、`npm run test`、`npm run build`。**原假设已作废**：本变更改了 `scripts/test-desktop.mjs` 与 `scripts/desktop-orchestrator.node-test.mjs`，eslint 覆盖二者，三条都要跑，不能以"不动前端"跳过。
+- [x] 7.9 `npm run desktop:unit:test`——改了编排脚本必须跑；其中有断言 CI 闸门层集合的守卫。
+- [x] 7.7 `npm run architecture:check`——本变更触及 Tauri 边界与上下文间调用，必须跑
+- [x] 7.8 `openspec validate stop-session-terminals-before-worktree-removal --strict` 与 `openspec validate --specs --strict`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vanehub-ai",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vanehub-ai",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.3.3",
         "@tanstack/react-query": "^5.102.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanehub-ai",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/desktop-orchestrator.node-test.mjs
+++ b/scripts/desktop-orchestrator.node-test.mjs
@@ -211,10 +211,13 @@ test("each desktop layer owns a disjoint spec directory and its own wdio configu
   const shared = await readFile("tests/desktop/wdio-shared.mjs", "utf8");
   const cliTerminal = await readFile("tests/desktop/wdio.cli-terminal.conf.mjs", "utf8");
 
-  // The CLI layer stays runnable on demand; the narrow CI gate selects only the core contract.
+  // The CLI layer stays runnable on demand; the CI gate stays narrow. Pinned by membership rather
+  // than by shape alone, so a layer cannot join the gate -- and spend its runtime on every PR
+  // across three runners -- without this assertion changing too.
   assert.match(orchestrator, /mode === "cli-terminal"/);
   assert.match(orchestrator, /runFullSuite = process\.env\.VANEHUB_DESKTOP_FULL_SUITE === "1" \|\| !process\.env\.CI/);
-  assert.match(orchestrator, /const layers = runFullSuite \? fullSuiteLayers : \[coreSmokeDesktop\]/);
+  assert.match(orchestrator, /const gatedLayers = \[coreSmokeDesktop, sessionDeletionDesktop\];/);
+  assert.match(orchestrator, /const layers = runFullSuite \? fullSuiteLayers : gatedLayers;/);
   assert.match(smoke, /specDirectory: "specs"/);
   assert.match(cliTerminal, /specDirectory: "specs-cli-terminal"/);
   assert.match(shared, /specFileRetries: 2/);

--- a/scripts/test-desktop.mjs
+++ b/scripts/test-desktop.mjs
@@ -492,6 +492,18 @@ async function agentEvaluationQualification(mode = "fixture-opencode") {
 }
 
 /** The layers the required hermetic gate runs. Every one of them must pass. */
+/**
+ * What the PR gate runs when the full suite is opted out of.
+ *
+ * The cross-platform smoke contract, plus the layers whose failure mode is quiet enough that
+ * nothing else would catch them. `desktop-session-deletion` earned its place the hard way: when
+ * worktree removal fails there is no crash and no data loss, only a retained directory and a
+ * `needs_attention` outcome, so a break shipped to main and survived until someone ran the full
+ * suite by hand. Adding a layer here costs its runtime on every PR across three runners -- this
+ * one is ~3 minutes -- so it is for silent failure modes, not for coverage in general.
+ */
+const gatedLayers = [coreSmokeDesktop, sessionDeletionDesktop];
+
 const fullSuiteLayers = [
   smokeDesktop,
   cliTerminalDesktop,
@@ -549,9 +561,9 @@ async function main() {
     process.exitCode = result.status === "FAILED" ? 1 : 0;
   } else if (mode === "all" || mode === "everything") {
     const artifact = await buildDesktop();
-    const layers = runFullSuite ? fullSuiteLayers : [coreSmokeDesktop];
+    const layers = runFullSuite ? fullSuiteLayers : gatedLayers;
     if (!runFullSuite) {
-      process.stdout.write("Desktop verification: CI gate runs the core smoke contract; set VANEHUB_DESKTOP_FULL_SUITE=1 for every required layer.\n");
+      process.stdout.write("Desktop verification: CI gate runs the core smoke contract and the session deletion layer; set VANEHUB_DESKTOP_FULL_SUITE=1 for every required layer.\n");
     }
     const results = await runLayers(layers, artifact);
     // Each layer sets its own exit code as it finishes; the run as a whole is only green when

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vanehub-ai"
-version = "1.4.0"
+version = "1.5.0"
 description = "Unified AI coding agent management"
 authors = ["vanehub-ai"]
 edition = "2021"

--- a/src-tauri/src/contexts/agent_runtime/api.rs
+++ b/src-tauri/src/contexts/agent_runtime/api.rs
@@ -19,6 +19,7 @@ use super::infrastructure::{
     NativeSeatTurnCoordinator,
 };
 use std::sync::Arc;
+use std::time::Duration;
 
 pub(crate) use super::application::{
     ActiveGenerationCorrelation, AgentChatConfiguration, AgentFileReference, AgentMessage,
@@ -910,6 +911,18 @@ impl AgentRuntimeApi {
         request: StopAgentTerminalRequest,
     ) -> Result<bool, AgentRuntimeApplicationError> {
         self.terminal_service.stop(request)
+    }
+
+    /// Stops `session_id`'s terminal and reports whether its process was observed to exit
+    /// within `budget`. Consumed by session deletion's quiescence barrier, which must not
+    /// hand a still-running process's working directory to `git worktree remove`.
+    pub(crate) fn stop_session_agent_terminal_and_confirm_exit(
+        &self,
+        session_id: &str,
+        budget: Duration,
+    ) -> Result<bool, AgentRuntimeApplicationError> {
+        self.terminal_service
+            .stop_for_session_and_confirm_exit(session_id, budget)
     }
 
     pub(crate) fn cleanup_idle_agent_terminals(

--- a/src-tauri/src/contexts/agent_runtime/application/ports.rs
+++ b/src-tauri/src/contexts/agent_runtime/application/ports.rs
@@ -4,7 +4,7 @@
 //! terminals, operations, clocks, logging, and event publication. Infrastructure implements these
 //! contracts; application services do not depend on Tauri, SQLite, or concrete CLI libraries.
 
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use crate::contexts::agent_runtime::domain::MemoryType;
 
@@ -556,6 +556,20 @@ pub(crate) trait AgentTerminalGateway: Send + Sync {
 
     fn stop(&self, request: StopAgentTerminalRequest)
         -> Result<bool, AgentRuntimeApplicationError>;
+
+    /// Stops the terminal owned by `session_id` and waits, within `budget`, for its process
+    /// to actually exit. Returns whether exit was observed.
+    ///
+    /// Separate from `stop` because that one answers "was the stop accepted", and a session
+    /// being deleted needs "is the process gone" — its working directory is the worktree
+    /// about to be removed, and Windows refuses to delete a live process's current
+    /// directory. `stop`'s own reap budget is fixed and its result discarded; this one
+    /// spends the caller's remaining deletion budget and reports what it saw.
+    fn stop_session_terminal_and_confirm_exit(
+        &self,
+        session_id: &str,
+        budget: Duration,
+    ) -> Result<bool, AgentRuntimeApplicationError>;
 
     fn cleanup_idle(
         &self,

--- a/src-tauri/src/contexts/agent_runtime/application/terminal_service.rs
+++ b/src-tauri/src/contexts/agent_runtime/application/terminal_service.rs
@@ -7,6 +7,7 @@ use super::{
 };
 use crate::contexts::agent_runtime::domain::{AgentLifecycle, InteractionMode};
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Clone)]
 pub(crate) struct AgentTerminalApplicationPorts {
@@ -212,6 +213,16 @@ impl AgentTerminalApplicationService {
         request: StopAgentTerminalRequest,
     ) -> Result<bool, AgentRuntimeApplicationError> {
         self.ports.terminals.stop(request)
+    }
+
+    pub(crate) fn stop_for_session_and_confirm_exit(
+        &self,
+        session_id: &str,
+        budget: Duration,
+    ) -> Result<bool, AgentRuntimeApplicationError> {
+        self.ports
+            .terminals
+            .stop_session_terminal_and_confirm_exit(session_id, budget)
     }
 
     pub(crate) fn cleanup_idle(

--- a/src-tauri/src/contexts/agent_runtime/application/terminal_service_tests.rs
+++ b/src-tauri/src/contexts/agent_runtime/application/terminal_service_tests.rs
@@ -24,6 +24,9 @@ struct TerminalWorld {
     terminal_events: Mutex<Vec<AgentTerminalEvent>>,
     workflow_events: Mutex<usize>,
     stopped: Mutex<Vec<String>>,
+    /// Whether the stop-by-session gateway reports a confirmed exit. Configurable because the
+    /// deletion path treats "stopped" and "confirmed gone" as different answers.
+    terminal_exit_confirmed: Mutex<bool>,
 }
 
 impl TerminalWorld {
@@ -42,6 +45,7 @@ impl TerminalWorld {
             terminal_events: Mutex::new(Vec::new()),
             workflow_events: Mutex::new(0),
             stopped: Mutex::new(Vec::new()),
+            terminal_exit_confirmed: Mutex::new(true),
         })
     }
 
@@ -352,7 +356,7 @@ impl AgentTerminalGateway for TerminalWorld {
             .lock()
             .expect("stopped")
             .push(session_id.to_string());
-        Ok(true)
+        Ok(*self.terminal_exit_confirmed.lock().expect("exit confirmed"))
     }
 
     fn cleanup_idle(
@@ -735,6 +739,36 @@ fn idle_cleanup_and_shutdown_report_stopped_sessions() {
         .lock()
         .expect("terminal events")
         .is_empty());
+}
+
+/// Session deletion asks a different question than `stop` does -- not "was the stop accepted"
+/// but "is the process gone" -- and both answers have to reach the caller. An unconfirmed exit
+/// is what keeps a session's worktree from being handed to `git worktree remove` while a
+/// process still has it as its working directory.
+#[test]
+fn stopping_a_session_terminal_reports_whether_the_exit_was_confirmed() {
+    let world = TerminalWorld::new(session(false));
+    let service = world.service();
+
+    assert!(service
+        .stop_for_session_and_confirm_exit("session-1", Duration::from_secs(5))
+        .expect("confirmed stop"));
+
+    *world
+        .terminal_exit_confirmed
+        .lock()
+        .expect("exit confirmed") = false;
+    assert!(
+        !service
+            .stop_for_session_and_confirm_exit("session-1", Duration::from_secs(5))
+            .expect("unconfirmed stop"),
+        "a terminal that did not exit must not be reported as gone",
+    );
+
+    assert_eq!(
+        world.stopped.lock().expect("stopped").as_slice(),
+        ["session-1".to_string(), "session-1".to_string()],
+    );
 }
 
 fn agent(availability: AvailabilityAssessment) -> AgentDefinition {

--- a/src-tauri/src/contexts/agent_runtime/application/terminal_service_tests.rs
+++ b/src-tauri/src/contexts/agent_runtime/application/terminal_service_tests.rs
@@ -11,6 +11,7 @@ use crate::contexts::agent_runtime::domain::{
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 struct TerminalWorld {
     session: Mutex<super::AgentSession>,
@@ -339,6 +340,18 @@ impl AgentTerminalGateway for TerminalWorld {
             .lock()
             .expect("stopped")
             .push(request.terminal_id);
+        Ok(true)
+    }
+
+    fn stop_session_terminal_and_confirm_exit(
+        &self,
+        session_id: &str,
+        _budget: Duration,
+    ) -> Result<bool, AgentRuntimeApplicationError> {
+        self.stopped
+            .lock()
+            .expect("stopped")
+            .push(session_id.to_string());
         Ok(true)
     }
 

--- a/src-tauri/src/contexts/agent_runtime/infrastructure/terminal_process.rs
+++ b/src-tauri/src/contexts/agent_runtime/infrastructure/terminal_process.rs
@@ -904,6 +904,47 @@ impl AgentTerminalGateway for PortablePtyAgentTerminalRuntime {
         Ok(true)
     }
 
+    fn stop_session_terminal_and_confirm_exit(
+        &self,
+        session_id: &str,
+        budget: Duration,
+    ) -> Result<bool, AgentRuntimeApplicationError> {
+        let deadline = Instant::now() + budget;
+        let terminal = self.lock_terminals()?.remove(session_id);
+        let Some(terminal) = terminal else {
+            // No terminal for this session, so none of ours holds its directory. Confirmed
+            // rather than refused: the caller asks whether anything is still running, and
+            // nothing is.
+            return Ok(true);
+        };
+        // Deliberately no `ProviderCapability::Cancellation` gate, unlike `stop`. That gate
+        // belongs to a user cancelling their own run; here the session is being destroyed,
+        // and a provider that does not advertise interactive cancellation must not leave a
+        // process holding the worktree.
+        let exited = terminate_terminal_child_before(terminal.child.as_ref(), deadline)?;
+        self.sessions
+            .update_lifecycle(&terminal.session_id, AgentLifecycle::Stopped)?;
+        let _ = self.events.publish_terminal(AgentTerminalEvent::State {
+            terminal_id: terminal.terminal_id,
+            session_id: terminal.session_id.clone(),
+            state: AgentTerminalState::Stopped,
+            error: None,
+        });
+        self.record_log(
+            AgentLogLevel::Info,
+            if exited {
+                "Agent terminal process stopped and confirmed exited for session deletion."
+                    .to_string()
+            } else {
+                "Agent terminal process did not confirm exit within the deletion budget."
+                    .to_string()
+            },
+            Some(&terminal.agent_id),
+            Some(&terminal.session_id),
+        );
+        Ok(exited)
+    }
+
     fn cleanup_idle(
         &self,
         idle_after_seconds: i64,
@@ -1223,6 +1264,37 @@ fn terminate_terminal_child(
     }
     let _ = reap_terminal_before(child, Instant::now() + TERMINAL_REAP_BUDGET);
     Ok(())
+}
+
+/// Kills the child and reports whether it was observed to exit before `deadline`.
+///
+/// Same shape as [`terminate_terminal_child`], with the two differences the deletion path
+/// needs: the caller supplies the budget instead of inheriting the fixed quit-path one, and
+/// the reap result is returned instead of discarded. A caller about to remove the child's
+/// working directory cannot treat "kill was issued" as "directory is free".
+fn terminate_terminal_child_before(
+    child: &Mutex<Box<dyn Child + Send + Sync>>,
+    deadline: Instant,
+) -> Result<bool, AgentRuntimeApplicationError> {
+    // Kill inside the lock, reap outside it, for the deadlock reason spelled out in
+    // `terminate_terminal_child`.
+    {
+        let mut child = child
+            .lock()
+            .map_err(|error| AgentRuntimeApplicationError::Process(error.to_string()))?;
+        if child
+            .try_wait()
+            .map_err(|error| AgentRuntimeApplicationError::Process(error.to_string()))?
+            .is_none()
+        {
+            child
+                .kill()
+                .map_err(|error| AgentRuntimeApplicationError::Process(error.to_string()))?;
+        }
+    }
+    Ok(reap_terminal_before(child, deadline)
+        .map_err(AgentRuntimeApplicationError::Process)?
+        .is_some())
 }
 
 fn cleanup_unattached_terminal_child(child: &mut dyn Child) {
@@ -1848,6 +1920,35 @@ mod tests {
         let mut child = child.lock().expect("child lock");
         let _ = child.kill();
         let _ = child.wait();
+    }
+
+    /// The deletion path's variant must report the exit it observed, not just that a kill was
+    /// issued. `terminate_terminal_child` discards its reap result, which is safe on the quit
+    /// path and wrong here: session deletion hands the child's working directory to
+    /// `git worktree remove` next, and Windows refuses to delete a live process's current
+    /// directory.
+    #[test]
+    fn deletion_path_terminate_reports_the_exit_it_observed() {
+        let (_master, child) = long_lived_child();
+        let child = Mutex::new(child);
+
+        let exited =
+            terminate_terminal_child_before(&child, Instant::now() + Duration::from_secs(5))
+                .expect("terminate");
+
+        assert!(
+            exited,
+            "a killed child that was reaped within budget must be reported as exited",
+        );
+        assert!(
+            child
+                .lock()
+                .expect("child lock")
+                .try_wait()
+                .expect("child status")
+                .is_some(),
+            "the child is still running after a confirmed exit was reported",
+        );
     }
 
     #[test]

--- a/src-tauri/src/contexts/desktop/infrastructure/folder_opener_discovery.rs
+++ b/src-tauri/src/contexts/desktop/infrastructure/folder_opener_discovery.rs
@@ -654,6 +654,27 @@ mod tests {
         std::fs::write(path, "#!/bin/sh\n").unwrap();
     }
 
+    /// Asserts a discovered path denotes the fixture file, independent of separator spelling.
+    ///
+    /// These Linux and macOS layout tests run on every host, which is the point: a Windows or
+    /// Linux runner can still assert what the macOS ranking would pick. But the discovery code
+    /// spells its known locations as POSIX literals -- `home.join(".local/share/flatpak/exports/bin")`
+    /// -- and then joins the final component, so on Windows its result reads `...bin\name` while
+    /// a fixture written the same way reads `...bin/name`. Both denote the same file and both
+    /// resolve to it; only the spelling differs. Asserting on the spelling fails these tests on
+    /// Windows for no behavioural reason, and normalising the fixture instead just moves the
+    /// mismatch to the other end.
+    fn assert_same_path(discovered: Option<&str>, expected: &Path) {
+        fn normalize(value: &str) -> String {
+            value.replace('\\', "/")
+        }
+        assert_eq!(
+            discovered.map(normalize),
+            expected.to_str().map(normalize),
+            "the discovered path does not denote the fixture file",
+        );
+    }
+
     #[test]
     fn windows_only_products_are_unsupported_elsewhere() {
         for platform in [HostPlatform::MacOs, HostPlatform::Linux] {
@@ -698,9 +719,9 @@ mod tests {
 
         let detected = detect_on(HostPlatform::Linux, FolderOpenerId::IntellijIdea, &env);
         assert_eq!(detected.status, "available");
-        assert_eq!(
+        assert_same_path(
             detected.executable_path.as_deref(),
-            Some(app.join("bin/idea.sh").to_str().unwrap())
+            &app.join("bin/idea.sh"),
         );
         assert_eq!(detected.detection_source, Some("jetbrains-toolbox"));
         assert_eq!(detected.version.as_deref(), Some("2025.1"));
@@ -737,7 +758,7 @@ mod tests {
         let detected = detect_on(HostPlatform::Linux, FolderOpenerId::IntellijIdea, &env);
         assert_eq!(detected.status, "available");
         assert_eq!(detected.detection_source, Some("flatpak"));
-        assert_eq!(detected.executable_path.as_deref(), wrapper.to_str());
+        assert_same_path(detected.executable_path.as_deref(), &wrapper);
     }
 
     #[test]
@@ -755,7 +776,7 @@ mod tests {
         let detected = detect_on(HostPlatform::MacOs, FolderOpenerId::Webstorm, &env);
         assert_eq!(detected.status, "available");
         assert_eq!(detected.detection_source, Some("jetbrains-toolbox"));
-        assert_eq!(detected.executable_path.as_deref(), bundle.to_str());
+        assert_same_path(detected.executable_path.as_deref(), &bundle);
     }
 
     #[test]
@@ -792,7 +813,7 @@ mod tests {
             ..DiscoveryEnv::default()
         };
         let detected = detect_on(HostPlatform::Linux, FolderOpenerId::IntellijIdea, &env);
-        assert_eq!(detected.executable_path.as_deref(), launcher.to_str());
+        assert_same_path(detected.executable_path.as_deref(), &launcher);
     }
 
     #[test]

--- a/src-tauri/src/contexts/sessions/application/deletion/tests.rs
+++ b/src-tauri/src/contexts/sessions/application/deletion/tests.rs
@@ -1460,6 +1460,44 @@ fn a_session_that_will_not_quiesce_keeps_its_record_and_directory() {
     assert!(harness.journal.claims.lock().unwrap().is_empty());
 }
 
+/// The agent terminal is a distinct blocker from the shell above, and it is the one that was
+/// missing: its working directory is the worktree, so a terminal that has not confirmed exit
+/// makes `git worktree remove` fail with "Permission denied" on Windows. Pins the blocker name
+/// the quiescence adapter pushes -- a later change that special-cases blockers by name must not
+/// silently drop this one back to a Git failure.
+#[test]
+fn a_session_whose_agent_terminal_will_not_exit_keeps_its_record_and_directory() {
+    let harness = Harness::new();
+    harness.add_worktree("wt-1", "/repo-feature", &["w1"]);
+    harness.runtime.reports.lock().unwrap().insert(
+        "w1".to_string(),
+        QuiescenceReport {
+            quiet: false,
+            blockers: vec!["agent_terminal".to_string()],
+        },
+    );
+    let preview = harness.preview(&["w1"]);
+    let handle = harness.execute(&preview, "r1", vec![Harness::remove_choice("wt-1")]);
+    let operation = harness.coordinator.run(&handle.operation_id).expect("run");
+
+    assert_eq!(operation.outcome, DeletionOutcome::Failed);
+    assert_eq!(
+        operation.groups[0].error_code.as_deref(),
+        Some(error_code::QUIESCE_TIMEOUT)
+    );
+    assert_eq!(
+        operation.groups[0].worktree_effect,
+        WorktreeEffect::Retained
+    );
+    assert_eq!(operation.groups[0].db_effect, SessionDbEffect::Retained);
+    assert_eq!(harness.sessions.ids(), vec!["w1"]);
+    assert_eq!(
+        harness.workspace.count("remove:"),
+        0,
+        "a live terminal must never reach Git remove",
+    );
+}
+
 // --- Remove-safe -------------------------------------------------------------------------------
 
 #[test]

--- a/src-tauri/src/contexts/sessions/infrastructure/deletion_runtime.rs
+++ b/src-tauri/src/contexts/sessions/infrastructure/deletion_runtime.rs
@@ -61,6 +61,25 @@ impl SessionDeletionRuntimePort for AgentSessionRuntimeAdapter {
             blockers.push("background_command".to_string());
         }
 
+        // Agent terminal: stop it and wait for the process to actually exit. Its working
+        // directory is the session worktree, and Windows refuses to delete a directory that
+        // is a live process's current directory -- so `git worktree remove` fails with
+        // "Permission denied" while any of it survives. Sits before the shells block because
+        // a terminal can spawn a shell, and the shell count below has to be checked after
+        // the thing that can still create one is gone.
+        match runtime.stop_session_agent_terminal_and_confirm_exit(session_id, remaining()) {
+            Ok(true) => {}
+            Ok(false) => blockers.push("agent_terminal".to_string()),
+            Err(
+                crate::contexts::agent_runtime::api::AgentRuntimeApplicationError::SessionNotFound(
+                    _,
+                ),
+            ) => {}
+            Err(error) => {
+                return Err(SessionsApplicationError::Runtime(error.to_string()));
+            }
+        }
+
         // Shells: close is strict already; retry it while a close is still being confirmed.
         loop {
             match self.workspaces().kill_shells_for_session(session_id) {

--- a/src-tauri/src/native_lifecycle_tests.rs
+++ b/src-tauri/src/native_lifecycle_tests.rs
@@ -670,6 +670,24 @@ impl AgentTerminalGateway for LifecycleDoubles {
         Ok(true)
     }
 
+    fn stop_session_terminal_and_confirm_exit(
+        &self,
+        session_id: &str,
+        _budget: std::time::Duration,
+    ) -> Result<bool, AgentRuntimeApplicationError> {
+        let terminal_id = self
+            .terminals
+            .lock()
+            .expect("terminals")
+            .values()
+            .find(|terminal| terminal.session_id == session_id)
+            .map(|terminal| terminal.terminal_id.clone());
+        let Some(terminal_id) = terminal_id else {
+            return Ok(true);
+        };
+        self.stop(StopAgentTerminalRequest { terminal_id })
+    }
+
     fn cleanup_idle(
         &self,
         _idle_after_seconds: i64,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VaneHub AI",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "identifier": "ai.vanehub.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tests/architecture.rs
+++ b/src-tauri/tests/architecture.rs
@@ -2706,8 +2706,15 @@ const NATIVE_SUBTREE_BUDGETS: &[SubtreeBudget] = &[
         // +7 by `harden-session-workspace-tab-layouts`, measured on the merged tree: the early
         // return in `record_terminal_usage_log` that stops a periodic poll which persisted nothing
         // from being written -- it was three quarters of the unified log -- and the note saying why.
-        budget: 63_085,
-        owner: "harden-session-workspace-tab-layouts",
+        //
+        // +101 by `stop-session-terminals-before-worktree-removal`, all in `terminal_process.rs`:
+        // a stop-by-session that confirms the child actually exited, the bounded-reap helper it
+        // needs, and the test that pins it reports the exit it observed. Nothing was duplicated --
+        // the existing `stop` and `terminate_terminal_child` keep the fixed quit-path budget whose
+        // reap result is deliberately discarded, which is exactly why the deletion path could not
+        // reuse them: it hands the child's working directory to `git worktree remove` next.
+        budget: 63_186,
+        owner: "stop-session-terminals-before-worktree-removal",
     },
     // Raised from 2,914 by `split-database-migrations`, which turned `migrations.rs` into a
     // directory module. The +51 is entirely per-file boilerplate: +29 module headers (the `mod`
@@ -2880,8 +2887,12 @@ const NATIVE_PRODUCTION_SUBTREE_BUDGETS: &[SubtreeBudget] = &[
         //
         // +7 production by `harden-session-workspace-tab-layouts`: the no-op poll guard in
         // `record_terminal_usage_log`, the same lines counted by the aggregate above.
-        budget: 33_953,
-        owner: "harden-session-workspace-tab-layouts",
+        //
+        // +72 production by `stop-session-terminals-before-worktree-removal`: the stop-by-session
+        // gateway method and its bounded-reap helper. The remaining 29 of that change's 101
+        // aggregate lines are its test, counted by the aggregate above and deliberately not here.
+        budget: 34_025,
+        owner: "stop-session-terminals-before-worktree-removal",
     },
 ];
 

--- a/src/services/about-service.test.ts
+++ b/src/services/about-service.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { checkAboutUpdates, compareVersions } from "./about-service";
+import { aboutCurrentVersion, checkAboutUpdates, compareVersions } from "./about-service";
+
+/**
+ * A release one patch ahead of whatever this build is.
+ *
+ * Spelling the newer version as a literal ties the test to the shipped version: the moment the
+ * project bumped past it, the "newer release" fixture became an older one and the test failed on
+ * the release commit rather than on any change to update detection.
+ */
+const nextPatchVersion = (() => {
+  const [major, minor, patch] = aboutCurrentVersion.split(".").map(Number);
+  return `${major}.${minor}.${patch + 1}`;
+})();
 
 describe("about-service", () => {
   it("compares semantic versions with optional v prefix", () => {
@@ -13,9 +25,9 @@ describe("about-service", () => {
       new Response(
         JSON.stringify({
           body: "Release notes",
-          html_url: "https://github.com/cdavid817/vanehub-ai/releases/tag/v1.4.1",
-          name: "VaneHub AI v1.4.1",
-          tag_name: "v1.4.1",
+          html_url: `https://github.com/cdavid817/vanehub-ai/releases/tag/v${nextPatchVersion}`,
+          name: `VaneHub AI v${nextPatchVersion}`,
+          tag_name: `v${nextPatchVersion}`,
         }),
         { status: 200 },
       );
@@ -23,7 +35,7 @@ describe("about-service", () => {
     const result = await checkAboutUpdates(fetchImpl);
 
     expect(result.updateAvailable).toBe(true);
-    expect(result.latestVersion).toBe("1.4.1");
+    expect(result.latestVersion).toBe(nextPatchVersion);
     expect(result.releaseNotes).toBe("Release notes");
   });
 


### PR DESCRIPTION
## Why

Deleting a session with *also remove the worktree* ticked always failed on Windows. The operation finished `needs_attention` instead of `succeeded` and left the directory behind — no crash, no data loss, nothing to notice unless you looked.

Found by running the full WebdriverIO desktop suite by hand: the `desktop-session-deletion` layer failed 2 of its 4 tests, deterministically, 6 times out of 6.

## Root cause

The quiescence barrier in `deletion_runtime.rs` stopped four kinds of writer — generation, tool-approval waiter, background commands, shells — but not the CLI-mode agent terminal. That terminal is a direct child of the app: a `cmd.exe` running a wrapper whose first line is `cd /d <session worktree>`. The worktree is therefore a live process's current directory, and Windows refuses to delete one, so `git worktree remove` returned 255 with `Permission denied` and the runtime correctly reported `Refused`.

The spec already required this. `add-session-worktree-cleanup`'s *Quiescence before session deletion* names the CLI among the writers deletion must stop and wait for, and its task 5.3 claimed the barrier was implemented. It was, minus this one writer. That claim is withdrawn here rather than quietly reworded.

## Why stopping alone was not enough

The existing `stop` removes the registry entry *before* killing, reaps on a fixed 1.5s budget, and discards the result. It answers "was the stop accepted" — which the spec explicitly refuses as an exit receipt, and which is exactly the shape of this bug.

This adds a by-session gateway method that spends the caller's remaining deletion budget and reports whether the process was **observed to exit**. An unconfirmed exit becomes an `agent_terminal` blocker, so the session and its directory are retained exactly as the other blockers already arrange. No new failure mode, no UI change.

A process-tree container was considered and deliberately not built: the evidence never showed that killing the direct child leaves the grandchild behind, only that nothing was stopping it at all. The e2e layer settled it — the minimal fix releases the directory. The escalation path is written down in `design.md` in case that ever stops holding.

## Why nothing caught it

`Desktop Smoke` runs only the core smoke contract when `CI` is set; the layer covering this path lives in the opt-in `Desktop Full Suite`, behind a label. So this shipped to `main` and survived until someone ran the full suite by hand.

That layer joins the PR gate here (~3 minutes), and its guard test now pins the gated set **by membership**, so a layer cannot join or leave it unnoticed.

## Also in this PR

- **Cross-platform test portability** (separate commit). Four `folder_opener_discovery` tests asserted POSIX-spelled paths against results the code joins with the platform separator, so they failed on any Windows checkout of `main` while passing in CI, which runs `cargo test --workspace` on ubuntu only. `AGENTS.md` makes that command mandatory before committing, so the gate was red for Windows developers through no fault of their own.
- **1.5.0 release preparation** (separate commit, no tag). Version synchronized across the three files `version:check` covers *and* the three READMEs `docs:check` pins separately. `about-service.test.ts` spelled its newer-release fixture as the literal `1.4.1`, which only reads as newer while the project ships 1.4.0; it is derived from the build's own version now, so it tests update detection rather than the release number.

## Verification

Run on Windows. The `desktop-session-deletion` layer goes from 2 of 4 tests failing across three attempts (8m54s) to **4 passing in 26 seconds**, with no empty worktree left in the temp directory.

| Gate | Result |
| --- | --- |
| `npm run test:desktop` (full, 10 layers) | 10/10 passed, 43 min |
| `cargo test --workspace` | 6717 passed, 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `npm run native:panic:check` | pass |
| `cargo fmt --check` | pass |
| `npm run test` | 3015 passed |
| `npm run build` | pass |
| `npm run architecture:check` | 63 passed |
| `npm run desktop:unit:test` | 72 passed |
| `npm run lint:ci` / `docs:check` / `contracts:check` | pass |
| `openspec validate` (change + specs) | pass |

`ARCH-NATIVE-007/008` were raised to the exact new measurement with the reason recorded inline, per the repair note on those budgets.

Desktop results are Windows-only and are not extrapolated to macOS or Linux; CI reports those independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)