### PR TITLE
Normalize the native CLI parameter payload at the desktop adapter

### DIFF
--- a/scripts/architecture/frontend-rules.mjs
+++ b/scripts/architecture/frontend-rules.mjs
@@ -420,7 +420,13 @@ const SUBTREE_LINE_BUDGETS = Object.freeze([
   // 设置服务的目录选择能力——`pickDirectory` 进入 `SettingsService` 接口、Tauri 侧走 dialog
   // 插件、Web 侧以「仅桌面」原因拒绝——加上 `cliTerminalTheme` 的归一化与其单测。两者都是
   // 桌面/Web 双实现必须同时补的接口,不是既有代码的复制。
-  { root: "src/services", budget: 28161, owner: "harden-session-workspace-tab-layouts" },
+  //
+  // 28161 -> 28196(fix-cli-parameters-native-payload-normalization):+35 是把原生 IPC 载荷接进
+  // registry 已有的 Zod 归一化——一个按 profile 的导出函数、它调用的定义级私有函数,以及
+  // Tauri 客户端三条返回路径上的 await/map 改写。不是复制:归一化本身早就存在,Web 适配器一直
+  // 在用,缺的只是桌面适配器没有接上去。逐点 `?? []` 补丁会更省行数,但下一个空数组字段还会
+  // 复发。
+  { root: "src/services", budget: 28196, owner: "fix-cli-parameters-native-payload-normalization" },
 ]);
 
 const STATE_PACKAGES = new Set([

--- a/src/contracts/cli-parameter-contract.test.ts
+++ b/src/contracts/cli-parameter-contract.test.ts
@@ -6,6 +6,7 @@ import {
   cliParameterDefinitions,
   defaultCliParameterSelections,
   editableCliParameterDefinitions,
+  normalizeCliParameterProfile,
 } from "../services/cli-parameter-registry";
 import {
   cliArgumentSegmentValues,
@@ -192,5 +193,49 @@ describe("CLI parameter contract", () => {
     expect(
       cliArgumentSegmentValues(renderCliParameterSegments(definitions, selections, "interactive")),
     ).not.toEqual([]);
+  });
+});
+
+describe("native profile payload normalization", () => {
+  // The native serializer omits an empty array. That is fine for the catalog file, which is read
+  // back through serde defaults, and fine for the Web adapter, which builds definitions from the
+  // generated catalog and so passes them through the registry schema. It was not fine for the
+  // desktop adapter, which handed the payload straight to React: a parameter with no dependencies
+  // arrived as `dependencies: {}` and `definition.dependencies.conflictsWith.filter(...)` threw,
+  // taking the whole CLI parameters page down to its load-failure fallback.
+  it("the canonical catalog really does omit the empty arrays this guards", () => {
+    const parameters = nativeParameters("claude-code") as unknown as Record<string, unknown>[];
+    expect(parameters.length).toBeGreaterThan(0);
+    const withoutDependencies = parameters.filter((parameter) => {
+      const dependencies = parameter.dependencies as Record<string, unknown> | undefined;
+      return dependencies === undefined || Object.keys(dependencies).length === 0;
+    });
+    expect(withoutDependencies.length).toBeGreaterThan(0);
+  });
+
+  it("fills every array the page dereferences without checking", () => {
+    const definition = cliParameterDefinitions("claude-code")[0];
+    expect(definition).toBeDefined();
+    // Strip the fields back to the shape the wire actually carries.
+    const wireDefinition = { ...definition, dependencies: {}, constraints: { dedupe: false } };
+    delete (wireDefinition as Record<string, unknown>).diagnostics;
+
+    const normalized = normalizeCliParameterProfile({
+      agentId: "claude-code",
+      catalogVersion: cliParameterCatalogVersion,
+      revision: 0,
+      updatedAt: null,
+      installation: { installed: false, runnable: false, activePath: null, version: null, conflict: false },
+      fields: [{ definition: wireDefinition, support: "supported", optionSupport: {} }],
+      selections: {},
+      savedPreviews: { chat: null, interactive: null },
+      diagnostics: [],
+    } as unknown as Parameters<typeof normalizeCliParameterProfile>[0]);
+
+    const filled = normalized.fields[0].definition;
+    expect(filled.dependencies.conflictsWith).toEqual([]);
+    expect(filled.dependencies.requiresAll).toEqual([]);
+    expect(filled.constraints.exclusiveValues).toEqual([]);
+    expect(filled.diagnostics).toEqual([]);
   });
 });

--- a/src/services/cli-parameter-registry.ts
+++ b/src/services/cli-parameter-registry.ts
@@ -8,6 +8,7 @@ import type {
   CliParameterSelections,
 } from "../types/cli-parameter";
 import type { ManagedCliAgentId } from "../types/agent";
+import type { CliParameterProfile } from "../types/cli-parameter-profile";
 
 // The generated artifact is parsed, not asserted. A bare `as CliParameterCatalog` would let a
 // generator regression reach the Web adapter as a runtime shape mismatch instead of a load-time
@@ -149,6 +150,32 @@ export function editableCliParameterDefinitions(
   return cliParameterDefinitions(agentId).filter(
     (definition) => definition.ownership === "user-editable",
   );
+}
+
+/**
+ * Normalises a definition that arrived over IPC rather than from the generated catalog.
+ *
+ * Same reasoning as the catalog parse above, applied to the other way a definition reaches the
+ * UI. The native serializer omits an empty array, so a parameter with no dependencies arrives as
+ * `dependencies: {}` while the TypeScript type declares two arrays; `conflictsWith.filter(...)`
+ * then threw and the whole page rendered its load-failure fallback. `exclusiveValues` and
+ * `diagnostics` are omitted the same way and would have followed. The Web adapter never saw any
+ * of it because it builds definitions from the generated catalog, which passes through this
+ * schema and picks up its defaults.
+ */
+function normalizeCliParameterDefinition(value: unknown): CliParameterDefinition {
+  return definitionSchema.parse(value) as CliParameterDefinition;
+}
+
+/** Brings a natively-serialized profile up to the shape the page's types promise. */
+export function normalizeCliParameterProfile(profile: CliParameterProfile): CliParameterProfile {
+  return {
+    ...profile,
+    fields: profile.fields.map((field) => ({
+      ...field,
+      definition: normalizeCliParameterDefinition(field.definition),
+    })),
+  };
 }
 
 export function defaultCliParameterSelections(agentId: ManagedCliAgentId): CliParameterSelections {

--- a/src/services/tauri-agent-client.ts
+++ b/src/services/tauri-agent-client.ts
@@ -185,6 +185,7 @@ import {
   normalizeCodeIndexWorkspace,
   normalizeCodeIndexWorkspaces,
 } from "./code-index-contract";
+import { normalizeCliParameterProfile } from "./cli-parameter-registry";
 import {
   normalizeLspConfiguration,
   normalizeLspServerDiscoveries,
@@ -243,6 +244,7 @@ function isSessionStateEvent(value: unknown): value is SessionStateEvent {
     && Number.isSafeInteger(value.recoveryRevision)
     && value.recoveryRevision >= 0;
 }
+
 export const tauriAgentClient: AgentService = { ...tauriSkillCuratorClient,
   listEvaluationTasks: () => invoke<EvaluationTask[]>("list_evaluation_tasks"),
   startEvaluation: (input) => invoke<EvaluationArena>("start_evaluation", { input }),
@@ -549,20 +551,26 @@ export const tauriAgentClient: AgentService = { ...tauriSkillCuratorClient,
     return normalizeLspServerStatuses(await invoke<unknown>("list_lsp_server_status"));
   },
 
-  listCliParameterProfiles() {
-    return invoke<CliParameterProfile[]>("list_cli_parameter_profiles");
+  async listCliParameterProfiles() {
+    return (await invoke<CliParameterProfile[]>("list_cli_parameter_profiles")).map(
+      normalizeCliParameterProfile,
+    );
   },
 
   previewCliParameterProfile(input: PreviewCliParameterProfileInput) {
     return invoke<CliParameterPreview>("preview_cli_parameter_profile", { input });
   },
 
-  saveCliParameterProfile(input: SaveCliParameterProfileInput) {
-    return invoke<CliParameterProfile>("save_cli_parameter_profile", { input });
+  async saveCliParameterProfile(input: SaveCliParameterProfileInput) {
+    return normalizeCliParameterProfile(
+      await invoke<CliParameterProfile>("save_cli_parameter_profile", { input }),
+    );
   },
 
-  resetCliParameterProfile(input: ResetCliParameterProfileInput) {
-    return invoke<CliParameterProfile>("reset_cli_parameter_profile", { input });
+  async resetCliParameterProfile(input: ResetCliParameterProfileInput) {
+    return normalizeCliParameterProfile(
+      await invoke<CliParameterProfile>("reset_cli_parameter_profile", { input }),
+    );
   },
 
   listCliConfigPresets(agentId: string) {

--- a/tests/desktop/specs/screen-sweep.e2e.mjs
+++ b/tests/desktop/specs/screen-sweep.e2e.mjs
@@ -66,6 +66,15 @@ async function assertScreenRendered(name) {
     !/^(正在加载功能|Loading feature)/.test(text),
     `${name} was captured as its loading placeholder rather than the screen`,
   );
+  // The other `LazyFeature` fallback, and the one that mattered: a screen whose component threw is
+  // still non-empty text, so every check above passes on it. The sweep walked the CLI parameters
+  // page while it rendered nothing but this message and reported the screen as covered, which is
+  // how the failure reached a release. Matched anywhere rather than anchored -- the fallback sits
+  // inside the page shell, so the screen's own chrome comes first in the text.
+  assert.ok(
+    !/(该功能加载失败|This feature could not be loaded)/.test(text),
+    `${name} rendered its load-failure fallback instead of the screen`,
+  );
 }
 
 const navigate = navigateTo;


### PR DESCRIPTION
## What was broken

**Settings → CLI parameters showed nothing but "this feature could not be loaded"** in the packaged desktop client. Reported against the installed 1.5.0 build.

## Root cause

Reproduced by driving a real desktop build to the page and capturing the console:

```
TypeError: Cannot read properties of undefined (reading 'filter')
    at cli-parameters-page-BSRoPss_.js:1:8398
```

`cli-parameter-field.tsx` reads `definition.dependencies.conflictsWith.filter(...)`. The native serializer omits an empty array:

```rust
#[serde(default, skip_serializing_if = "Vec::is_empty")]
pub(crate) conflicts_with: Vec<String>,
```

so a parameter with no dependencies arrives as `dependencies: {}` while `types/cli-parameter.ts` declares two required arrays. **41 of the 43 catalogued parameters have no dependencies**, so the page failed for practically everyone. The lazy-feature error boundary turned the throw into the message the user saw.

## Why nothing caught it

The frontend already normalizes this — `cli-parameter-registry.ts` parses the generated catalog through a Zod schema whose `requiresAll` and `conflictsWith` carry `.default([])`. The **Web adapter** builds profiles from that catalog, so it never sees the raw shape. The **desktop adapter** took the IPC payload as `invoke<CliParameterProfile[]>` — a bare type assertion — and handed it to React unchanged.

So three Playwright specs for this exact page, and the whole 3,000-test vitest suite, exercised the working path and stayed green. The registry's own header comment already made this argument for the catalog file ("parsed, not asserted… the adapter is the only place a wrong catalog cannot be caught by the native tests"); it simply was not applied to the other way a definition reaches the UI.

## The fix

At the adapter, not at the three dereferences. `exclusiveValues` and `diagnostics` are omitted the same way and are declared just as required, so patching each call site would have left the next one to be found in production. This follows the `normalizeLspServerStatuses` precedent two lines above it in the same file: the registry owns the schema and now exposes a profile normalizer that `list`, `save` and `reset` all pass through.

## The coverage gap that let it ship

`screen-sweep.e2e.mjs` walks every settings page and asserts the screen rendered. **It walked this page and reported it covered.** Its assertions reject a `LazyFeature` *loading* placeholder but not a `LazyFeature` *error* fallback — which is non-empty text, is not the bootstrap shell, does not trip the fatal boundary, and does not say "command not found". Every check passed on a screen that was entirely an error message.

It now rejects both, matched in either locale, so any screen that trips its boundary fails the sweep instead of being photographed.

**Not addressed here:** that sweep runs in the full desktop suite, not the PR gate, which still selects only `smoke.e2e.mjs`. Putting it in the gate means 25 specs on three runners per PR; worth deciding separately rather than widening the gate twice in one week.

## Verification

| Gate | Result |
| --- | --- |
| Real desktop build, page driven to render | load-failure alert gone (`alerts: []`); was `["该功能加载失败。\n\n重试"]` |
| `npm run test` | 3017 passed |
| `npm run lint:ci` | pass |
| `npm run build` | pass |
| `npm run architecture:check` | pass |
| `npm run desktop:unit:test` | pass |
| `tsc --noEmit` | pass |

Two regression tests: one pins that the canonical catalog really does omit these arrays (so the guard cannot rot into asserting nothing), one pins that the normalizer fills every array the page dereferences unchecked.

ARCH-FE-004 raised to the measured 28,196 with the reason recorded inline, per the repair note on that budget.

No Rust change. The wire format is unchanged and stays lean; the frontend now reads it the way it already reads the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)